### PR TITLE
Github Actions - Default checkout behaviour

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2.4.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Setup node
         uses: actions/setup-node@v2.5.1
         with:
@@ -41,8 +39,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2.4.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Setup node
         uses: actions/setup-node@v2.5.1
         with:

--- a/.github/workflows/deploy-pre-release.yaml
+++ b/.github/workflows/deploy-pre-release.yaml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2.4.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Setup node
         uses: actions/setup-node@v2.5.1
         with:


### PR DESCRIPTION
PR should merge into the latest `main` during ci.
This will help us in detecting if PR will break `main` on merge.

### Verification steps:
1. Visit CI build at https://github.com/bosonprotocol/boson-protocol-contracts/runs/5871714057?check_suite_focus=true
<img width="2558" alt="Screenshot 2022-04-07_21-30-55-088" src="https://user-images.githubusercontent.com/91169722/162247457-1e3bb549-bd66-471f-89c5-78d5b13669b3.png">

2. Verify that ropsten deploy isn't affected. Visit https://github.com/bosonprotocol/boson-protocol-contracts/actions/runs/2110079001
