### PR TITLE
Added expireVoucher

### DIFF
--- a/contracts/domain/BosonConstants.sol
+++ b/contracts/domain/BosonConstants.sol
@@ -59,6 +59,7 @@ contract BosonConstants {
     string internal constant NO_SUCH_EXCHANGE = "No such exchange";
     string internal constant FULFILLMENT_PERIOD_NOT_ELAPSED = "Fulfillment period has not yet elapsed";
     string internal constant VOUCHER_NOT_REDEEMABLE = "Voucher not yet valid or already expired";
+    string internal constant VOUCHER_STILL_VALID = "Voucher still valid";
 
     // Revert Reasons: Twin related
     string internal constant NO_SUCH_TWIN = "No such twin";
@@ -90,7 +91,8 @@ contract BosonConstants {
     string internal constant SIGNER_AND_SIGNATURE_DO_NOT_MATCH = "Signer and signature do not match";
 }
 
-// Librarires cannot inherit BosonConstants, therefore the revert reasons are defined on the file level
+// TODO: Refactor to use file level constants throughout or use custom Errors
+// Libraries cannot inherit BosonConstants, therefore these revert reasons are defined on the file level
 string constant TOKEN_TRANSFER_FAILED = "Token transfer failed";
 string constant INSUFFICIENT_VALUE_SENT = "Insufficient value sent";
 string constant INSUFFICIENT_AVAILABLE_FUNDS = "Insufficient available funds";

--- a/contracts/interfaces/events/IBosonExchangeEvents.sol
+++ b/contracts/interfaces/events/IBosonExchangeEvents.sol
@@ -11,7 +11,9 @@ import {BosonTypes} from "../../domain/BosonTypes.sol";
 interface IBosonExchangeEvents {
     event BuyerCommitted(uint256 indexed offerId, uint256 indexed buyerId, uint256 indexed exchangeId, BosonTypes.Exchange exchange);
     event ExchangeCompleted(uint256 indexed offerId, uint256 indexed buyerId, uint256 indexed exchangeId);
-    event VoucherRevoked(uint256 indexed offerId, uint256 indexed exchangeId, address indexed revokedBy);
     event VoucherCanceled(uint256 indexed offerId, uint256 indexed exchangeId, address indexed canceledBy);
+    event VoucherExpired(uint256 indexed offerId, uint256 indexed exchangeId, address indexed expiredBy);
     event VoucherRedeemed(uint256 indexed offerId, uint256 indexed exchangeId, address indexed redeemedBy);
+    event VoucherRevoked(uint256 indexed offerId, uint256 indexed exchangeId, address indexed revokedBy);
+
 }

--- a/contracts/interfaces/handlers/IBosonExchangeHandler.sol
+++ b/contracts/interfaces/handlers/IBosonExchangeHandler.sol
@@ -10,7 +10,7 @@ import {IBosonFundsLibEvents} from "../events/IBosonFundsEvents.sol";
  *
  * @notice Handles exchanges associated with offers within the protocol.
  *
- * The ERC-165 identifier for this interface is: 0x028ba007
+ * The ERC-165 identifier for this interface is: 0x1a9cab74
  */
 interface IBosonExchangeHandler is IBosonExchangeEvents, IBosonFundsLibEvents {
 
@@ -84,6 +84,22 @@ interface IBosonExchangeHandler is IBosonExchangeEvents, IBosonFundsLibEvents {
      * @param _exchangeId - the id of the exchange
      */
     function cancelVoucher(uint256 _exchangeId) external;
+
+    /**
+     * @notice Expire a voucher.
+     *
+     * Reverts if
+     * - Exchange does not exist
+     * - Exchange is not in committed state
+     * - Redemption period has not yet elapsed
+     *
+     * Emits
+     * - VoucherExpired
+     *
+     * @param _exchangeId - the id of the exchange
+     */
+    function expireVoucher(uint256 _exchangeId)
+    external;
 
     /**
      * @notice Redeem a voucher.

--- a/scripts/config/revert-reasons.js
+++ b/scripts/config/revert-reasons.js
@@ -58,6 +58,7 @@ exports.RevertReasons = {
   FULFILLMENT_PERIOD_NOT_ELAPSED: "Fulfillment period has not yet elapsed",
   EXCHANGE_FOR_BUNDLED_OFFERS_EXISTS: "Exchange for the bundled offers exists",
   VOUCHER_NOT_REDEEMABLE: "Voucher not yet valid or already expired",
+  VOUCHER_STILL_VALID: "Voucher still valid",
 
   // Funds related
   NATIVE_WRONG_ADDRESS: "Native token address must be 0",


### PR DESCRIPTION
* In BosonConstants.sol and revert-reasons.js,
  - added VOUCHER_STILL_VALID

* In ExchangeHandlerFacet.sol and IBosonExchangeHandler.sol
  - added expireVoucher method
  - updated ERC-165 id in natspect

* In ExchangeHandlerTest.js, 
  - Removed redundant copy of cancelVoucher context named as isExchangeFinalized. Copypasta, yum.
  - added expireVoucher context 
  - tests include
    - "should emit an VoucherExpired event when anyone calls and voucher has expired
    - "should update state when anyone calls and voucher has expired"
    - "should update voucher expired flag when anyone calls and voucher has expired"
      - revert reason tests
        - "exchange id is invalid"
        - "exchange is not in committed state"
        - "Redemption period has not yet elapsed"
  
* In IBosonExchangeEvents.sol,
  - added VoucherExpired
  - reordered alphabetically