### PR TITLE
Bug - When we merge an automated PR, another automated PR is generated.

### DIFF
--- a/.github/workflows/deploy-internal-test-env.yaml
+++ b/.github/workflows/deploy-internal-test-env.yaml
@@ -20,13 +20,16 @@ jobs:
           fetch-depth: 2 # we want 2 of the latest commit history to identify PR author
       - name: Check Author Name of the PR that merged to main
         run: |
-          echo "AUTHOR_NAME=$(git log -n 2 --pretty=format:%an | tail -1)" >> "$GITHUB_ENV"
-      - name: Check Author Email of the PR that merged to main
-        run: |
-          echo "AUTHOR_EMAIL=$(git log -n 2 --pretty=format:%ae | tail -1)" >> "$GITHUB_ENV"
+          LATEST_COMMIT_MESSAGE=$(git show -s --format=%s)
+
+          if [[ $LATEST_COMMIT_MESSAGE == *"Merge pull request #"* ]]; then
+            echo "AUTHOR_NAME=$(git log -n 2 --pretty=format:%an | tail -1)" >> "$GITHUB_ENV"
+          else
+            echo "AUTHOR_NAME=$(git log -n 1 --pretty=format:%an | tail -1)" >> "$GITHUB_ENV"
+          fi
       - name: Check if we can generate a new automated PR
         run: |
-          if [[ "$AUTHOR_NAME" == "GitHub Actions Bot" && "$AUTHOR_EMAIL" == "noreply@github.com" ]]; then
+          if [[ "$AUTHOR_NAME" == "GitHub Actions Bot" || "$AUTHOR_NAME" == "github-actions[bot]" ]]; then
               echo "CAN_GENERATE_AUTOMATED_PR=false" >> "$GITHUB_ENV"
           else
               echo "CAN_GENERATE_AUTOMATED_PR=true" >> "$GITHUB_ENV"


### PR DESCRIPTION
### Cause of the problem:
1. There are 3 ways to merge an approved PR.
  1.1  `Create a merge commit`.
  1.2 `Squash and merge`.
  1.3 `Rebase and merge`.
2. The bug occurred because `Squash and merge` and `Rebase and merge` were not handled in code.

<img width="1834" alt="Screenshot 2022-06-01_12-47-54-880" src="https://user-images.githubusercontent.com/91169722/171368661-16eecd14-cca1-410a-90cf-7622a856514a.png">


### How do we fix it:
1. If we do `Create a merge commit`, then I am checking the PR author name from the 2nd latest commit.
2. If we do `Squash and merge` or `Rebase and merge`, then I am checking the PR author name from the latest commit. This is because no new commit is added when we merge PRs to `main`.