### PR TITLE
Add MetaTransactionsHandlerFacet to deploy script

### DIFF
--- a/scripts/deploy-suite.js
+++ b/scripts/deploy-suite.js
@@ -78,15 +78,16 @@ function getConfig() {
 function getNoArgFacetNames(){
 
     return [
+        "AccountHandlerFacet",
+        "BundleHandlerFacet",
         "DisputeHandlerFacet",
         "ExchangeHandlerFacet",
         "FundsHandlerFacet",
-        "OfferHandlerFacet",
-        "TwinHandlerFacet",
-        "BundleHandlerFacet",
-        "AccountHandlerFacet",
         "GroupHandlerFacet",
-        "OrchestrationHandlerFacet"
+        "MetaTransactionsHandlerFacet",
+        "OfferHandlerFacet",
+        "OrchestrationHandlerFacet",
+        "TwinHandlerFacet"
     ];
 
 }


### PR DESCRIPTION
This pull request adds missing facets to the deployment script. It turns out only the MetaTransactionsHandlerFacet was missing. I added this to getNoArgFacetNames. I also re-ordered the facets so they are in alphabetical order and match the order in the IDE.