### PR TITLE
Remove updateOffer

### DIFF
--- a/contracts/interfaces/events/IBosonOfferEvents.sol
+++ b/contracts/interfaces/events/IBosonOfferEvents.sol
@@ -10,6 +10,6 @@ import {BosonTypes} from "../../domain/BosonTypes.sol";
  */
 interface IBosonOfferEvents {
     event OfferCreated(uint256 indexed offerId, uint256 indexed sellerId, BosonTypes.Offer offer);
-    event OfferUpdated(uint256 indexed offerId, uint256 indexed sellerId, BosonTypes.Offer offer);
+    event OfferExtended(uint256 indexed offerId, uint256 indexed sellerId, uint256 validUntilDate);
     event OfferVoided(uint256 indexed offerId, uint256 indexed sellerId);
 }

--- a/contracts/interfaces/handlers/IBosonOfferHandler.sol
+++ b/contracts/interfaces/handlers/IBosonOfferHandler.sol
@@ -86,7 +86,7 @@ interface IBosonOfferHandler is IBosonOfferEvents {
     /**
      * @notice Sets new valid until date
      *
-     * Emits an OfferUpdated event if successful.
+     * Emits an OfferExtended event if successful.
      *
      * Reverts if:
      * - Offer does not exist
@@ -101,7 +101,7 @@ interface IBosonOfferHandler is IBosonOfferEvents {
     /**
      * @notice Sets new valid until date
      *
-     * Emits an OfferUpdated event if successful.
+     * Emits an OfferExtended event if successful.
      *
      * Reverts if:
      * - Number of offers exceeds maximum allowed number per batch

--- a/contracts/protocol/facets/OfferHandlerFacet.sol
+++ b/contracts/protocol/facets/OfferHandlerFacet.sol
@@ -137,7 +137,7 @@ contract OfferHandlerFacet is IBosonOfferHandler, OfferBase {
     /**
      * @notice Sets new valid until date
      *
-     * Emits an OfferUpdated event if successful.
+     * Emits an OfferExtended event if successful.
      *
      * Reverts if:
      * - Offer does not exist
@@ -163,13 +163,13 @@ contract OfferHandlerFacet is IBosonOfferHandler, OfferBase {
         offer.validUntilDate = _validUntilDate;
 
         // Notify watchers of state change
-        emit OfferUpdated(_offerId, offer.sellerId, offer);
+        emit OfferExtended(_offerId, offer.sellerId, _validUntilDate);
     }
 
     /**
      * @notice Sets new valid until date
      *
-     * Emits an OfferUpdated event if successful.
+     * Emits an OfferExtended event if successful.
      *
      * Reverts if:
      * - Number of offers exceeds maximum allowed number per batch

--- a/test/protocol/OfferHandlerTest.js
+++ b/test/protocol/OfferHandlerTest.js
@@ -370,11 +370,11 @@ describe("IBosonOfferHandler", function () {
         offerStruct = offer.toStruct();
       });
 
-      it("should emit an OfferUpdated event", async function () {
+      it("should emit an OfferExtended event", async function () {
         // Extend the valid until date, testing for the event
         await expect(offerHandler.connect(operator).extendOffer(offer.id, offer.validUntilDate))
-          .to.emit(offerHandler, "OfferUpdated")
-          .withArgs(id, offer.sellerId, offerStruct);
+          .to.emit(offerHandler, "OfferExtended")
+          .withArgs(id, offer.sellerId, offer.validUntilDate);
       });
 
       it("should update state", async function () {
@@ -930,17 +930,16 @@ describe("IBosonOfferHandler", function () {
         for (const offerToExtend of offersToExtend) {
           let i = offerToExtend - 1;
           offers[i].validUntilDate = newValidUntilDate;
-          offerStructs[i] = offers[i].toStruct();
         }
       });
 
-      it("should emit OfferUpdated events", async function () {
+      it("should emit OfferExtended events", async function () {
         // Extend the valid until date, testing for the event
         await expect(offerHandler.connect(operator).extendOfferBatch(offersToExtend, newValidUntilDate))
-          .to.emit(offerHandler, "OfferUpdated")
-          .withArgs(offersToExtend[0], offer.sellerId, offerStructs[offersToExtend[0] - 1])
-          .withArgs(offersToExtend[1], offer.sellerId, offerStructs[offersToExtend[1] - 1])
-          .withArgs(offersToExtend[2], offer.sellerId, offerStructs[offersToExtend[2] - 1]);
+          .to.emit(offerHandler, "OfferExtended")
+          .withArgs(offersToExtend[0], offer.sellerId, newValidUntilDate)
+          .withArgs(offersToExtend[1], offer.sellerId, newValidUntilDate)
+          .withArgs(offersToExtend[2], offer.sellerId, newValidUntilDate);
       });
 
       it("should update state", async function () {


### PR DESCRIPTION
Allowing to update an offer before someone commits allows to execute front running attack, so it was decided to remove this functionality.

Changes in the code:
- removed `updateOffer` and corresponding tests
- removed `isOfferUpdateable` and corresponding test
- changed event `offerUpdated` to `offerExtended` since that's now the only case when a part of offer is changed.