### PR TITLE
Add CI to gha

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft }}
+    env:
+      GAS_REPORTER_COINMARKETCAP_API_KEY: ${{ secrets.COINMARKETCAP_API_KEY }}
     name: test
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This PR adds support to run build and unit test on Github actions
Please review this GHA job executed by the PR https://github.com/bosonprotocol/boson-protocol-contracts/actions/runs/1987141957

1. Contract compilation
2. Contract lint
3. Contract Sizing
4. Unit tests