### PR TITLE
Refactor configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# Gas limit override if default gas fails
+DEPLOYER_GAS_LIMIT=2045000
+
+# Etherscan API for verifying contracts on etherscan
+DEPLOYER_ETHERSCAN_API_KEY=000000000000000000000000000000000000000
+
+# Coinmarketcap API for reporting up to date gas price estimates for deployment and function calls
+GAS_REPORTER_COINMARKETCAP_API_KEY=000000000000000000000000000000000000000
+
+# Hardhat specific
+DEPLOYER_HARDHAT_MNEMONIC="reduce chair insane vault universe fitness flame motor wood toy vacuum special"
+
+# Ropsten specific 
+DEPLOYER_ROPSTEN_TXNODE=http://ropsten.node.example:666
+DEPLOYER_ROPSTEN_KEY=0xb644aa4a6ada1f1a996def5cee46b93922006d78754095525cefeed36f5ab1c0
+
+# Mainnet specific 
+DEPLOYER_MAINNET_TXNODE=http://mainnet.node.example:666
+DEPLOYER_MAINNET_KEY=0xb644aa4a6ada1f1a996def5cee46b93922006d78754095525cefeed36f5ab1c0

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ node_modules
 
 # Secrets
 .env
-.env.*
 
 # OS
 .DS_Store
@@ -24,6 +23,3 @@ node_modules
 
 # Test Coverage
 coverage*
-
-# Environment Config
-environments.js

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,4 +1,4 @@
-# Boson Protocol V2 
+# Boson Protocol V2
 ## [Intro](../README.md) | Setup | [Tasks](tasks.md) | [Architecture](architecture.md) | [Domain Model](domain.md)
 
 ## Developer Setup
@@ -22,36 +22,6 @@ npm install
 ```
 
 ### Configure Environment
-- Copy [environments_template.js](../environments_template.js) to `environments.js` and edit to suit.
+- Copy [.env.example](../.env.example) to `.env` and edit to suit.
 - API keys are only needed for deploying to public networks.
-- `environments.js` is included in `.gitignore` and will not be committed to the repo.
-- For your target Ethereum network environment, set:
-    * `txNode`: the endpoint for sending ethereum transactions
-    * `mnemonic`: a valid ethereum HD wallet seed phrase
-
-- For verifying code and running the gas reporter, set:
-    * `etherscan.apiKey`: your etherscan API key
-    * `coinmarketcap.apiKey`: your coinmarketcap API key
-
-```javascript
-module.exports = {
-    "etherscan": {
-        "apiKey": "<YOUR_ETHERSCAN_API_KEY>"
-    },
-
-  "coinmarketcap": {
-    "apiKey": "<YOUR_COINMARKETCAP_API_KEY>"
-  },
-
-  "ropsten": {
-        "txNode": "https://rinkeby.infura.io/v3/<YOUR_INFURA_API_KEY>",
-        "mnemonic": "<YOUR_UNIQUE_TWELVE_WORD_WALLET_SEED_PHRASE>"
-  },
-
-  "mainnet": {
-        "txNode": "https://mainnet.infura.io/v3/<YOUR_INFURA_API_KEY>",
-        "mnemonic": "<YOUR_UNIQUE_TWELVE_WORD_WALLET_SEED_PHRASE>"
-    }
-
-};
-```
+- `.env` is included in `.gitignore` and will not be committed to the repo.

--- a/environments.js
+++ b/environments.js
@@ -1,46 +1,47 @@
 /**
- *  Build and test environment configuration template.
+ *  Build and test environment configuration.
  *
- *  - Copy to environments.js and edit to suit local needs.
- *  - environments.js is in .gitignore and will not be committed
+ *  - Translates environment vars into JSON objects
+ *  - Environment vars are defined in .env and
  */
+
+require('dotenv').config()
+
 module.exports = {
 
     // For helping public deployments succeed if default gas doesn't work
-    "gasLimit": 20450000,
+    "gasLimit": parseInt(process.env.DEPLOYER_GAS_LIMIT),
 
     // Needed for verifying contract code on Etherscan
     "etherscan": {
-        "apiKey": ""
+        "apiKey": process.env.ETHERSCAN_API_KEY
     },
 
     // Needed for Gas Reporter
     "coinmarketcap": {
-        "apiKey": ""
+        "apiKey": process.env.GAS_REPORTER_COINMARKETCAP_API_KEY
     },
-
 
     // Hardhat testnet
     //  - throwaway HDWallet mnemonic for running unit tests, which require more than one address
     "hardhat": {
-        "txNode": "",
-        "mnemonic": "reduce chair insane vault universe fitness flame motor wood toy vacuum special"
+        "mnemonic": process.env.DEPLOYER_HARDHAT_MNEMONIC
     },
 
     // Ropsten testnet
     //  - placeholder private key is first address of test HDWallet used in hardhat network config
     //  - Replace key with multisig pk for deployment
     "ropsten": {
-        "txNode": "",
-        "keys": ["0xb644aa4a6ada1f1a996def5cee46b93922006d78754095525cefeed36f5ab1c0"]
+        "txNode": process.env.DEPLOYER_ROPSTEN_TXNODE,
+        "keys": [process.env.DEPLOYER_ROPSTEN_KEY]
     },
 
     // Ethereum Mainnet
     //  - placeholder private key is first address of test HDWallet used in hardhat network config
     //  - Replace key with multisig pk for deployment
     "mainnet": {
-        "txNode": "",
-        "keys": ["0xb644aa4a6ada1f1a996def5cee46b93922006d78754095525cefeed36f5ab1c0"]
+        "txNode": process.env.DEPLOYER_MAINNET_TXNODE,
+        "keys": [process.env.DEPLOYER_MAINNET_KEY]
     }
 
 };

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,3 +1,6 @@
+const dotEnvConfig = require('dotenv');
+dotEnvConfig.config();
+
 const environments = require('./environments');
 require("@nomiclabs/hardhat-etherscan");
 require("@nomiclabs/hardhat-waffle");
@@ -5,6 +8,7 @@ require("@nomiclabs/hardhat-web3");
 require('hardhat-contract-sizer');
 require("hardhat-gas-reporter");
 require("solidity-coverage");
+
 
 module.exports = {
   defaultNetwork: "hardhat",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
                 "@nomiclabs/hardhat-web3": "^2.0.0",
                 "@openzeppelin/test-helpers": "^0.5.15",
                 "chai": "^4.3.6",
+                "dotenv": "^16.0.0",
                 "eip55": "^2.1.0",
                 "ethereum-waffle": "^3.4.0",
                 "ethers": "^5.5.4",
@@ -5080,6 +5081,15 @@
             "dev": true,
             "dependencies": {
                 "no-case": "^2.2.0"
+            }
+        },
+        "node_modules/dotenv": {
+            "version": "16.0.0",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+            "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/drbg.js": {
@@ -27854,6 +27864,12 @@
             "requires": {
                 "no-case": "^2.2.0"
             }
+        },
+        "dotenv": {
+            "version": "16.0.0",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+            "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==",
+            "dev": true
         },
         "drbg.js": {
             "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
         "lint": "solhint 'contracts/**/*.sol'",
         "size": "npx hardhat size-contracts",
         "deploy-suite:local": "npx hardhat run --network hardhat scripts/deploy-suite.js",
-        "deploy-suite:rinkeby": "npx hardhat run --network rinkeby scripts/deploy-suite.js >> logs/rinkeby.deploy.contracts.txt",
+        "deploy-suite:ropsten": "npx hardhat run --network ropsten scripts/deploy-suite.js >> logs/ropsten.deploy.contracts.txt",
         "deploy-suite:mainnet": "npx hardhat run --network mainnet scripts/deploy-suite.js >> logs/mainnet.deploy.contracts.txt",
-        "manage-roles:rinkeby": " npx hardhat --network rinkeby run scripts/manage-roles.js >> logs/rinkeby.manage.roles.txt",
+        "manage-roles:ropsten": " npx hardhat --network ropsten run scripts/manage-roles.js >> logs/ropsten.manage.roles.txt",
         "manage-roles:mainnet": " npx hardhat --network mainnet run scripts/manage-roles.js >> logs/mainnet.manage.roles.txt"
     },
     "dependencies": {
@@ -42,6 +42,7 @@
         "@nomiclabs/hardhat-web3": "^2.0.0",
         "@openzeppelin/test-helpers": "^0.5.15",
         "chai": "^4.3.6",
+        "dotenv": "^16.0.0",
         "eip55": "^2.1.0",
         "ethereum-waffle": "^3.4.0",
         "ethers": "^5.5.4",

--- a/scripts/config/contract-addresses.js
+++ b/scripts/config/contract-addresses.js
@@ -5,23 +5,17 @@
  * Scripts rely on these addresses to be up to date.
  */
 exports.ContractAddresses = {
-    
+
     "ropsten": {
         AccessController: "",
-        DiamondLoupeFacet: "",
-        DiamondCutFacet: "",
         ProtocolDiamond: "",
-        ProtocolConfigFacet: "",
-        VoucherNFT: "",
+        VoucherProxy: "",
     },
 
     "mainnet": {
         AccessController: "",
-        DiamondLoupeFacet: "",
-        DiamondCutFacet: "",
         ProtocolDiamond: "",
-        ProtocolConfigFacet: "",
-        VoucherNFT: "",
+        VoucherProxy: "",
     },
 
 };

--- a/scripts/config/role-assignments.js
+++ b/scripts/config/role-assignments.js
@@ -2,10 +2,10 @@ const {ContractAddresses} = require('./contract-addresses');
 const Role = require("../domain/Role");
 
 /**
- * Role assignments for access control in the Boson Protocl contract suite
+ * Role assignments for access control in the Boson Protocol contract suite
  *
  * Process:
- *  1.  Edit scripts/constants/role-assignments.js
+ *  1.  Edit scripts/config/role-assignments.js
  *  1a. Add new address / role assignments following existing config
  *  1b. Remove an existing role assignment, delete role from addresses' role array
  *  1b. If removing all roles from a previously roled-address,

--- a/scripts/manage-roles.js
+++ b/scripts/manage-roles.js
@@ -2,8 +2,8 @@ const environments = require('../environments');
 const hre = require("hardhat");
 const ethers = hre.ethers;
 const network = hre.network.name;
-const {ContractAddresses} = require('./constants/contract-addresses');
-const {RoleAssignments} = require('./constants/role-assignments');
+const {ContractAddresses} = require('./config/contract-addresses');
+const {RoleAssignments} = require('./config/role-assignments');
 const Role = require("./domain/Role");
 
 /**
@@ -18,7 +18,7 @@ const Role = require("./domain/Role");
  *     the assignments.
  *
  * Preparation:
- *  1.  Edit scripts/constants/role-assignments.js
+ *  1.  Edit scripts/config/role-assignments.js
  *  1a. Add new address / role assignments following existing config
  *  1b. To remove an existing role assignment, delete role from addresses' roles array
  *  1b. If removing all roles from a previously roled address,


### PR DESCRIPTION
Moves the configuration data out to .env file so they can be set in the environment for Github Actions CI

* Added .env.example,
  - exposes the configuration vars that need sharing between CI and test/deployer

* Updated .gitignore
  - removed environments.js

* In contract-addresses.js,
  - updated the config blocks to hold only public endpoints, its all we need to track

* In environments.js,
  - refactored to pull in items from .env

* Removed environments_template.js

* In hardhat.config.js,
  - required dotenv

* In manage-roles.js and role-assignments.js,
  - updated paths

* In package.json,
  - replaced rinkeby with ropsten
  - added dotenv

* In setup.md,
  - updated configure environment section