### PR TITLE
Meta transactions: Remove chain id and use salt field instead

### DIFF
--- a/contracts/protocol/libs/MetaTransactionsLib.sol
+++ b/contracts/protocol/libs/MetaTransactionsLib.sol
@@ -9,7 +9,7 @@ import { ProtocolLib } from "../libs/ProtocolLib.sol";
  * @dev Provides the domain seperator and chain id.
  */
 library MetaTransactionsLib {
-    bytes32 internal constant EIP712_DOMAIN_TYPEHASH = keccak256(bytes("EIP712Domain(string name,string version,bytes32 salt,address verifyingContract)"));
+    bytes32 internal constant EIP712_DOMAIN_TYPEHASH = keccak256(bytes("EIP712Domain(string name,string version,address verifyingContract,bytes32 salt)"));
 
     /**
      * @notice Get the domain separator
@@ -19,7 +19,7 @@ library MetaTransactionsLib {
      */
     function domainSeparator(string memory _name, string memory _version) internal view returns (bytes32) {
         return keccak256(
-            abi.encode(EIP712_DOMAIN_TYPEHASH, keccak256(bytes(_name)), keccak256(bytes(_version)), getChainID(), address(this))
+            abi.encode(EIP712_DOMAIN_TYPEHASH, keccak256(bytes(_name)), keccak256(bytes(_version)), address(this), getChainID())
         );
     }
 

--- a/scripts/util/test-utils.js
+++ b/scripts/util/test-utils.js
@@ -68,15 +68,15 @@ async function prepareDataSignatureParameters(
   const domainType = [
     { name: "name", type: "string" },
     { name: "version", type: "string" },
-    { name: "salt", type: "bytes32" },
     { name: "verifyingContract", type: "address" },
+    { name: "salt", type: "bytes32" },
   ];
 
   const domainData = {
     name: "BosonProtocolDiamond",
     version: "V1",
-    salt: ethers.utils.hexZeroPad(ethers.BigNumber.from(31337).toHexString(), 32), //hardhat default chain id is 31337
     verifyingContract: metaTransactionsHandlerAddress,
+    salt: ethers.utils.hexZeroPad(ethers.BigNumber.from(31337).toHexString(), 32), //hardhat default chain id is 31337
   };
 
   // Prepare the types


### PR DESCRIPTION
### Purpose of this PR:
We want to support the scenario where Metamask needs to stay on Eth mainnet, while the meta-transaction should be signed for Polygon.

```
Without this change, it wouldn't be possible to create a meta-transaction for a chain with 
Metamask connected to another chain.
```
