### PR TITLE
Fixing lint tidy and check scripts

### DIFF
--- a/contracts/diamond/facets/DiamondCutFacet.sol
+++ b/contracts/diamond/facets/DiamondCutFacet.sol
@@ -21,7 +21,6 @@ import { EIP712Lib } from "../../protocol/libs/EIP712Lib.sol";
  * @author Cliff Hall <cliff@futurescale.com> (https://twitter.com/seaofarrows)
  */
 contract DiamondCutFacet is BosonConstants, IDiamondCut {
-
     /**
      * @notice Cut facets of the Diamond
      *
@@ -35,10 +34,11 @@ contract DiamondCutFacet is BosonConstants, IDiamondCut {
      * @param _init The address of the contract or facet to execute _calldata
      * @param _calldata A function call, including function selector and arguments
      */
-    function diamondCut(FacetCut[] calldata _facetCuts, address _init, bytes calldata _calldata)
-    external
-    override
-    {
+    function diamondCut(
+        FacetCut[] calldata _facetCuts,
+        address _init,
+        bytes calldata _calldata
+    ) external override {
         // Get the diamond storage slot
         DiamondLib.DiamondStorage storage ds = DiamondLib.diamondStorage();
 
@@ -47,6 +47,5 @@ contract DiamondCutFacet is BosonConstants, IDiamondCut {
 
         // Make the cuts
         JewelerLib.diamondCut(_facetCuts, _init, _calldata);
-
     }
 }

--- a/contracts/diamond/facets/DiamondLoupeFacet.sol
+++ b/contracts/diamond/facets/DiamondLoupeFacet.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import { IDiamondLoupe } from "../../interfaces/diamond/IDiamondLoupe.sol";
-import { DiamondLib } from  "../DiamondLib.sol";
+import { DiamondLib } from "../DiamondLib.sol";
 
 /**
  * @title DiamondLoupeFacet
@@ -15,15 +15,13 @@ import { DiamondLib } from  "../DiamondLib.sol";
  * @author Nick Mudge <nick@perfectabstractions.com> (https://twitter.com/mudgen)
  */
 contract DiamondLoupeFacet is IDiamondLoupe {
-
-    string constant internal TOO_MANY_FUNCTIONS = "Too many functions on facet.";
+    string internal constant TOO_MANY_FUNCTIONS = "Too many functions on facet.";
 
     /**
      *  @notice Gets all facets and their selectors.
      *  @return facets_ Facet
      */
-    function facets() external override view returns (Facet[] memory facets_) {
-
+    function facets() external view override returns (Facet[] memory facets_) {
         DiamondLib.DiamondStorage storage ds = DiamondLib.diamondStorage();
         facets_ = new Facet[](ds.selectorCount);
         uint8[] memory numFacetSelectors = new uint8[](ds.selectorCount);
@@ -80,7 +78,12 @@ contract DiamondLoupeFacet is IDiamondLoupe {
      * @param _facet The facet address.
      * @return facetFunctionSelectors_ The selectors associated with a facet address.
      */
-    function facetFunctionSelectors(address _facet) external override view returns (bytes4[] memory facetFunctionSelectors_) {
+    function facetFunctionSelectors(address _facet)
+        external
+        view
+        override
+        returns (bytes4[] memory facetFunctionSelectors_)
+    {
         DiamondLib.DiamondStorage storage ds = DiamondLib.diamondStorage();
         uint256 numSelectors;
         facetFunctionSelectors_ = new bytes4[](ds.selectorCount);
@@ -111,7 +114,7 @@ contract DiamondLoupeFacet is IDiamondLoupe {
      * @notice Get all the facet addresses used by a diamond
      * @return facetAddresses_
      */
-    function facetAddresses() external override view returns (address[] memory facetAddresses_) {
+    function facetAddresses() external view override returns (address[] memory facetAddresses_) {
         DiamondLib.DiamondStorage storage ds = DiamondLib.diamondStorage();
         facetAddresses_ = new address[](ds.selectorCount);
         uint256 numFacets;
@@ -154,9 +157,8 @@ contract DiamondLoupeFacet is IDiamondLoupe {
      * @param _functionSelector The function selector.
      * @return facetAddress_ The facet address.
      */
-    function facetAddress(bytes4 _functionSelector) external override view returns (address facetAddress_) {
+    function facetAddress(bytes4 _functionSelector) external view override returns (address facetAddress_) {
         DiamondLib.DiamondStorage storage ds = DiamondLib.diamondStorage();
         facetAddress_ = address(bytes20(ds.facets[_functionSelector]));
     }
-
 }

--- a/contracts/interfaces/clients/IBosonClient.sol
+++ b/contracts/interfaces/clients/IBosonClient.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import { IAccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/IAccessControlUpgradeable.sol";
-import {IBosonClientEvents} from "../events/IBosonClientEvents.sol";
+import { IBosonClientEvents } from "../events/IBosonClientEvents.sol";
 
 /**
  * @title IBosonClient
@@ -23,7 +23,6 @@ import {IBosonClientEvents} from "../events/IBosonClientEvents.sol";
  * The ERC-165 identifier for this interface is: 0xc4c6c36b
  */
 interface IBosonClient is IBosonClientEvents {
-
     /**
      * @dev Set the implementation address
      */

--- a/contracts/interfaces/clients/IBosonVoucher.sol
+++ b/contracts/interfaces/clients/IBosonVoucher.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import {IERC721Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC721/IERC721Upgradeable.sol";
-import {BosonTypes} from "../../domain/BosonTypes.sol";
+import { IERC721Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC721/IERC721Upgradeable.sol";
+import { BosonTypes } from "../../domain/BosonTypes.sol";
 
 /**
  * @title IBosonVoucher
@@ -12,7 +12,6 @@ import {BosonTypes} from "../../domain/BosonTypes.sol";
  * The ERC-165 identifier for this interface is: 0x17c286ab
  */
 interface IBosonVoucher is IERC721Upgradeable {
-
     /**
      * @notice Issue a voucher to a buyer
      *
@@ -22,8 +21,7 @@ interface IBosonVoucher is IERC721Upgradeable {
      * @param _exchangeId - the id of the exchange (corresponds to the ERC-721 token id)
      * @param _buyer - the buyer of the vouchers
      */
-    function issueVoucher(uint256 _exchangeId, BosonTypes.Buyer calldata _buyer)
-    external;
+    function issueVoucher(uint256 _exchangeId, BosonTypes.Buyer calldata _buyer) external;
 
     /**
      * @notice Burn a voucher
@@ -32,7 +30,5 @@ interface IBosonVoucher is IERC721Upgradeable {
      *
      * @param _exchangeId - the id of the exchange (corresponds to the ERC-721 token id)
      */
-    function burnVoucher(uint256 _exchangeId)
-    external;
-
+    function burnVoucher(uint256 _exchangeId) external;
 }

--- a/contracts/interfaces/events/IBosonAccountEvents.sol
+++ b/contracts/interfaces/events/IBosonAccountEvents.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import {BosonTypes} from "../../domain/BosonTypes.sol";
+import { BosonTypes } from "../../domain/BosonTypes.sol";
 
 /**
  * @title IBosonAccountEvents
@@ -12,10 +12,31 @@ interface IBosonAccountEvents {
     event SellerCreated(uint256 indexed sellerId, BosonTypes.Seller seller, address indexed executedBy);
     event SellerUpdated(uint256 indexed sellerId, BosonTypes.Seller seller, address indexed executedBy);
     event BuyerCreated(uint256 indexed buyerId, BosonTypes.Buyer buyer, address indexed executedBy);
-    event BuyerUpdated(uint256 indexed buyerId, BosonTypes.Buyer buyer,  address indexed executedBy);
-    event DisputeResolverCreated(uint256 indexed disputeResolverId, BosonTypes.DisputeResolver disputeResolver,  BosonTypes.DisputeResolverFee[] disputeResolverFees, address indexed executedBy);
-    event DisputeResolverUpdated(uint256 indexed disputeResolverId, BosonTypes.DisputeResolver disputeResolver, address indexed executedBy);
-    event DisputeResolverFeesAdded(uint256 indexed disputeResolverId, BosonTypes.DisputeResolverFee[] disputeResolverFees, address indexed executedBy);
-    event DisputeResolverFeesRemoved(uint256 indexed disputeResolverId, address[] feeTokensRemoved, address indexed executedBy);
-    event DisputeResolverActivated(uint256 indexed disputeResolverId, BosonTypes.DisputeResolver disputeResolver, address indexed executedBy);
+    event BuyerUpdated(uint256 indexed buyerId, BosonTypes.Buyer buyer, address indexed executedBy);
+    event DisputeResolverCreated(
+        uint256 indexed disputeResolverId,
+        BosonTypes.DisputeResolver disputeResolver,
+        BosonTypes.DisputeResolverFee[] disputeResolverFees,
+        address indexed executedBy
+    );
+    event DisputeResolverUpdated(
+        uint256 indexed disputeResolverId,
+        BosonTypes.DisputeResolver disputeResolver,
+        address indexed executedBy
+    );
+    event DisputeResolverFeesAdded(
+        uint256 indexed disputeResolverId,
+        BosonTypes.DisputeResolverFee[] disputeResolverFees,
+        address indexed executedBy
+    );
+    event DisputeResolverFeesRemoved(
+        uint256 indexed disputeResolverId,
+        address[] feeTokensRemoved,
+        address indexed executedBy
+    );
+    event DisputeResolverActivated(
+        uint256 indexed disputeResolverId,
+        BosonTypes.DisputeResolver disputeResolver,
+        address indexed executedBy
+    );
 }

--- a/contracts/interfaces/events/IBosonBundleEvents.sol
+++ b/contracts/interfaces/events/IBosonBundleEvents.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import {BosonTypes} from "../../domain/BosonTypes.sol";
+import { BosonTypes } from "../../domain/BosonTypes.sol";
 
 /**
  * @title IBosonBundleEvents
@@ -9,7 +9,17 @@ import {BosonTypes} from "../../domain/BosonTypes.sol";
  * @notice Events related to management of bundles within the protocol
  */
 interface IBosonBundleEvents {
-    event BundleCreated(uint256 indexed bundleId, uint256 indexed sellerId, BosonTypes.Bundle bundle, address indexed executedBy);
-    event BundleUpdated(uint256 indexed bundleId, uint256 indexed sellerId, BosonTypes.Bundle bundle, address indexed executedBy);
+    event BundleCreated(
+        uint256 indexed bundleId,
+        uint256 indexed sellerId,
+        BosonTypes.Bundle bundle,
+        address indexed executedBy
+    );
+    event BundleUpdated(
+        uint256 indexed bundleId,
+        uint256 indexed sellerId,
+        BosonTypes.Bundle bundle,
+        address indexed executedBy
+    );
     event BundleDeleted(uint256 indexed bundleId, uint256 indexed sellerId, address indexed executedBy);
 }

--- a/contracts/interfaces/events/IBosonConfigEvents.sol
+++ b/contracts/interfaces/events/IBosonConfigEvents.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import {BosonTypes} from "../../domain/BosonTypes.sol";
+import { BosonTypes } from "../../domain/BosonTypes.sol";
 
 /**
  * @title IBosonConfigEvents
  *
  * @notice Events related to management of configuration within the protocol.
  */
-interface IBosonConfigEvents { 
+interface IBosonConfigEvents {
     event VoucherAddressChanged(address indexed voucher, address indexed executedBy);
     event TokenAddressChanged(address indexed tokenAddress, address indexed executedBy);
     event TreasuryAddressChanged(address indexed treasuryAddress, address indexed executedBy);
@@ -18,8 +18,8 @@ interface IBosonConfigEvents {
     event MaxOffersPerBatchChanged(uint16 maxOffersPerBatch, address indexed executedBy);
     event MaxTwinsPerBundleChanged(uint16 maxTwinsPerBundle, address indexed executedBy);
     event MaxOffersPerBundleChanged(uint16 maxOffersPerBundle, address indexed executedBy);
-    event MaxTokensPerWithdrawalChanged(uint16 maxTokensPerWithdrawal, address indexed executedBy);  
-    event MaxFeesPerDisputeResolverChanged(uint16 maxFeesPerDisputeResolver, address indexed executedBy); 
+    event MaxTokensPerWithdrawalChanged(uint16 maxTokensPerWithdrawal, address indexed executedBy);
+    event MaxFeesPerDisputeResolverChanged(uint16 maxFeesPerDisputeResolver, address indexed executedBy);
     event MaxEscalationResponsePeriodChanged(uint256 maxEscalationResponsePeriod, address indexed executedBy);
     event MaxDisputesPerBatchChanged(uint16 maxDisputesPerBatch, address indexed executedBy);
 }

--- a/contracts/interfaces/events/IBosonDisputeEvents.sol
+++ b/contracts/interfaces/events/IBosonDisputeEvents.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import {BosonTypes} from "../../domain/BosonTypes.sol";
+import { BosonTypes } from "../../domain/BosonTypes.sol";
 
 /**
  * @title IBosonDisputeEvents
@@ -9,12 +9,18 @@ import {BosonTypes} from "../../domain/BosonTypes.sol";
  * @notice Events related to disputes within the protocol.
  */
 interface IBosonDisputeEvents {
-    event DisputeRaised(uint256 indexed exchangeId, uint256 indexed buyerId, uint256 indexed sellerId, string complaint, address executedBy);
+    event DisputeRaised(
+        uint256 indexed exchangeId,
+        uint256 indexed buyerId,
+        uint256 indexed sellerId,
+        string complaint,
+        address executedBy
+    );
     event DisputeRetracted(uint256 indexed exchangeId, address indexed executedBy);
     event DisputeResolved(uint256 indexed exchangeId, uint256 _buyerPercent, address indexed executedBy);
     event DisputeExpired(uint256 indexed exchangeId, address indexed executedBy);
     event DisputeDecided(uint256 indexed exchangeId, uint256 _buyerPercent, address indexed executedBy);
-    event DisputeTimeoutExtended(uint256 indexed exchangeId, uint256 newDisputeTimeout, address indexed executedBy);   
+    event DisputeTimeoutExtended(uint256 indexed exchangeId, uint256 newDisputeTimeout, address indexed executedBy);
     event DisputeEscalated(uint256 indexed exchangeId, uint256 indexed disputeResolverId, address indexed executedBy);
     event EscalatedDisputeExpired(uint256 indexed exchangeId, address indexed executedBy);
     event EscalatedDisputeRefused(uint256 indexed exchangeId, address indexed executedBy);

--- a/contracts/interfaces/events/IBosonExchangeEvents.sol
+++ b/contracts/interfaces/events/IBosonExchangeEvents.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import {BosonTypes} from "../../domain/BosonTypes.sol";
+import { BosonTypes } from "../../domain/BosonTypes.sol";
 
 /**
  * @title IBosonExchangeEvents
@@ -9,11 +9,27 @@ import {BosonTypes} from "../../domain/BosonTypes.sol";
  * @notice Events related to exchanges within the protocol.
  */
 interface IBosonExchangeEvents {
-    event BuyerCommitted(uint256 indexed offerId, uint256 indexed buyerId, uint256 indexed exchangeId, BosonTypes.Exchange exchange, address executedBy);
-    event ExchangeCompleted(uint256 indexed offerId, uint256 indexed buyerId, uint256 indexed exchangeId, address executedBy);
+    event BuyerCommitted(
+        uint256 indexed offerId,
+        uint256 indexed buyerId,
+        uint256 indexed exchangeId,
+        BosonTypes.Exchange exchange,
+        address executedBy
+    );
+    event ExchangeCompleted(
+        uint256 indexed offerId,
+        uint256 indexed buyerId,
+        uint256 indexed exchangeId,
+        address executedBy
+    );
     event VoucherCanceled(uint256 indexed offerId, uint256 indexed exchangeId, address indexed executedBy);
     event VoucherExpired(uint256 indexed offerId, uint256 indexed exchangeId, address indexed executedBy);
     event VoucherRedeemed(uint256 indexed offerId, uint256 indexed exchangeId, address indexed executedBy);
     event VoucherRevoked(uint256 indexed offerId, uint256 indexed exchangeId, address indexed executedBy);
-    event VoucherTransferred(uint256 indexed offerId, uint256 indexed exchangeId, uint256 indexed newBuyerId, address executedBy);
+    event VoucherTransferred(
+        uint256 indexed offerId,
+        uint256 indexed exchangeId,
+        uint256 indexed newBuyerId,
+        address executedBy
+    );
 }

--- a/contracts/interfaces/events/IBosonFundsEvents.sol
+++ b/contracts/interfaces/events/IBosonFundsEvents.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import {BosonTypes} from "../../domain/BosonTypes.sol";
+import { BosonTypes } from "../../domain/BosonTypes.sol";
 
 /**
  * @title IBosonFundsEvents
@@ -9,12 +9,39 @@ import {BosonTypes} from "../../domain/BosonTypes.sol";
  * @notice Events related to management of funds within the protocol.
  */
 interface IBosonFundsEvents {
-    event FundsDeposited(uint256 indexed sellerId, address indexed executedBy, address indexed tokenAddress, uint256 amount);  
+    event FundsDeposited(
+        uint256 indexed sellerId,
+        address indexed executedBy,
+        address indexed tokenAddress,
+        uint256 amount
+    );
 }
 
 interface IBosonFundsLibEvents {
-    event FundsEncumbered(uint256 indexed entityId, address indexed exchangeToken, uint256 amount, address indexed executedBy);  
-    event FundsReleased(uint256 indexed exchangeId, uint256 indexed entityId, address indexed exchangeToken, uint256 amount, address executedBy);
-    event ProtocolFeeCollected(uint256 indexed exchangeId, address indexed exchangeToken, uint256 amount, address indexed executedBy);
-    event FundsWithdrawn(uint256 indexed sellerId, address indexed withdrawnTo, address indexed tokenAddress, uint256 amount, address executedBy);  
+    event FundsEncumbered(
+        uint256 indexed entityId,
+        address indexed exchangeToken,
+        uint256 amount,
+        address indexed executedBy
+    );
+    event FundsReleased(
+        uint256 indexed exchangeId,
+        uint256 indexed entityId,
+        address indexed exchangeToken,
+        uint256 amount,
+        address executedBy
+    );
+    event ProtocolFeeCollected(
+        uint256 indexed exchangeId,
+        address indexed exchangeToken,
+        uint256 amount,
+        address indexed executedBy
+    );
+    event FundsWithdrawn(
+        uint256 indexed sellerId,
+        address indexed withdrawnTo,
+        address indexed tokenAddress,
+        uint256 amount,
+        address executedBy
+    );
 }

--- a/contracts/interfaces/events/IBosonGroupEvents.sol
+++ b/contracts/interfaces/events/IBosonGroupEvents.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import {BosonTypes} from "../../domain/BosonTypes.sol";
+import { BosonTypes } from "../../domain/BosonTypes.sol";
 
 /**
  * @title IBosonGroupEvents
@@ -9,6 +9,16 @@ import {BosonTypes} from "../../domain/BosonTypes.sol";
  * @notice Events related to management of groups within the protocol.
  */
 interface IBosonGroupEvents {
-    event GroupCreated(uint256 indexed groupId, uint256 indexed sellerId, BosonTypes.Group group, address indexed executedBy);
-    event GroupUpdated(uint256 indexed groupId, uint256 indexed sellerId, BosonTypes.Group group, address indexed executedBy);
+    event GroupCreated(
+        uint256 indexed groupId,
+        uint256 indexed sellerId,
+        BosonTypes.Group group,
+        address indexed executedBy
+    );
+    event GroupUpdated(
+        uint256 indexed groupId,
+        uint256 indexed sellerId,
+        BosonTypes.Group group,
+        address indexed executedBy
+    );
 }

--- a/contracts/interfaces/events/IBosonMetaTransactionsEvents.sol
+++ b/contracts/interfaces/events/IBosonMetaTransactionsEvents.sol
@@ -7,5 +7,10 @@ pragma solidity ^0.8.0;
  * @notice Events related to meta-transactions in the protocol.
  */
 interface IBosonMetaTransactionsEvents {
-    event MetaTransactionExecuted(address indexed userAddress, address indexed relayerAddress, string indexed functionName, uint256 nonce);
+    event MetaTransactionExecuted(
+        address indexed userAddress,
+        address indexed relayerAddress,
+        string indexed functionName,
+        uint256 nonce
+    );
 }

--- a/contracts/interfaces/events/IBosonOfferEvents.sol
+++ b/contracts/interfaces/events/IBosonOfferEvents.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import {BosonTypes} from "../../domain/BosonTypes.sol";
+import { BosonTypes } from "../../domain/BosonTypes.sol";
 
 /**
  * @title IBosonOfferEvents
@@ -9,7 +9,19 @@ import {BosonTypes} from "../../domain/BosonTypes.sol";
  * @notice Events related to management of offers within the protocol.
  */
 interface IBosonOfferEvents {
-    event OfferCreated(uint256 indexed offerId, uint256 indexed sellerId, BosonTypes.Offer offer, BosonTypes.OfferDates offerDates, BosonTypes.OfferDurations offerDurations, address indexed executedBy);
-    event OfferExtended(uint256 indexed offerId, uint256 indexed sellerId, uint256 validUntilDate, address indexed executedBy);
+    event OfferCreated(
+        uint256 indexed offerId,
+        uint256 indexed sellerId,
+        BosonTypes.Offer offer,
+        BosonTypes.OfferDates offerDates,
+        BosonTypes.OfferDurations offerDurations,
+        address indexed executedBy
+    );
+    event OfferExtended(
+        uint256 indexed offerId,
+        uint256 indexed sellerId,
+        uint256 validUntilDate,
+        address indexed executedBy
+    );
     event OfferVoided(uint256 indexed offerId, uint256 indexed sellerId, address indexed executedBy);
 }

--- a/contracts/interfaces/events/IBosonTwinEvents.sol
+++ b/contracts/interfaces/events/IBosonTwinEvents.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import {BosonTypes} from "../../domain/BosonTypes.sol";
+import { BosonTypes } from "../../domain/BosonTypes.sol";
 
 /**
  * @title IBosonTwinEvents
@@ -9,6 +9,11 @@ import {BosonTypes} from "../../domain/BosonTypes.sol";
  * @notice Events related to management of twins within the protocol.
  */
 interface IBosonTwinEvents {
-    event TwinCreated(uint256 indexed twinId, uint256 indexed sellerId, BosonTypes.Twin twin, address indexed executedBy);
+    event TwinCreated(
+        uint256 indexed twinId,
+        uint256 indexed sellerId,
+        BosonTypes.Twin twin,
+        address indexed executedBy
+    );
     event TwinDeleted(uint256 indexed twinId, uint256 indexed sellerId, address indexed executedBy);
 }

--- a/contracts/interfaces/handlers/IBosonAccountHandler.sol
+++ b/contracts/interfaces/handlers/IBosonAccountHandler.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import {BosonTypes} from "../../domain/BosonTypes.sol";
-import {IBosonAccountEvents} from "../events/IBosonAccountEvents.sol";
+import { BosonTypes } from "../../domain/BosonTypes.sol";
+import { IBosonAccountEvents } from "../events/IBosonAccountEvents.sol";
 
 /**
  * @title IBosonAccountHandler
@@ -12,7 +12,6 @@ import {IBosonAccountEvents} from "../events/IBosonAccountEvents.sol";
  * The ERC-165 identifier for this interface is: 0x2cf25a22
  */
 interface IBosonAccountHandler is IBosonAccountEvents {
-
     /**
      * @notice Creates a seller
      *
@@ -56,7 +55,10 @@ interface IBosonAccountHandler is IBosonAccountEvents {
      * @param _disputeResolver - the fully populated struct with dispute resolver id set to 0x0
      * @param _disputeResolverFees - array of fees dispute resolver charges per token type. Zero address is native currency. Can be empty.
      */
-    function createDisputeResolver(BosonTypes.DisputeResolver memory _disputeResolver, BosonTypes.DisputeResolverFee[] calldata _disputeResolverFees) external;
+    function createDisputeResolver(
+        BosonTypes.DisputeResolver memory _disputeResolver,
+        BosonTypes.DisputeResolverFee[] calldata _disputeResolverFees
+    ) external;
 
     /**
      * @notice Updates a seller
@@ -90,10 +92,10 @@ interface IBosonAccountHandler is IBosonAccountEvents {
     function updateBuyer(BosonTypes.Buyer memory _buyer) external;
 
     /**
-     * @notice Updates a dispute resolver, not including DisputeResolverFees or active flag. 
+     * @notice Updates a dispute resolver, not including DisputeResolverFees or active flag.
      * All DisputeResolver fields should be filled, even those staying the same.
      * Use removeFeesFromDisputeResolver
-     * 
+     *
      * Emits a DisputeResolverUpdated event if successful.
      *
      * Reverts if:
@@ -108,7 +110,7 @@ interface IBosonAccountHandler is IBosonAccountEvents {
 
     /**
      * @notice Add DisputeResolverFees to an existing dispute resolver
-     * 
+     *
      * Emits a DisputeResolverFeesAdded event if successful.
      *
      * Reverts if:
@@ -121,11 +123,14 @@ interface IBosonAccountHandler is IBosonAccountEvents {
      * @param _disputeResolverId - Id of the dispute resolver
      * @param _disputeResolverFees - list of fees dispute resolver charges per token type. Zero address is native currency. See {BosonTypes.DisputeResolverFee}
      */
-    function addFeesToDisputeResolver(uint256 _disputeResolverId, BosonTypes.DisputeResolverFee[] calldata _disputeResolverFees) external;
+    function addFeesToDisputeResolver(
+        uint256 _disputeResolverId,
+        BosonTypes.DisputeResolverFee[] calldata _disputeResolverFees
+    ) external;
 
     /**
      * @notice Remove DisputeResolverFees from  an existing dispute resolver
-     * 
+     *
      * Emits a DisputeResolverFeesRemoved event if successful.
      *
      * Reverts if:
@@ -142,7 +147,7 @@ interface IBosonAccountHandler is IBosonAccountEvents {
 
     /**
      * @notice Set the active flag for this Dispute Resolver to true. Only callable by the protocol ADMIN role.
-     * 
+     *
      * Emits a DisputeResolverActivated event if successful.
      *
      * Reverts if:
@@ -191,7 +196,14 @@ interface IBosonAccountHandler is IBosonAccountEvents {
      * @return disputeResolver - the resolver details. See {BosonTypes.DisputeResolver}
      * @return disputeResolverFees - list of fees dispute resolver charges per token type. Zero address is native currency. See {BosonTypes.DisputeResolverFee}
      */
-    function getDisputeResolver(uint256 _disputeResolverId) external view returns (bool exists, BosonTypes.DisputeResolver memory disputeResolver, BosonTypes.DisputeResolverFee[] memory disputeResolverFees);
+    function getDisputeResolver(uint256 _disputeResolverId)
+        external
+        view
+        returns (
+            bool exists,
+            BosonTypes.DisputeResolver memory disputeResolver,
+            BosonTypes.DisputeResolverFee[] memory disputeResolverFees
+        );
 
     /**
      * @notice Gets the details about a dispute resolver by an address associated with that seller: operator, admin, or clerk address.
@@ -204,7 +216,11 @@ interface IBosonAccountHandler is IBosonAccountEvents {
     function getDisputeResolverByAddress(address _associatedAddress)
         external
         view
-        returns (bool exists, BosonTypes.DisputeResolver memory disputeResolver, BosonTypes.DisputeResolverFee[] memory disputeResolverFees);
+        returns (
+            bool exists,
+            BosonTypes.DisputeResolver memory disputeResolver,
+            BosonTypes.DisputeResolverFee[] memory disputeResolverFees
+        );
 
     /**
      * @notice Gets the next account Id that can be assigned to an account.

--- a/contracts/interfaces/handlers/IBosonBundleHandler.sol
+++ b/contracts/interfaces/handlers/IBosonBundleHandler.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import {BosonTypes} from "../../domain/BosonTypes.sol";
-import {IBosonBundleEvents} from "../events/IBosonBundleEvents.sol";
+import { BosonTypes } from "../../domain/BosonTypes.sol";
+import { IBosonBundleEvents } from "../events/IBosonBundleEvents.sol";
 
 /**
  * @title IBosonBundleHandler
@@ -12,7 +12,6 @@ import {IBosonBundleEvents} from "../events/IBosonBundleEvents.sol";
  * The ERC-165 identifier for this interface is: 0xa13dc8bd
  */
 interface IBosonBundleHandler is IBosonBundleEvents {
-
     /**
      * @notice Creates a bundle.
      *

--- a/contracts/interfaces/handlers/IBosonConfigHandler.sol
+++ b/contracts/interfaces/handlers/IBosonConfigHandler.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import {BosonTypes} from "../../domain/BosonTypes.sol";
-import {IBosonConfigEvents} from "../events/IBosonConfigEvents.sol";
+import { BosonTypes } from "../../domain/BosonTypes.sol";
+import { IBosonConfigEvents } from "../events/IBosonConfigEvents.sol";
 
 /**
  * @title IBosonConfigHandler
@@ -12,7 +12,6 @@ import {IBosonConfigEvents} from "../events/IBosonConfigEvents.sol";
  * The ERC-165 identifier for this interface is: 0x52192fa6
  */
 interface IBosonConfigHandler is IBosonConfigEvents {
-
     /**
      * @notice Sets the address of the Boson Token (ERC-20) contract.
      *
@@ -72,7 +71,7 @@ interface IBosonConfigHandler is IBosonConfigEvents {
      */
     function getProtocolFeePercentage() external view returns (uint16);
 
-     /**
+    /**
      * @notice Sets the flat protocol fee for exchanges in $BOSON.
      *
      * Emits a ProtocolFeeFlatBosonChanged event.
@@ -143,7 +142,7 @@ interface IBosonConfigHandler is IBosonConfigEvents {
      */
     function getMaxOffersPerBundle() external view returns (uint16);
 
-     /**
+    /**
      * @notice Sets the maximum numbers of tokens that can be withdrawn in a single transaction
      *
      * Emits a mMxTokensPerWithdrawalChanged event.
@@ -180,13 +179,12 @@ interface IBosonConfigHandler is IBosonConfigEvents {
      */
     function setMaxEscalationResponsePeriod(uint256 _maxEscalationResponsePeriod) external;
 
-   
     /**
      * @notice Get the maximum escalation response period a dispute resolver can specify
      */
     function getMaxEscalationResponsePeriod() external view returns (uint256);
 
-     /**
+    /**
      * @notice Sets the maximum numbers of disputes that can be expired in a single transaction
      *
      * Emits a MaxDisputesPerBatchChanged event.
@@ -198,5 +196,5 @@ interface IBosonConfigHandler is IBosonConfigEvents {
     /**
      * @notice Get the maximum disputes per batch
      */
-    function getMaxDisputesPerBatch() external view returns (uint16);   
+    function getMaxDisputesPerBatch() external view returns (uint16);
 }

--- a/contracts/interfaces/handlers/IBosonDisputeHandler.sol
+++ b/contracts/interfaces/handlers/IBosonDisputeHandler.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import {BosonTypes} from "../../domain/BosonTypes.sol";
-import {IBosonDisputeEvents} from "../events/IBosonDisputeEvents.sol";
-import {IBosonFundsLibEvents} from "../events/IBosonFundsEvents.sol";
+import { BosonTypes } from "../../domain/BosonTypes.sol";
+import { IBosonDisputeEvents } from "../events/IBosonDisputeEvents.sol";
+import { IBosonFundsLibEvents } from "../events/IBosonFundsEvents.sol";
 
 /**
  * @title IBosonDisputeHandler
@@ -13,7 +13,6 @@ import {IBosonFundsLibEvents} from "../events/IBosonFundsEvents.sol";
  * The ERC-165 identifier for this interface is: 0x88b4cc7b
  */
 interface IBosonDisputeHandler is IBosonDisputeEvents, IBosonFundsLibEvents {
-
     /**
      * @notice Raise a dispute
      *
@@ -25,7 +24,7 @@ interface IBosonDisputeHandler is IBosonDisputeEvents, IBosonFundsLibEvents {
      * - exchange is not in a redeemed state
      * - the complaint is blank
      * - fulfillment period has elapsed already
-     * 
+     *
      * @param _exchangeId - the id of the associated offer
      * @param _complaint - the buyer's complaint description
      */
@@ -65,7 +64,7 @@ interface IBosonDisputeHandler is IBosonDisputeEvents, IBosonFundsLibEvents {
      * @param _newDisputeTimeout - new date when resolution period ends
      */
     function extendDisputeTimeout(uint256 _exchangeId, uint256 _newDisputeTimeout) external;
-    
+
     /**
      * @notice Expire the dispute and release the funds
      *
@@ -98,7 +97,7 @@ interface IBosonDisputeHandler is IBosonDisputeEvents, IBosonFundsLibEvents {
      */
     function expireDisputeBatch(uint256[] calldata _exchangeIds) external;
 
-     /**
+    /**
      * @notice Resolve a dispute by providing the information about the split. Callable by the buyer or seller, but they must provide the resolution signed by the other party
      *
      * Emits a DisputeResolved event if successful.
@@ -119,9 +118,13 @@ interface IBosonDisputeHandler is IBosonDisputeEvents, IBosonFundsLibEvents {
      * @param _sigS - s part of the signer's signature.
      * @param _sigV - v part of the signer's signature.
      */
-    function resolveDispute(uint256 _exchangeId, uint256 _buyerPercent, bytes32 _sigR,
+    function resolveDispute(
+        uint256 _exchangeId,
+        uint256 _buyerPercent,
+        bytes32 _sigR,
         bytes32 _sigS,
-        uint8 _sigV) external;
+        uint8 _sigV
+    ) external;
 
     /**
      * @notice Puts the dispute into escalated state
@@ -197,10 +200,14 @@ interface IBosonDisputeHandler is IBosonDisputeEvents, IBosonFundsLibEvents {
      * @return disputeDates - the dispute dates details {BosonTypes.DisputeDates}
      */
     function getDispute(uint256 _exchangeId)
-    external
-    view
-    returns(bool exists, BosonTypes.Dispute memory dispute, BosonTypes.DisputeDates memory disputeDates);
-       
+        external
+        view
+        returns (
+            bool exists,
+            BosonTypes.Dispute memory dispute,
+            BosonTypes.DisputeDates memory disputeDates
+        );
+
     /**
      * @notice Gets the state of a given dispute.
      *
@@ -208,7 +215,7 @@ interface IBosonDisputeHandler is IBosonDisputeEvents, IBosonFundsLibEvents {
      * @return exists - true if the dispute exists
      * @return state - the dispute state. See {BosonTypes.DisputeState}
      */
-    function getDisputeState(uint256 _exchangeId) external view returns(bool exists, BosonTypes.DisputeState state);
+    function getDisputeState(uint256 _exchangeId) external view returns (bool exists, BosonTypes.DisputeState state);
 
     /**
      * @notice Gets the timeout of a given dispute.
@@ -217,10 +224,7 @@ interface IBosonDisputeHandler is IBosonDisputeEvents, IBosonFundsLibEvents {
      * @return exists - true if the dispute exists
      * @return timeout - the end of resolution period
      */
-    function getDisputeTimeout(uint256 _exchangeId)
-    external
-    view
-    returns(bool exists, uint256 timeout);
+    function getDisputeTimeout(uint256 _exchangeId) external view returns (bool exists, uint256 timeout);
 
     /**
      * @notice Is the given dispute in a finalized state?
@@ -232,5 +236,5 @@ interface IBosonDisputeHandler is IBosonDisputeEvents, IBosonFundsLibEvents {
      * @return exists - true if the dispute exists
      * @return isFinalized - true if the dispute is finalized
      */
-    function isDisputeFinalized(uint256 _exchangeId) external view returns(bool exists, bool isFinalized);
+    function isDisputeFinalized(uint256 _exchangeId) external view returns (bool exists, bool isFinalized);
 }

--- a/contracts/interfaces/handlers/IBosonExchangeHandler.sol
+++ b/contracts/interfaces/handlers/IBosonExchangeHandler.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import {BosonTypes} from "../../domain/BosonTypes.sol";
-import {IBosonExchangeEvents} from "../events/IBosonExchangeEvents.sol";
-import {IBosonFundsLibEvents} from "../events/IBosonFundsEvents.sol";
+import { BosonTypes } from "../../domain/BosonTypes.sol";
+import { IBosonExchangeEvents } from "../events/IBosonExchangeEvents.sol";
+import { IBosonFundsLibEvents } from "../events/IBosonFundsEvents.sol";
 
 /**
  * @title IBosonExchangeHandler
@@ -13,7 +13,6 @@ import {IBosonFundsLibEvents} from "../events/IBosonFundsEvents.sol";
  * The ERC-165 identifier for this interface is: 0x619e9d29
  */
 interface IBosonExchangeHandler is IBosonExchangeEvents, IBosonFundsLibEvents {
-
     /**
      * @notice Commit to an offer (first step of an exchange)
      *
@@ -98,8 +97,7 @@ interface IBosonExchangeHandler is IBosonExchangeEvents, IBosonFundsLibEvents {
      *
      * @param _exchangeId - the id of the exchange
      */
-    function expireVoucher(uint256 _exchangeId)
-    external;
+    function expireVoucher(uint256 _exchangeId) external;
 
     /**
      * @notice Redeem a voucher.
@@ -144,10 +142,7 @@ interface IBosonExchangeHandler is IBosonExchangeEvents, IBosonFundsLibEvents {
      * @return exists - true if the exchange exists
      * @return isFinalized - true if the exchange is finalized
      */
-    function isExchangeFinalized(uint256 _exchangeId)
-    external
-    view
-    returns(bool exists, bool isFinalized);
+    function isExchangeFinalized(uint256 _exchangeId) external view returns (bool exists, bool isFinalized);
 
     /**
      * @notice Gets the details about a given exchange.

--- a/contracts/interfaces/handlers/IBosonFundsHandler.sol
+++ b/contracts/interfaces/handlers/IBosonFundsHandler.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import {BosonTypes} from "../../domain/BosonTypes.sol";
-import {IBosonFundsEvents} from "../events/IBosonFundsEvents.sol";
-import {IBosonFundsLibEvents} from "../events/IBosonFundsEvents.sol";
+import { BosonTypes } from "../../domain/BosonTypes.sol";
+import { IBosonFundsEvents } from "../events/IBosonFundsEvents.sol";
+import { IBosonFundsLibEvents } from "../events/IBosonFundsEvents.sol";
 
 /**
  * @title IBosonFundsHandler
@@ -13,7 +13,6 @@ import {IBosonFundsLibEvents} from "../events/IBosonFundsEvents.sol";
  * The ERC-165 identifier for this interface is: 0x18834247
  */
 interface IBosonFundsHandler is IBosonFundsEvents, IBosonFundsLibEvents {
-
     /**
      * @notice Receives funds from the caller and stores it to the seller id, so they can be used during the commitToOffer
      *
@@ -28,7 +27,11 @@ interface IBosonFundsHandler is IBosonFundsEvents, IBosonFundsLibEvents {
      * @param _tokenAddress - contract address of token that is being deposited (0 for native currency)
      * @param _amount - amount to be credited
      */
-     function depositFunds(uint256 _sellerId, address _tokenAddress, uint256 _amount) external payable;
+    function depositFunds(
+        uint256 _sellerId,
+        address _tokenAddress,
+        uint256 _amount
+    ) external payable;
 
     /**
      * @notice For a given seller or buyer id it returns the information about the funds that can use as a sellerDeposit and/or be withdrawn
@@ -53,7 +56,11 @@ interface IBosonFundsHandler is IBosonFundsEvents, IBosonFundsLibEvents {
      * @param _tokenList - list of contract addresses of tokens that are being withdrawn
      * @param _tokenAmounts - list of amounts to be withdrawn, corresponding to tokens in tokenList
      */
-    function withdrawFunds(uint256 _entityId, address[] calldata _tokenList, uint256[] calldata _tokenAmounts) external;
+    function withdrawFunds(
+        uint256 _entityId,
+        address[] calldata _tokenList,
+        uint256[] calldata _tokenAmounts
+    ) external;
 
     /**
      * @notice Withdraw the protocol fees

--- a/contracts/interfaces/handlers/IBosonGroupHandler.sol
+++ b/contracts/interfaces/handlers/IBosonGroupHandler.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import {BosonTypes} from "../../domain/BosonTypes.sol";
-import {IBosonGroupEvents} from "../events/IBosonGroupEvents.sol";
+import { BosonTypes } from "../../domain/BosonTypes.sol";
+import { IBosonGroupEvents } from "../events/IBosonGroupEvents.sol";
 
 /**
  * @title IBosonGroupHandler
@@ -12,7 +12,6 @@ import {IBosonGroupEvents} from "../events/IBosonGroupEvents.sol";
  * The ERC-165 identifier for this interface is: 0x4d0d87ad
  */
 interface IBosonGroupHandler is IBosonGroupEvents {
-
     /**
      * @notice Creates a group.
      *

--- a/contracts/interfaces/handlers/IBosonMetaTransactionsHandler.sol
+++ b/contracts/interfaces/handlers/IBosonMetaTransactionsHandler.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import {BosonTypes} from "../../domain/BosonTypes.sol";
-import {IBosonMetaTransactionsEvents} from "../events/IBosonMetaTransactionsEvents.sol";
+import { BosonTypes } from "../../domain/BosonTypes.sol";
+import { IBosonMetaTransactionsEvents } from "../events/IBosonMetaTransactionsEvents.sol";
 
 /**
  * @title IBosonMetaTransactionsHandler
@@ -12,13 +12,12 @@ import {IBosonMetaTransactionsEvents} from "../events/IBosonMetaTransactionsEven
  * The ERC-165 identifier for this interface is: 0x369a01ef
  */
 interface IBosonMetaTransactionsHandler is IBosonMetaTransactionsEvents {
-
     /**
      * @notice Checks nonce and returns true if used already.
      *
      * @param _nonce - the nonce that we want to check.
      */
-    function isUsedNonce(uint256 _nonce) external view returns(bool);
+    function isUsedNonce(uint256 _nonce) external view returns (bool);
 
     /**
      * @notice Handles the incoming meta transaction.

--- a/contracts/interfaces/handlers/IBosonOfferHandler.sol
+++ b/contracts/interfaces/handlers/IBosonOfferHandler.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import {BosonTypes} from "../../domain/BosonTypes.sol";
-import {IBosonOfferEvents} from "../events/IBosonOfferEvents.sol";
+import { BosonTypes } from "../../domain/BosonTypes.sol";
+import { IBosonOfferEvents } from "../events/IBosonOfferEvents.sol";
 
 /**
  * @title IBosonOfferHandler
@@ -12,7 +12,6 @@ import {IBosonOfferEvents} from "../events/IBosonOfferEvents.sol";
  * The ERC-165 identifier for this interface is: 0xf411945f
  */
 interface IBosonOfferHandler is IBosonOfferEvents {
-
     /**
      * @notice Creates an offer
      *
@@ -37,7 +36,11 @@ interface IBosonOfferHandler is IBosonOfferEvents {
      * @param _offerDates - the fully populated offer dates struct
      * @param _offerDurations - the fully populated offer durations struct
      */
-    function createOffer(BosonTypes.Offer memory _offer, BosonTypes.OfferDates calldata _offerDates, BosonTypes.OfferDurations calldata _offerDurations) external;
+    function createOffer(
+        BosonTypes.Offer memory _offer,
+        BosonTypes.OfferDates calldata _offerDates,
+        BosonTypes.OfferDurations calldata _offerDurations
+    ) external;
 
     /**
      * @notice Creates a batch of offers.
@@ -66,7 +69,11 @@ interface IBosonOfferHandler is IBosonOfferEvents {
      * @param _offerDates - the array of fully populated offer dates structs
      * @param _offerDurations - the array of fully populated offer durations structs
      */
-    function createOfferBatch(BosonTypes.Offer[] calldata _offers, BosonTypes.OfferDates[] calldata _offerDates, BosonTypes.OfferDurations[] calldata _offerDurations) external;
+    function createOfferBatch(
+        BosonTypes.Offer[] calldata _offers,
+        BosonTypes.OfferDates[] calldata _offerDates,
+        BosonTypes.OfferDurations[] calldata _offerDurations
+    ) external;
 
     /**
      * @notice Voids a given offer
@@ -148,7 +155,15 @@ interface IBosonOfferHandler is IBosonOfferEvents {
      * @return offerDates - the offer dates details. See {BosonTypes.OfferDates}
      * @return offerDurations - the offer durations details. See {BosonTypes.OfferDurations}
      */
-    function getOffer(uint256 _offerId) external view returns (bool exists, BosonTypes.Offer memory offer, BosonTypes.OfferDates calldata offerDates, BosonTypes.OfferDurations calldata offerDurations);
+    function getOffer(uint256 _offerId)
+        external
+        view
+        returns (
+            bool exists,
+            BosonTypes.Offer memory offer,
+            BosonTypes.OfferDates calldata offerDates,
+            BosonTypes.OfferDurations calldata offerDurations
+        );
 
     /**
      * @notice Gets the next offer id.
@@ -167,5 +182,4 @@ interface IBosonOfferHandler is IBosonOfferEvents {
      * @return offerVoided - true if voided, false otherwise
      */
     function isOfferVoided(uint256 _offerId) external view returns (bool exists, bool offerVoided);
-
 }

--- a/contracts/interfaces/handlers/IBosonOrchestrationHandler.sol
+++ b/contracts/interfaces/handlers/IBosonOrchestrationHandler.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import {BosonTypes} from "../../domain/BosonTypes.sol";
-import {IBosonAccountEvents} from "../events/IBosonAccountEvents.sol";
-import {IBosonGroupEvents} from "../events/IBosonGroupEvents.sol";
-import {IBosonOfferEvents} from "../events/IBosonOfferEvents.sol";
-import {IBosonTwinEvents} from "../events/IBosonTwinEvents.sol";
-import {IBosonBundleEvents} from "../events/IBosonBundleEvents.sol";
+import { BosonTypes } from "../../domain/BosonTypes.sol";
+import { IBosonAccountEvents } from "../events/IBosonAccountEvents.sol";
+import { IBosonGroupEvents } from "../events/IBosonGroupEvents.sol";
+import { IBosonOfferEvents } from "../events/IBosonOfferEvents.sol";
+import { IBosonTwinEvents } from "../events/IBosonTwinEvents.sol";
+import { IBosonBundleEvents } from "../events/IBosonBundleEvents.sol";
 
 /**
  * @title IBosonOrchestrationHandler
@@ -15,7 +15,13 @@ import {IBosonBundleEvents} from "../events/IBosonBundleEvents.sol";
  *
  * The ERC-165 identifier for this interface is: 0x7e9447cc
  */
-interface IBosonOrchestrationHandler is IBosonAccountEvents, IBosonGroupEvents, IBosonOfferEvents, IBosonTwinEvents, IBosonBundleEvents {
+interface IBosonOrchestrationHandler is
+    IBosonAccountEvents,
+    IBosonGroupEvents,
+    IBosonOfferEvents,
+    IBosonTwinEvents,
+    IBosonBundleEvents
+{
     /**
      * @notice Creates a seller and an offer in a single transaction.
      *
@@ -46,7 +52,12 @@ interface IBosonOrchestrationHandler is IBosonAccountEvents, IBosonGroupEvents, 
      * @param _offerDates - the fully populated offer dates struct
      * @param _offerDurations - the fully populated offer durations struct
      */
-    function createSellerAndOffer(BosonTypes.Seller calldata _seller, BosonTypes.Offer memory _offer, BosonTypes.OfferDates calldata _offerDates, BosonTypes.OfferDurations calldata _offerDurations) external;
+    function createSellerAndOffer(
+        BosonTypes.Seller calldata _seller,
+        BosonTypes.Offer memory _offer,
+        BosonTypes.OfferDates calldata _offerDates,
+        BosonTypes.OfferDurations calldata _offerDurations
+    ) external;
 
     /**
      * @notice Takes an offer and a condition, creates an offer, then a group with that offer and the given condition.
@@ -77,12 +88,12 @@ interface IBosonOrchestrationHandler is IBosonAccountEvents, IBosonGroupEvents, 
      */
     function createOfferWithCondition(
         BosonTypes.Offer memory _offer,
-        BosonTypes.OfferDates calldata _offerDates, BosonTypes.OfferDurations calldata _offerDurations,
+        BosonTypes.OfferDates calldata _offerDates,
+        BosonTypes.OfferDurations calldata _offerDurations,
         BosonTypes.Condition memory _condition
-    )
-    external;
+    ) external;
 
-     /**
+    /**
      * @notice Takes an offer and group ID, creates an offer and adds it to the existing group with given id
      *
      * Emits an OfferCreated and a GroupUpdated event if successful.
@@ -113,10 +124,10 @@ s    *   - Buyer cancel penalty is greater than price
      */
     function createOfferAddToGroup(
         BosonTypes.Offer memory _offer,
-        BosonTypes.OfferDates calldata _offerDates, BosonTypes.OfferDurations calldata _offerDurations,
+        BosonTypes.OfferDates calldata _offerDates,
+        BosonTypes.OfferDurations calldata _offerDurations,
         uint256 _groupId
-    )
-    external;
+    ) external;
 
     /**
      * @notice Takes an offer and a twin, creates an offer, creates a twin, then a bundle with that offer and the given twin
@@ -148,10 +159,10 @@ s    *   - Buyer cancel penalty is greater than price
      */
     function createOfferAndTwinWithBundle(
         BosonTypes.Offer memory _offer,
-        BosonTypes.OfferDates calldata _offerDates, BosonTypes.OfferDurations calldata _offerDurations,
+        BosonTypes.OfferDates calldata _offerDates,
+        BosonTypes.OfferDurations calldata _offerDurations,
         BosonTypes.Twin memory _twin
-    )
-    external;
+    ) external;
 
     /**
      * @notice Takes an offer, a condition and a twin, creates an offer, then a group with that offer and the given condition, then creates a twin, then a bundle with that offer and the given twin
@@ -185,11 +196,11 @@ s    *   - Buyer cancel penalty is greater than price
      */
     function createOfferWithConditionAndTwinAndBundle(
         BosonTypes.Offer memory _offer,
-        BosonTypes.OfferDates calldata _offerDates, BosonTypes.OfferDurations calldata _offerDurations,
+        BosonTypes.OfferDates calldata _offerDates,
+        BosonTypes.OfferDurations calldata _offerDurations,
         BosonTypes.Condition memory _condition,
         BosonTypes.Twin memory _twin
-    )
-    external;
+    ) external;
 
     /**
      * @notice Takes a seller, an offer and a condition, creates a seller, creates an offer, then a group with that offer and the given condition.
@@ -227,10 +238,10 @@ s    *   - Buyer cancel penalty is greater than price
     function createSellerAndOfferWithCondition(
         BosonTypes.Seller memory _seller,
         BosonTypes.Offer memory _offer,
-        BosonTypes.OfferDates calldata _offerDates, BosonTypes.OfferDurations calldata _offerDurations,
+        BosonTypes.OfferDates calldata _offerDates,
+        BosonTypes.OfferDurations calldata _offerDurations,
         BosonTypes.Condition memory _condition
-    )
-    external;
+    ) external;
 
     /**
      * @notice Takes a seller, an offer and a twin, creates a seller, creates an offer, creates a twin, then a bundle with that offer and the given twin
@@ -269,10 +280,10 @@ s    *   - Buyer cancel penalty is greater than price
     function createSellerAndOfferAndTwinWithBundle(
         BosonTypes.Seller memory _seller,
         BosonTypes.Offer memory _offer,
-        BosonTypes.OfferDates calldata _offerDates, BosonTypes.OfferDurations calldata _offerDurations,
+        BosonTypes.OfferDates calldata _offerDates,
+        BosonTypes.OfferDurations calldata _offerDurations,
         BosonTypes.Twin memory _twin
-    )
-    external;
+    ) external;
 
     /**
      * @notice Takes a seller, an offer, a condition and a twin, creates a sellerm an offer, then a group with that offer and the given condition, then creates a twin, then a bundle with that offer and the given twin
@@ -313,9 +324,9 @@ s    *   - Buyer cancel penalty is greater than price
     function createSellerAndOfferWithConditionAndTwinAndBundle(
         BosonTypes.Seller memory _seller,
         BosonTypes.Offer memory _offer,
-        BosonTypes.OfferDates calldata _offerDates, BosonTypes.OfferDurations calldata _offerDurations,
+        BosonTypes.OfferDates calldata _offerDates,
+        BosonTypes.OfferDurations calldata _offerDurations,
         BosonTypes.Condition memory _condition,
         BosonTypes.Twin memory _twin
-    )
-    external;
+    ) external;
 }

--- a/contracts/interfaces/handlers/IBosonTwinHandler.sol
+++ b/contracts/interfaces/handlers/IBosonTwinHandler.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import {BosonTypes} from "../../domain/BosonTypes.sol";
-import {IBosonTwinEvents} from "../events/IBosonTwinEvents.sol";
+import { BosonTypes } from "../../domain/BosonTypes.sol";
+import { IBosonTwinEvents } from "../events/IBosonTwinEvents.sol";
 
 /**
  * @title IBosonTwinHandler
@@ -12,7 +12,6 @@ import {IBosonTwinEvents} from "../events/IBosonTwinEvents.sol";
  * The ERC-165 identifier for this interface is: 0x44f98e5d
  */
 interface IBosonTwinHandler is IBosonTwinEvents {
-
     /**
      * @notice Creates a Twin
      *
@@ -43,7 +42,6 @@ interface IBosonTwinHandler is IBosonTwinEvents {
      * @return nextTwinId - the next twin id
      */
     function getNextTwinId() external view returns (uint256 nextTwinId);
-
 
     /**
      * @notice Removes the twin.

--- a/contracts/protocol/bases/AccountBase.sol
+++ b/contracts/protocol/bases/AccountBase.sol
@@ -45,7 +45,7 @@ contract AccountBase is ProtocolBase, IBosonAccountEvents {
         emit SellerCreated(sellerId, _seller, msgSender());
     }
 
-       /**
+    /**
      * @notice Creates a Buyer
      *
      * Emits an BuyerCreated event if successful.
@@ -57,9 +57,7 @@ contract AccountBase is ProtocolBase, IBosonAccountEvents {
      *
      * @param _buyer - the fully populated struct with buyer id set to 0x0
      */
-    function createBuyerInternal(Buyer memory _buyer) 
-    internal
-    {
+    function createBuyerInternal(Buyer memory _buyer) internal {
         //Check for zero address
         require(_buyer.wallet != address(0), INVALID_ADDRESS);
 
@@ -84,10 +82,9 @@ contract AccountBase is ProtocolBase, IBosonAccountEvents {
      *
      * @param _buyer - the fully populated struct with buyer id set
      */
-    function storeBuyer(Buyer memory _buyer) internal 
-    {
+    function storeBuyer(Buyer memory _buyer) internal {
         // Get storage location for buyer
-        (,Buyer storage buyer) = fetchBuyer(_buyer.id);
+        (, Buyer storage buyer) = fetchBuyer(_buyer.id);
 
         // Set buyer props individually since memory structs can't be copied to storage
         buyer.id = _buyer.id;

--- a/contracts/protocol/bases/BundleBase.sol
+++ b/contracts/protocol/bases/BundleBase.sol
@@ -43,7 +43,7 @@ contract BundleBase is ProtocolBase, IBosonBundleEvents {
         // Get the next bundle and increment the counter
         uint256 bundleId = protocolCounters().nextBundleId++;
 
-        for (uint i = 0; i < _bundle.offerIds.length; i++) {
+        for (uint256 i = 0; i < _bundle.offerIds.length; i++) {
             // make sure all offers exist and belong to the seller
             getValidOffer(_bundle.offerIds[i]);
 
@@ -58,14 +58,14 @@ contract BundleBase is ProtocolBase, IBosonBundleEvents {
             protocolLookups().bundleIdByOffer[_bundle.offerIds[i]] = bundleId;
         }
 
-        for (uint i = 0; i < _bundle.twinIds.length; i++) {
+        for (uint256 i = 0; i < _bundle.twinIds.length; i++) {
             // make sure all twins exist and belong to the seller
             getValidTwin(_bundle.twinIds[i]);
 
             // A twin can belong to multiple bundles
             (bool bundlesForTwinExist, uint256[] memory bundleIds) = fetchBundleIdsByTwin(_bundle.twinIds[i]);
             if (bundlesForTwinExist) {
-                for (uint j = 0; j < bundleIds.length; j++) {
+                for (uint256 j = 0; j < bundleIds.length; j++) {
                     require((bundleIds[j] != bundleId), TWIN_ALREADY_EXISTS_IN_SAME_BUNDLE);
                 }
             }

--- a/contracts/protocol/bases/ClientBase.sol
+++ b/contracts/protocol/bases/ClientBase.sol
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import {IBosonOfferHandler} from "../../interfaces/handlers/IBosonOfferHandler.sol";
-import {IBosonExchangeHandler} from "../../interfaces/handlers/IBosonExchangeHandler.sol";
-import {BosonConstants} from "../../domain/BosonConstants.sol";
-import {BosonTypes} from "../../domain/BosonTypes.sol";
-import {ClientLib} from "../libs/ClientLib.sol";
-
+import { IBosonOfferHandler } from "../../interfaces/handlers/IBosonOfferHandler.sol";
+import { IBosonExchangeHandler } from "../../interfaces/handlers/IBosonExchangeHandler.sol";
+import { BosonConstants } from "../../domain/BosonConstants.sol";
+import { BosonTypes } from "../../domain/BosonTypes.sol";
+import { ClientLib } from "../libs/ClientLib.sol";
 
 /**
  * @title ClientBase
@@ -17,7 +16,6 @@ import {ClientLib} from "../libs/ClientLib.sol";
  * Boson client contracts include BosonVoucher
  */
 abstract contract ClientBase is BosonTypes, BosonConstants {
-
     /**
      * @dev Modifier that checks that the caller has a specific role.
      *
@@ -38,11 +36,7 @@ abstract contract ClientBase is BosonTypes, BosonConstants {
      * @return exists - the offer was found
      * @return offer - the offer associated with the _offerId
      */
-    function getBosonOffer(uint256 _exchangeId)
-    internal
-    view
-    returns (bool exists, Offer memory offer)
-    {
+    function getBosonOffer(uint256 _exchangeId) internal view returns (bool exists, Offer memory offer) {
         ClientLib.ProxyStorage memory ps = ClientLib.proxyStorage();
         (, Exchange memory exchange) = IBosonExchangeHandler(ps.protocolDiamond).getExchange(_exchangeId);
         (exists, offer, , ) = IBosonOfferHandler(ps.protocolDiamond).getOffer(exchange.offerId);
@@ -54,11 +48,8 @@ abstract contract ClientBase is BosonTypes, BosonConstants {
      * @param _exchangeId - the id of the exchange
      * @param _newBuyer - the address of the new buyer
      */
-    function onVoucherTransferred(uint256 _exchangeId, address payable _newBuyer)
-    internal
-    {
+    function onVoucherTransferred(uint256 _exchangeId, address payable _newBuyer) internal {
         ClientLib.ProxyStorage memory ps = ClientLib.proxyStorage();
         IBosonExchangeHandler(ps.protocolDiamond).onVoucherTransferred(_exchangeId, _newBuyer);
     }
-
 }

--- a/contracts/protocol/bases/GroupBase.sol
+++ b/contracts/protocol/bases/GroupBase.sol
@@ -17,7 +17,7 @@ contract GroupBase is ProtocolBase, IBosonGroupEvents {
      * Emits a GroupCreated event if successful.
      *
      * Reverts if:
-     * 
+     *
      * - Caller is not an operator
      * - any of offers belongs to different seller
      * - any of offers does not exist
@@ -26,28 +26,24 @@ contract GroupBase is ProtocolBase, IBosonGroupEvents {
      *
      * @param _group - the fully populated struct with group id set to 0x0
      */
-    function createGroupInternal(
-        Group memory _group
-    )
-    internal
-    {
+    function createGroupInternal(Group memory _group) internal {
         // get seller id, make sure it exists and store it to incoming struct
         (bool exists, uint256 sellerId) = getSellerIdByOperator(msgSender());
         require(exists, NOT_OPERATOR);
-        
+
         // limit maximum number of offers to avoid running into block gas limit in a loop
         require(_group.offerIds.length <= protocolLimits().maxOffersPerGroup, TOO_MANY_OFFERS);
-        
+
         // condition must be valid
         require(validateCondition(_group.condition), INVALID_CONDITION_PARAMETERS);
 
         // Get the next group and increment the counter
         uint256 groupId = protocolCounters().nextGroupId++;
 
-        for (uint i = 0; i < _group.offerIds.length; i++) {
+        for (uint256 i = 0; i < _group.offerIds.length; i++) {
             // make sure offer exists and belongs to the seller
             getValidOffer(_group.offerIds[i]);
-            
+
             // Offer should not belong to another group already
             (bool exist, ) = getGroupIdByOffer(_group.offerIds[i]);
             require(!exist, OFFER_MUST_BE_UNIQUE);
@@ -55,7 +51,7 @@ contract GroupBase is ProtocolBase, IBosonGroupEvents {
             // add to groupIdByOffer mapping
             protocolLookups().groupIdByOffer[_group.offerIds[i]] = groupId;
         }
-       
+
         // Get storage location for group
         (, Group storage group) = fetchGroup(groupId);
 
@@ -67,12 +63,11 @@ contract GroupBase is ProtocolBase, IBosonGroupEvents {
 
         // Notify watchers of state change
         emit GroupCreated(groupId, sellerId, _group, msgSender());
-
     }
 
     /**
      * @dev this might change, depending on how checks at the time of the commit will be implemented
-     * @notice Validates that condition parameters make sense 
+     * @notice Validates that condition parameters make sense
      *
      * Reverts if:
      * - EvaluationMethod.None and has fields different from 0
@@ -81,28 +76,18 @@ contract GroupBase is ProtocolBase, IBosonGroupEvents {
      *
      * @param _condition - fully populated condition struct
      * @return valid - validity of condition
-     * 
+     *
      */
     function validateCondition(Condition memory _condition) internal pure returns (bool valid) {
         if (_condition.method == EvaluationMethod.None) {
-            valid  = (
-                _condition.tokenAddress == address(0) &&
+            valid = (_condition.tokenAddress == address(0) &&
                 _condition.tokenId == 0 &&
                 _condition.threshold == 0 &&
-                _condition.maxCommits == 0
-            );
-        } else if (_condition.method ==  EvaluationMethod.Threshold) {
-            valid = (
-                _condition.tokenAddress != address(0) &&
-                _condition.maxCommits > 0 &&
-                _condition.threshold > 0
-            );
-        } else if (_condition.method ==  EvaluationMethod.SpecificToken) {
-            valid = (
-                _condition.tokenAddress != address(0) &&
-                _condition.threshold == 0 &&
-                _condition.maxCommits > 0
-            );
+                _condition.maxCommits == 0);
+        } else if (_condition.method == EvaluationMethod.Threshold) {
+            valid = (_condition.tokenAddress != address(0) && _condition.maxCommits > 0 && _condition.threshold > 0);
+        } else if (_condition.method == EvaluationMethod.SpecificToken) {
+            valid = (_condition.tokenAddress != address(0) && _condition.threshold == 0 && _condition.maxCommits > 0);
         }
     }
 
@@ -112,7 +97,7 @@ contract GroupBase is ProtocolBase, IBosonGroupEvents {
      * Emits a GroupUpdated event if successful.
      *
      * Reverts if:
-     * 
+     *
      * - caller is not the seller
      * - offer ids is an empty list
      * - number of offers exceeds maximum allowed number per group
@@ -120,25 +105,20 @@ contract GroupBase is ProtocolBase, IBosonGroupEvents {
      * - any of offers belongs to different seller
      * - any of offers does not exist
      * - offer exists in a different group
-     * - offer ids contains duplicated offers 
+     * - offer ids contains duplicated offers
      *
      * @param _groupId  - the id of the group to be updated
      * @param _offerIds - array of offer ids to be added to the group
      */
-    function addOffersToGroupInternal(
-        uint256 _groupId,
-        uint256[] memory _offerIds
-    )
-    internal
-    {
+    function addOffersToGroupInternal(uint256 _groupId, uint256[] memory _offerIds) internal {
         // check if group can be updated
         (uint256 sellerId, Group storage group) = preUpdateChecks(_groupId, _offerIds);
 
-        for (uint i = 0; i < _offerIds.length; i++) {
-            uint offerId = _offerIds[i];
+        for (uint256 i = 0; i < _offerIds.length; i++) {
+            uint256 offerId = _offerIds[i];
             // make sure offer exist and belong to the seller
             getValidOffer(offerId);
-            
+
             // Offer should not belong to another group already
             (bool exist, ) = getGroupIdByOffer(offerId);
             require(!exist, OFFER_MUST_BE_UNIQUE);
@@ -149,17 +129,17 @@ contract GroupBase is ProtocolBase, IBosonGroupEvents {
             // add to group struct
             group.offerIds.push(offerId);
         }
-             
+
         // Notify watchers of state change
         emit GroupUpdated(_groupId, sellerId, group, msgSender());
     }
 
     /**
-     * @dev Before performing an update, make sure update can be done 
-     * and return seller id and group storage pointer for further use 
+     * @dev Before performing an update, make sure update can be done
+     * and return seller id and group storage pointer for further use
      *
      * Reverts if:
-     * 
+     *
      * - caller is not the seller
      * - offer ids is an empty list
      * - number of offers exceeds maximum allowed number per group
@@ -170,7 +150,11 @@ contract GroupBase is ProtocolBase, IBosonGroupEvents {
      * @return sellerId  - the seller Id
      * @return group - the group details
      */
-    function preUpdateChecks(uint256 _groupId, uint256[] memory _offerIds) internal view returns (uint256 sellerId, Group storage group) {
+    function preUpdateChecks(uint256 _groupId, uint256[] memory _offerIds)
+        internal
+        view
+        returns (uint256 sellerId, Group storage group)
+    {
         // make sure that at least something will be updated
         require(_offerIds.length != 0, NOTHING_UPDATED);
 

--- a/contracts/protocol/bases/OfferBase.sol
+++ b/contracts/protocol/bases/OfferBase.sol
@@ -35,7 +35,11 @@ contract OfferBase is ProtocolBase, IBosonOfferEvents {
      * @param _offerDates - the fully populated offer dates struct
      * @param _offerDurations - the fully populated offer durations struct
      */
-    function createOfferInternal(Offer memory _offer, OfferDates calldata _offerDates, OfferDurations calldata _offerDurations) internal {
+    function createOfferInternal(
+        Offer memory _offer,
+        OfferDates calldata _offerDates,
+        OfferDurations calldata _offerDurations
+    ) internal {
         // get seller id, make sure it exists and store it to incoming struct
         (bool exists, uint256 sellerId) = getSellerIdByOperator(msgSender());
         require(exists, NOT_OPERATOR);
@@ -57,15 +61,15 @@ contract OfferBase is ProtocolBase, IBosonOfferEvents {
      *
      * @dev Rationale for the checks that are not obvious.
      * 1. voucher expiration date is either
-     *   -  _offerDates.voucherRedeemableUntil  [fixed voucher expiration date] 
+     *   -  _offerDates.voucherRedeemableUntil  [fixed voucher expiration date]
      *   - max([commitment time], _offerDates.voucherRedeemableFrom) + offerDurations.voucherValid [fixed voucher expiration duration]
      * This is calculated during the commitToOffer. To avoid any ambiguity, we make sure that exactly one of _offerDates.voucherRedeemableUntil
      * and offerDurations.voucherValid is defined.
-     * 2. Checks that include _offer.sellerDeposit, protocolFee, offer.buyerCancelPenalty and _offer.price  
+     * 2. Checks that include _offer.sellerDeposit, protocolFee, offer.buyerCancelPenalty and _offer.price
      * Exchange can have one of multiple final states and different states have different seller and buyer payoffs. If offer parameters are
      * not set appropriately, it's possible for some payoffs to become negative or unfair to some participant. By making the checks at the time
      * of the offer creation we ensure that all payoffs are possible and fair.
-     * 
+     *
      *
      * Reverts if:
      * - Valid from date is greater than valid until date
@@ -85,7 +89,11 @@ contract OfferBase is ProtocolBase, IBosonOfferEvents {
      * @param _offerDates - the fully populated offer dates struct
      * @param _offerDurations - the fully populated offer durations struct
      */
-    function storeOffer(Offer memory _offer, OfferDates calldata _offerDates, OfferDurations calldata _offerDurations) internal {
+    function storeOffer(
+        Offer memory _offer,
+        OfferDates calldata _offerDates,
+        OfferDurations calldata _offerDurations
+    ) internal {
         // validFrom date must be less than validUntil date
         require(_offerDates.validFrom < _offerDates.validUntil, OFFER_PERIOD_INVALID);
 
@@ -116,15 +124,16 @@ contract OfferBase is ProtocolBase, IBosonOfferEvents {
 
         // specified resolver must be registered, except for absolute zero offers with unspecified dispute resolver
         if (_offer.price != 0 || _offer.sellerDeposit != 0 || _offer.disputeResolverId != 0) {
-            (bool exists,,) = fetchDisputeResolver(_offer.disputeResolverId);
+            (bool exists, , ) = fetchDisputeResolver(_offer.disputeResolverId);
             require(exists, INVALID_DISPUTE_RESOLVER);
         }
 
         // Calculate and set the protocol fee
-        uint256 protocolFee = _offer.exchangeToken == protocolAddresses().tokenAddress ? 
-            protocolFees().flatBoson : protocolFees().percentage*_offer.price/10000;
+        uint256 protocolFee = _offer.exchangeToken == protocolAddresses().tokenAddress
+            ? protocolFees().flatBoson
+            : (protocolFees().percentage * _offer.price) / 10000;
         _offer.protocolFee = protocolFee;
-        
+
         // condition for succesfull payout when exchange final state is canceled
         require(_offer.buyerCancelPenalty <= _offer.price, OFFER_PENALTY_INVALID);
 

--- a/contracts/protocol/bases/ProtocolBase.sol
+++ b/contracts/protocol/bases/ProtocolBase.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import {ProtocolLib} from "../libs/ProtocolLib.sol";
-import {DiamondLib} from "../../diamond/DiamondLib.sol";
-import {BosonTypes} from "../../domain/BosonTypes.sol";
-import {BosonConstants} from "../../domain/BosonConstants.sol";
-import {EIP712Lib} from "../libs/EIP712Lib.sol";
+import { ProtocolLib } from "../libs/ProtocolLib.sol";
+import { DiamondLib } from "../../diamond/DiamondLib.sol";
+import { BosonTypes } from "../../domain/BosonTypes.sol";
+import { BosonConstants } from "../../domain/BosonConstants.sol";
+import { EIP712Lib } from "../libs/EIP712Lib.sol";
 
 /**
  * @title ProtocolBase
@@ -83,7 +83,7 @@ abstract contract ProtocolBase is BosonTypes, BosonConstants {
         pl = ProtocolLib.protocolLookups();
     }
 
-     /**
+    /**
      * @dev Get the Protocol Fees slot
      *
      * @return pf the Protocol Fees slot
@@ -186,7 +186,11 @@ abstract contract ProtocolBase is BosonTypes, BosonConstants {
      * @return exists - whether the dispute resolver Id exists
      * @return disputeResolverId  - the dispute resolver  Id
      */
-    function getDisputeResolverIdByOperator(address _operator) internal view returns (bool exists, uint256 disputeResolverId) {
+    function getDisputeResolverIdByOperator(address _operator)
+        internal
+        view
+        returns (bool exists, uint256 disputeResolverId)
+    {
         // Get the dispute resolver Id
         disputeResolverId = protocolLookups().disputeResolverIdByOperator[_operator];
 
@@ -201,7 +205,11 @@ abstract contract ProtocolBase is BosonTypes, BosonConstants {
      * @return exists - whether the dispute resolver Id exists
      * @return disputeResolverId  - the dispute resolver Id
      */
-    function getDisputeResolverIdByAdmin(address _admin) internal view returns (bool exists, uint256 disputeResolverId) {
+    function getDisputeResolverIdByAdmin(address _admin)
+        internal
+        view
+        returns (bool exists, uint256 disputeResolverId)
+    {
         // Get the dispute resolver Id
         disputeResolverId = protocolLookups().disputeResolverIdByAdmin[_admin];
 
@@ -216,7 +224,11 @@ abstract contract ProtocolBase is BosonTypes, BosonConstants {
      * @return exists - whether the dispute resolver Id exists
      * @return disputeResolverId  - the dispute resolver Id
      */
-    function getDisputeResolverIdByClerk(address _clerk) internal view returns (bool exists, uint256 disputeResolverId) {
+    function getDisputeResolverIdByClerk(address _clerk)
+        internal
+        view
+        returns (bool exists, uint256 disputeResolverId)
+    {
         // Get the dispute resolver Id
         disputeResolverId = protocolLookups().disputeResolverIdByClerk[_clerk];
 
@@ -277,7 +289,15 @@ abstract contract ProtocolBase is BosonTypes, BosonConstants {
      * @return disputeResolver - the dispute resolver details. See {BosonTypes.DisputeResolver}
      * @return disputeResolverFees - list of fees dispute resolver charges per token type. Zero address is native currency. See {BosonTypes.DisputeResolverFee}
      */
-    function fetchDisputeResolver(uint256 _disputeResolverId) internal view returns (bool exists, BosonTypes.DisputeResolver storage disputeResolver, BosonTypes.DisputeResolverFee[] storage disputeResolverFees) {
+    function fetchDisputeResolver(uint256 _disputeResolverId)
+        internal
+        view
+        returns (
+            bool exists,
+            BosonTypes.DisputeResolver storage disputeResolver,
+            BosonTypes.DisputeResolverFee[] storage disputeResolverFees
+        )
+    {
         // Get the dispute resolver's slot
         disputeResolver = protocolEntities().disputeResolvers[_disputeResolverId];
 
@@ -320,7 +340,11 @@ abstract contract ProtocolBase is BosonTypes, BosonConstants {
      * @param _offerId - the id of the offer
      * @return offerDurations - the offer durations details. See {BosonTypes.OfferDurations}
      */
-    function fetchOfferDurations(uint256 _offerId) internal view returns (BosonTypes.OfferDurations storage offerDurations) {
+    function fetchOfferDurations(uint256 _offerId)
+        internal
+        view
+        returns (BosonTypes.OfferDurations storage offerDurations)
+    {
         // Get the offer's slot
         offerDurations = protocolEntities().offerDurations[_offerId];
     }
@@ -347,11 +371,7 @@ abstract contract ProtocolBase is BosonTypes, BosonConstants {
      * @return exists - whether the exchange exists
      * @return exchange - the exchange details. See {BosonTypes.Exchange}
      */
-    function fetchExchange(uint256 _exchangeId)
-        internal
-        view
-        returns (bool exists, Exchange storage exchange)
-    {
+    function fetchExchange(uint256 _exchangeId) internal view returns (bool exists, Exchange storage exchange) {
         // Get the exchange's slot
         exchange = protocolEntities().exchanges[_exchangeId];
 
@@ -367,9 +387,13 @@ abstract contract ProtocolBase is BosonTypes, BosonConstants {
      * @return dispute - the dispute details. See {BosonTypes.Dispute}
      */
     function fetchDispute(uint256 _exchangeId)
-    internal
-    view
-    returns (bool exists, Dispute storage dispute, DisputeDates storage disputeDates)
+        internal
+        view
+        returns (
+            bool exists,
+            Dispute storage dispute,
+            DisputeDates storage disputeDates
+        )
     {
         // Get the dispute's slot
         dispute = protocolEntities().disputes[_exchangeId];
@@ -379,7 +403,6 @@ abstract contract ProtocolBase is BosonTypes, BosonConstants {
 
         // Determine existence
         exists = (_exchangeId > 0 && dispute.exchangeId == _exchangeId);
-    
     }
 
     /**
@@ -392,7 +415,7 @@ abstract contract ProtocolBase is BosonTypes, BosonConstants {
     function fetchTwin(uint256 _twinId) internal view returns (bool exists, Twin storage twin) {
         // Get the twin's slot
         twin = protocolEntities().twins[_twinId];
- 
+
         // Determine existence
         exists = (_twinId > 0 && twin.id == _twinId);
     }
@@ -495,10 +518,7 @@ abstract contract ProtocolBase is BosonTypes, BosonConstants {
      *
      * @param _currentBuyer - id of current buyer associated with the exchange
      */
-    function checkBuyer(uint256 _currentBuyer)
-    internal
-    view
-    {
+    function checkBuyer(uint256 _currentBuyer) internal view {
         // Get the caller's buyer account id
         uint256 buyerId;
         (, buyerId) = getBuyerIdByWallet(msgSender());
@@ -519,9 +539,9 @@ abstract contract ProtocolBase is BosonTypes, BosonConstants {
      * @return exchange - the exchange
      */
     function getValidExchange(uint256 _exchangeId, ExchangeState _expectedState)
-    internal
-    view
-    returns(Exchange storage exchange)
+        internal
+        view
+        returns (Exchange storage exchange)
     {
         // Get the exchange
         bool exchangeExists;

--- a/contracts/protocol/bases/TwinBase.sol
+++ b/contracts/protocol/bases/TwinBase.sol
@@ -12,7 +12,6 @@ import { ProtocolLib } from "./../libs/ProtocolLib.sol";
  * @dev Provides methods for twin creation that can be shared accross facets
  */
 contract TwinBase is ProtocolBase, IBosonTwinEvents {
-
     /**
      * @notice Creates a Twin.
      *
@@ -24,11 +23,7 @@ contract TwinBase is ProtocolBase, IBosonTwinEvents {
      *
      * @param _twin - the fully populated struct with twin id set to 0x0
      */
-    function createTwinInternal(
-        Twin memory _twin
-    )
-    internal
-    {
+    function createTwinInternal(Twin memory _twin) internal {
         // get seller id, make sure it exists and store it to incoming struct
         (bool exists, uint256 sellerId) = getSellerIdByOperator(msgSender());
         require(exists, NOT_OPERATOR);
@@ -36,7 +31,7 @@ contract TwinBase is ProtocolBase, IBosonTwinEvents {
         // Protocol must be approved to transfer seller’s tokens
         require(isProtocolApproved(_twin.tokenAddress, msgSender(), address(this)), NO_TRANSFER_APPROVED);
 
-        if(_twin.tokenType == TokenType.NonFungibleToken) {
+        if (_twin.tokenType == TokenType.NonFungibleToken) {
             require(_twin.lastTokenId >= _twin.tokenId, ERC721_INVALID_RANGE);
         }
 
@@ -71,14 +66,13 @@ contract TwinBase is ProtocolBase, IBosonTwinEvents {
         address _tokenAddress,
         address _operator,
         address _protocol
-    ) internal view returns (bool _approved){
+    ) internal view returns (bool _approved) {
         require(_tokenAddress != address(0), UNSUPPORTED_TOKEN);
 
-        try ITwinToken(_tokenAddress).allowance(
-            _operator,
-            _protocol
-        ) returns(uint256 _allowance) {
-            if (_allowance > 0) {_approved = true; }
+        try ITwinToken(_tokenAddress).allowance(_operator, _protocol) returns (uint256 _allowance) {
+            if (_allowance > 0) {
+                _approved = true;
+            }
         } catch {
             try ITwinToken(_tokenAddress).isApprovedForAll(_operator, _protocol) returns (bool _isApproved) {
                 _approved = _isApproved;
@@ -87,5 +81,4 @@ contract TwinBase is ProtocolBase, IBosonTwinEvents {
             }
         }
     }
-
 }

--- a/contracts/protocol/clients/proxy/ClientProxy.sol
+++ b/contracts/protocol/clients/proxy/ClientProxy.sol
@@ -24,7 +24,6 @@ import { Proxy } from "./Proxy.sol";
  * future upgradability.
  */
 contract ClientProxy is IBosonClient, BosonConstants, Proxy {
-
     /**
      * @dev Modifier that checks that the caller has a specific role.
      *
@@ -42,7 +41,6 @@ contract ClientProxy is IBosonClient, BosonConstants, Proxy {
         address _protocolAddress,
         address _impl
     ) payable {
-
         // Get the ProxyStorage struct
         ClientLib.ProxyStorage storage ps = ClientLib.proxyStorage();
 
@@ -54,35 +52,24 @@ contract ClientProxy is IBosonClient, BosonConstants, Proxy {
 
         // Store the implementation address
         ps.implementation = _impl;
-
     }
 
     /**
      * @dev Returns the address to which the fallback function
      * and {_fallback} should delegate.
      */
-    function _implementation()
-    internal
-    view
-    override
-    returns (address) {
-
+    function _implementation() internal view override returns (address) {
         // Get the ProxyStorage struct
         ClientLib.ProxyStorage storage ps = ClientLib.proxyStorage();
 
         // Return the current implementation address
         return ps.implementation;
-
     }
 
     /**
      * @dev Set the implementation address
      */
-    function setImplementation(address _impl)
-    external
-    onlyRole(UPGRADER)
-    override
-    {
+    function setImplementation(address _impl) external override onlyRole(UPGRADER) {
         // Get the ProxyStorage struct
         ClientLib.ProxyStorage storage ps = ClientLib.proxyStorage();
 
@@ -91,17 +78,12 @@ contract ClientProxy is IBosonClient, BosonConstants, Proxy {
 
         // Notify watchers of state change
         emit Upgraded(_impl, EIP712Lib.msgSender());
-
     }
 
     /**
      * @dev Get the implementation address
      */
-    function getImplementation()
-    external
-    view
-    override
-    returns (address) {
+    function getImplementation() external view override returns (address) {
         return _implementation();
     }
 
@@ -112,11 +94,7 @@ contract ClientProxy is IBosonClient, BosonConstants, Proxy {
      *
      * @param _accessController - the Boson Protocol AccessController address
      */
-    function setAccessController(address _accessController)
-    external
-    onlyRole(UPGRADER)
-    override
-    {
+    function setAccessController(address _accessController) external override onlyRole(UPGRADER) {
         // Get the ProxyStorage struct
         ClientLib.ProxyStorage storage ps = ClientLib.proxyStorage();
 
@@ -132,12 +110,7 @@ contract ClientProxy is IBosonClient, BosonConstants, Proxy {
      *
      * @return the address of the AccessController contract
      */
-    function getAccessController()
-    public
-    view
-    override
-    returns(IAccessControlUpgradeable)
-    {
+    function getAccessController() public view override returns (IAccessControlUpgradeable) {
         // Get the ProxyStorage struct
         ClientLib.ProxyStorage storage ps = ClientLib.proxyStorage();
 
@@ -152,11 +125,7 @@ contract ClientProxy is IBosonClient, BosonConstants, Proxy {
      *
      * @param _protocolAddress - the ProtocolDiamond address
      */
-    function setProtocolAddress(address _protocolAddress)
-    external
-    onlyRole(UPGRADER)
-    override
-    {
+    function setProtocolAddress(address _protocolAddress) external override onlyRole(UPGRADER) {
         // Get the ProxyStorage struct
         ClientLib.ProxyStorage storage ps = ClientLib.proxyStorage();
 
@@ -172,17 +141,11 @@ contract ClientProxy is IBosonClient, BosonConstants, Proxy {
      *
      * @return the address of the ProtocolDiamond contract
      */
-    function getProtocolAddress()
-    public
-    override
-    view
-    returns(address)
-    {
+    function getProtocolAddress() public view override returns (address) {
         // Get the ProxyStorage struct
         ClientLib.ProxyStorage storage ps = ClientLib.proxyStorage();
 
         // Return the current ProtocolDiamond address
         return ps.protocolDiamond;
     }
-
 }

--- a/contracts/protocol/clients/voucher/BosonVoucher.sol
+++ b/contracts/protocol/clients/voucher/BosonVoucher.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import {ERC721Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
-import {IERC165Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
+import { ERC721Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
+import { IERC165Upgradeable } from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
 
-import {IBosonVoucher} from "../../../interfaces/clients/IBosonVoucher.sol";
-import {IBosonClient} from "../../../interfaces/clients/IBosonClient.sol";
-import {ClientBase} from "../../bases/ClientBase.sol";
+import { IBosonVoucher } from "../../../interfaces/clients/IBosonVoucher.sol";
+import { IBosonClient } from "../../../interfaces/clients/IBosonClient.sol";
+import { ClientBase } from "../../bases/ClientBase.sol";
 
 /**
  * @title BosonVoucher
@@ -17,15 +17,13 @@ import {ClientBase} from "../../bases/ClientBase.sol";
  * - Newly minted voucher NFTs are automatically transferred to the buyer
  */
 contract BosonVoucher is IBosonVoucher, ClientBase, ERC721Upgradeable {
-
     string internal constant VOUCHER_NAME = "Boson Voucher";
     string internal constant VOUCHER_SYMBOL = "BOSON_VOUCHER";
 
     /**
      * @notice Initializer
      */
-    function initialize()
-    public {
+    function initialize() public {
         __ERC721_init_unchained(VOUCHER_NAME, VOUCHER_SYMBOL);
     }
 
@@ -38,11 +36,7 @@ contract BosonVoucher is IBosonVoucher, ClientBase, ERC721Upgradeable {
      * @param _exchangeId - the id of the exchange (corresponds to the ERC-721 token id)
      * @param _buyer - the buyer of the vouchers
      */
-    function issueVoucher(uint256 _exchangeId, Buyer calldata _buyer)
-    external
-    override
-    onlyRole(PROTOCOL)
-    {
+    function issueVoucher(uint256 _exchangeId, Buyer calldata _buyer) external override onlyRole(PROTOCOL) {
         // Mint the voucher, sending it to the buyer
         _mint(_buyer.wallet, _exchangeId);
     }
@@ -54,11 +48,7 @@ contract BosonVoucher is IBosonVoucher, ClientBase, ERC721Upgradeable {
      *
      * @param _exchangeId - the id of the exchange (corresponds to the ERC-721 token id)
      */
-    function burnVoucher(uint256 _exchangeId)
-    external
-    override
-    onlyRole(PROTOCOL)
-    {
+    function burnVoucher(uint256 _exchangeId) external override onlyRole(PROTOCOL) {
         _burn(_exchangeId);
     }
 
@@ -76,16 +66,14 @@ contract BosonVoucher is IBosonVoucher, ClientBase, ERC721Upgradeable {
      * to respond.
      */
     function supportsInterface(bytes4 interfaceId)
-    public
-    view
-    override(ERC721Upgradeable, IERC165Upgradeable)
-    returns (bool)
+        public
+        view
+        override(ERC721Upgradeable, IERC165Upgradeable)
+        returns (bool)
     {
-        return (
-            interfaceId == type(IBosonVoucher).interfaceId ||
+        return (interfaceId == type(IBosonVoucher).interfaceId ||
             interfaceId == type(IBosonClient).interfaceId ||
-            super.supportsInterface(interfaceId)
-        );
+            super.supportsInterface(interfaceId));
     }
 
     /**
@@ -99,12 +87,7 @@ contract BosonVoucher is IBosonVoucher, ClientBase, ERC721Upgradeable {
      * @param _exchangeId - id of the voucher's associated exchange
      * @return the uri for the associated offer's off-chain metadata (blank if not found)
      */
-    function tokenURI(uint256 _exchangeId)
-    public
-    view
-    override
-    returns (string memory)
-    {
+    function tokenURI(uint256 _exchangeId) public view override returns (string memory) {
         (bool exists, Offer memory offer) = getBosonOffer(_exchangeId);
         return exists ? offer.metadataUri : "";
     }
@@ -133,5 +116,4 @@ contract BosonVoucher is IBosonVoucher, ClientBase, ERC721Upgradeable {
             onVoucherTransferred(tokenId, payable(to));
         }
     }
-
 }

--- a/contracts/protocol/facets/ConfigHandlerFacet.sol
+++ b/contracts/protocol/facets/ConfigHandlerFacet.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import { IBosonConfigHandler } from  "../../interfaces/handlers/IBosonConfigHandler.sol";
-import { DiamondLib } from  "../../diamond/DiamondLib.sol";
-import { ProtocolBase } from  "../bases/ProtocolBase.sol";
-import { ProtocolLib } from  "../libs/ProtocolLib.sol";
+import { IBosonConfigHandler } from "../../interfaces/handlers/IBosonConfigHandler.sol";
+import { DiamondLib } from "../../diamond/DiamondLib.sol";
+import { ProtocolBase } from "../bases/ProtocolBase.sol";
+import { ProtocolLib } from "../libs/ProtocolLib.sol";
 import { EIP712Lib } from "../libs/EIP712Lib.sol";
 
 /**
@@ -13,7 +13,6 @@ import { EIP712Lib } from "../libs/EIP712Lib.sol";
  * @notice Handles management of various protocol-related settings.
  */
 contract ConfigHandlerFacet is IBosonConfigHandler, ProtocolBase {
-
     /**
      * @notice Facet Initializer
      *
@@ -25,10 +24,7 @@ contract ConfigHandlerFacet is IBosonConfigHandler, ProtocolBase {
         ProtocolLib.ProtocolAddresses calldata _addresses,
         ProtocolLib.ProtocolLimits calldata _limits,
         ProtocolLib.ProtocolFees calldata _fees
-    )
-    public
-    onlyUnInitialized(type(IBosonConfigHandler).interfaceId)
-    {
+    ) public onlyUnInitialized(type(IBosonConfigHandler).interfaceId) {
         // Register supported interfaces
         DiamondLib.addSupportedInterface(type(IBosonConfigHandler).interfaceId);
 
@@ -45,8 +41,8 @@ contract ConfigHandlerFacet is IBosonConfigHandler, ProtocolBase {
         setMaxTokensPerWithdrawal(_limits.maxTokensPerWithdrawal);
         setMaxFeesPerDisputeResolver(_limits.maxFeesPerDisputeResolver);
         setMaxEscalationResponsePeriod(_limits.maxEscalationResponsePeriod);
-        setMaxDisputesPerBatch(_limits.maxDisputesPerBatch);        
-        
+        setMaxDisputesPerBatch(_limits.maxDisputesPerBatch);
+
         // Initialize protocol counters
         ProtocolLib.ProtocolCounters storage pc = protocolCounters();
         pc.nextAccountId = 1;
@@ -68,11 +64,7 @@ contract ConfigHandlerFacet is IBosonConfigHandler, ProtocolBase {
      *
      * @param _tokenAddress - the address of the token contract
      */
-    function setTokenAddress(address payable _tokenAddress)
-    public
-    override
-    onlyRole(ADMIN)
-    {
+    function setTokenAddress(address payable _tokenAddress) public override onlyRole(ADMIN) {
         protocolAddresses().tokenAddress = _tokenAddress;
         emit TokenAddressChanged(_tokenAddress, msgSender());
     }
@@ -80,12 +72,7 @@ contract ConfigHandlerFacet is IBosonConfigHandler, ProtocolBase {
     /**
      * @notice The tokenAddress getter
      */
-    function getTokenAddress()
-    external
-    override
-    view
-    returns (address payable)
-    {
+    function getTokenAddress() external view override returns (address payable) {
         return protocolAddresses().tokenAddress;
     }
 
@@ -96,11 +83,7 @@ contract ConfigHandlerFacet is IBosonConfigHandler, ProtocolBase {
      *
      * @param _treasuryAddress - the address of the multi-sig wallet
      */
-    function setTreasuryAddress(address payable _treasuryAddress)
-    public
-    override
-    onlyRole(ADMIN)
-    {
+    function setTreasuryAddress(address payable _treasuryAddress) public override onlyRole(ADMIN) {
         protocolAddresses().treasuryAddress = _treasuryAddress;
         emit TreasuryAddressChanged(_treasuryAddress, msgSender());
     }
@@ -108,12 +91,7 @@ contract ConfigHandlerFacet is IBosonConfigHandler, ProtocolBase {
     /**
      * @notice The treasuryAddress getter
      */
-    function getTreasuryAddress()
-    external
-    override
-    view
-    returns (address payable)
-    {
+    function getTreasuryAddress() external view override returns (address payable) {
         return protocolAddresses().treasuryAddress;
     }
 
@@ -124,11 +102,7 @@ contract ConfigHandlerFacet is IBosonConfigHandler, ProtocolBase {
      *
      * @param _voucherAddress - the address of the nft contract (proxy)
      */
-    function setVoucherAddress(address _voucherAddress)
-    public
-    override
-    onlyRole(ADMIN)
-    {
+    function setVoucherAddress(address _voucherAddress) public override onlyRole(ADMIN) {
         protocolAddresses().voucherAddress = _voucherAddress;
         emit VoucherAddressChanged(_voucherAddress, msgSender());
     }
@@ -136,12 +110,7 @@ contract ConfigHandlerFacet is IBosonConfigHandler, ProtocolBase {
     /**
      * @notice The Boson Protocol Voucher NFT contract (proxy) getter
      */
-    function getVoucherAddress()
-    external
-    override
-    view
-    returns (address)
-    {
+    function getVoucherAddress() external view override returns (address) {
         return protocolAddresses().voucherAddress;
     }
 
@@ -157,14 +126,9 @@ contract ConfigHandlerFacet is IBosonConfigHandler, ProtocolBase {
      * N.B. Represent percentage value as an unsigned int by multiplying the percentage by 100:
      * e.g, 1.75% = 175, 100% = 10000
      */
-    function setProtocolFeePercentage(uint16 _protocolFeePercentage)
-    public
-    override
-    onlyRole(ADMIN)
-    {
+    function setProtocolFeePercentage(uint16 _protocolFeePercentage) public override onlyRole(ADMIN) {
         // Make sure percentage is less than 10000
-        require(_protocolFeePercentage <= 10000,
-            PROTOCOL_FEE_PERCENTAGE_INVALID);
+        require(_protocolFeePercentage <= 10000, PROTOCOL_FEE_PERCENTAGE_INVALID);
 
         // Store fee percentage
         protocolFees().percentage = _protocolFeePercentage;
@@ -176,17 +140,11 @@ contract ConfigHandlerFacet is IBosonConfigHandler, ProtocolBase {
     /**
      * @notice Get the protocol fee percentage
      */
-    function getProtocolFeePercentage()
-    external
-    override
-    view
-    returns (uint16)
-    {
+    function getProtocolFeePercentage() external view override returns (uint16) {
         return protocolFees().percentage;
     }
-    
 
-     /**
+    /**
      * @notice Sets the flat protocol fee for exchanges in $BOSON.
      *
      * Emits a ProtocolFeeFlatBosonChanged event.
@@ -194,11 +152,7 @@ contract ConfigHandlerFacet is IBosonConfigHandler, ProtocolBase {
      * @param _protocolFeeFlatBoson - Flat fee taken for exchanges in $BOSON
      *
      */
-    function setProtocolFeeFlatBoson(uint256 _protocolFeeFlatBoson)
-    public
-    override
-    onlyRole(ADMIN)
-    {
+    function setProtocolFeeFlatBoson(uint256 _protocolFeeFlatBoson) public override onlyRole(ADMIN) {
         // Store fee percentage
         protocolFees().flatBoson = _protocolFeeFlatBoson;
 
@@ -209,27 +163,18 @@ contract ConfigHandlerFacet is IBosonConfigHandler, ProtocolBase {
     /**
      * @notice Get the protocol fee percentage
      */
-    function getProtocolFeeFlatBoson()
-    external
-    override
-    view
-    returns (uint256)
-    {
+    function getProtocolFeeFlatBoson() external view override returns (uint256) {
         return protocolFees().flatBoson;
     }
 
-     /**
+    /**
      * @notice Sets the maximum numbers of offers that can be added to a group in a single transaction
      *
      * Emits a MaxOffersPerGroupChanged event.
      *
      * @param _maxOffersPerGroup - the maximum length of {BosonTypes.Group.offerIds}
      */
-    function setMaxOffersPerGroup(uint16 _maxOffersPerGroup)
-    public
-    override
-    onlyRole(ADMIN)
-    {
+    function setMaxOffersPerGroup(uint16 _maxOffersPerGroup) public override onlyRole(ADMIN) {
         protocolLimits().maxOffersPerGroup = _maxOffersPerGroup;
         emit MaxOffersPerGroupChanged(_maxOffersPerGroup, msgSender());
     }
@@ -237,27 +182,18 @@ contract ConfigHandlerFacet is IBosonConfigHandler, ProtocolBase {
     /**
      * @notice Get the maximum offers per group
      */
-    function getMaxOffersPerGroup()
-    external
-    override
-    view
-    returns (uint16)
-    {
+    function getMaxOffersPerGroup() external view override returns (uint16) {
         return protocolLimits().maxOffersPerGroup;
     }
 
-     /**
+    /**
      * @notice Sets the maximum numbers of twins that can be added to a bundle in a single transaction
      *
      * Emits a MaxTwinsPerBundleChanged event.
      *
      * @param _maxTwinsPerBundle - the maximum length of {BosonTypes.Bundle.twinIds}
      */
-    function setMaxTwinsPerBundle(uint16 _maxTwinsPerBundle)
-    public
-    override
-    onlyRole(ADMIN)
-    {
+    function setMaxTwinsPerBundle(uint16 _maxTwinsPerBundle) public override onlyRole(ADMIN) {
         protocolLimits().maxTwinsPerBundle = _maxTwinsPerBundle;
         emit MaxTwinsPerBundleChanged(_maxTwinsPerBundle, msgSender());
     }
@@ -265,12 +201,7 @@ contract ConfigHandlerFacet is IBosonConfigHandler, ProtocolBase {
     /**
      * @notice Get the maximum twins per bundle
      */
-    function getMaxTwinsPerBundle()
-    external
-    override
-    view
-    returns (uint16)
-    {
+    function getMaxTwinsPerBundle() external view override returns (uint16) {
         return protocolLimits().maxTwinsPerBundle;
     }
 
@@ -281,11 +212,7 @@ contract ConfigHandlerFacet is IBosonConfigHandler, ProtocolBase {
      *
      * @param _maxOffersPerBundle - the maximum length of {BosonTypes.Bundle.offerIds}
      */
-    function setMaxOffersPerBundle(uint16 _maxOffersPerBundle)
-    public
-    override
-    onlyRole(ADMIN)
-    {
+    function setMaxOffersPerBundle(uint16 _maxOffersPerBundle) public override onlyRole(ADMIN) {
         protocolLimits().maxOffersPerBundle = _maxOffersPerBundle;
         emit MaxOffersPerBundleChanged(_maxOffersPerBundle, msgSender());
     }
@@ -293,27 +220,18 @@ contract ConfigHandlerFacet is IBosonConfigHandler, ProtocolBase {
     /**
      * @notice Get the maximum offers per bundle
      */
-    function getMaxOffersPerBundle()
-    external
-    override
-    view
-    returns (uint16)
-    {
+    function getMaxOffersPerBundle() external view override returns (uint16) {
         return protocolLimits().maxOffersPerBundle;
     }
 
-     /**
+    /**
      * @notice Sets the maximum numbers of offers that can be created in a single transaction
      *
      * Emits a MaxOffersPerBatchChanged event.
      *
      * @param _maxOffersPerBatch - the maximum length of {BosonTypes.Offer[]}
      */
-    function setMaxOffersPerBatch(uint16 _maxOffersPerBatch)
-    public
-    override
-    onlyRole(ADMIN)
-    {
+    function setMaxOffersPerBatch(uint16 _maxOffersPerBatch) public override onlyRole(ADMIN) {
         protocolLimits().maxOffersPerBatch = _maxOffersPerBatch;
         emit MaxOffersPerBatchChanged(_maxOffersPerBatch, msgSender());
     }
@@ -321,15 +239,10 @@ contract ConfigHandlerFacet is IBosonConfigHandler, ProtocolBase {
     /**
      * @notice Get the maximum offers per batch
      */
-    function getMaxOffersPerBatch()
-    external
-    override
-    view
-    returns (uint16)
-    {
+    function getMaxOffersPerBatch() external view override returns (uint16) {
         return protocolLimits().maxOffersPerBatch;
     }
-    
+
     /**
      * @notice Sets the maximum numbers of tokens that can be withdrawn in a single transaction
      *
@@ -337,11 +250,7 @@ contract ConfigHandlerFacet is IBosonConfigHandler, ProtocolBase {
      *
      * @param _maxTokensPerWithdrawal - the maximum length of token list when calling {FundsHandlerFacet.withdraw}
      */
-    function setMaxTokensPerWithdrawal(uint16 _maxTokensPerWithdrawal)
-    public
-    override
-    onlyRole(ADMIN)
-    {
+    function setMaxTokensPerWithdrawal(uint16 _maxTokensPerWithdrawal) public override onlyRole(ADMIN) {
         protocolLimits().maxTokensPerWithdrawal = _maxTokensPerWithdrawal;
         emit MaxTokensPerWithdrawalChanged(_maxTokensPerWithdrawal, msgSender());
     }
@@ -349,12 +258,7 @@ contract ConfigHandlerFacet is IBosonConfigHandler, ProtocolBase {
     /**
      * @notice Get the maximum tokens per withdrawal
      */
-    function getMaxTokensPerWithdrawal()
-    external
-    override
-    view
-    returns (uint16)
-    {
+    function getMaxTokensPerWithdrawal() external view override returns (uint16) {
         return protocolLimits().maxTokensPerWithdrawal;
     }
 
@@ -365,24 +269,15 @@ contract ConfigHandlerFacet is IBosonConfigHandler, ProtocolBase {
      *
      * @param _maxFeesPerDisputeResolver - the maximum length of dispute resolver fees list when calling {AccountHandlerFacet.createDisputeResolver} or {AccountHandlerFacet.updateDisputeResolver}
      */
-    function setMaxFeesPerDisputeResolver(uint16 _maxFeesPerDisputeResolver)
-    public
-    override
-    onlyRole(ADMIN)
-    {
+    function setMaxFeesPerDisputeResolver(uint16 _maxFeesPerDisputeResolver) public override onlyRole(ADMIN) {
         protocolLimits().maxFeesPerDisputeResolver = _maxFeesPerDisputeResolver;
         emit MaxFeesPerDisputeResolverChanged(_maxFeesPerDisputeResolver, msgSender());
     }
-   
+
     /**
      * @notice Get the maximum number of dispute resolver fee structs that can be processed in a single transaction
      */
-    function getMaxFeesPerDisputeResolver() 
-    external 
-    override
-    view 
-    returns (uint16)
-    {
+    function getMaxFeesPerDisputeResolver() external view override returns (uint16) {
         return protocolLimits().maxFeesPerDisputeResolver;
     }
 
@@ -393,25 +288,15 @@ contract ConfigHandlerFacet is IBosonConfigHandler, ProtocolBase {
      *
      * @param _maxEscalationResponsePeriod - the maximum escalation response period that a {BosonTypes.DisputeResolver} can specify
      */
-    function setMaxEscalationResponsePeriod(uint256 _maxEscalationResponsePeriod) 
-    public
-    override
-    onlyRole(ADMIN)
-    {
+    function setMaxEscalationResponsePeriod(uint256 _maxEscalationResponsePeriod) public override onlyRole(ADMIN) {
         protocolLimits().maxEscalationResponsePeriod = _maxEscalationResponsePeriod;
         emit MaxEscalationResponsePeriodChanged(_maxEscalationResponsePeriod, msgSender());
     }
 
-   
     /**
      * @notice Get the maximum escalation response period a dispute resolver can specify
      */
-    function getMaxEscalationResponsePeriod()
-    external
-    override
-    view
-    returns (uint256)
-    {
+    function getMaxEscalationResponsePeriod() external view override returns (uint256) {
         return protocolLimits().maxEscalationResponsePeriod;
     }
 
@@ -422,11 +307,7 @@ contract ConfigHandlerFacet is IBosonConfigHandler, ProtocolBase {
      *
      * @param _maxDisputesPerBatch - the maximum number of disputes that can be expired
      */
-    function setMaxDisputesPerBatch(uint16 _maxDisputesPerBatch)
-    public
-    override
-    onlyRole(ADMIN)
-    {
+    function setMaxDisputesPerBatch(uint16 _maxDisputesPerBatch) public override onlyRole(ADMIN) {
         protocolLimits().maxDisputesPerBatch = _maxDisputesPerBatch;
         emit MaxDisputesPerBatchChanged(_maxDisputesPerBatch, msgSender());
     }
@@ -434,12 +315,7 @@ contract ConfigHandlerFacet is IBosonConfigHandler, ProtocolBase {
     /**
      * @notice Get the maximum disputes per batch
      */
-    function getMaxDisputesPerBatch()
-    external
-    override
-    view
-    returns (uint16)
-    {
+    function getMaxDisputesPerBatch() external view override returns (uint16) {
         return protocolLimits().maxDisputesPerBatch;
     }
 }

--- a/contracts/protocol/facets/DisputeHandlerFacet.sol
+++ b/contracts/protocol/facets/DisputeHandlerFacet.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import {IBosonDisputeHandler} from "../../interfaces/handlers/IBosonDisputeHandler.sol";
-import {DiamondLib} from "../../diamond/DiamondLib.sol";
-import {ProtocolBase} from "../bases/ProtocolBase.sol";
-import {FundsLib} from "../libs/FundsLib.sol";
-import {EIP712Lib} from "../libs/EIP712Lib.sol";
+import { IBosonDisputeHandler } from "../../interfaces/handlers/IBosonDisputeHandler.sol";
+import { DiamondLib } from "../../diamond/DiamondLib.sol";
+import { ProtocolBase } from "../bases/ProtocolBase.sol";
+import { FundsLib } from "../libs/FundsLib.sol";
+import { EIP712Lib } from "../libs/EIP712Lib.sol";
 
 /**
  * @title DisputeHandlerFacet
@@ -13,15 +13,13 @@ import {EIP712Lib} from "../libs/EIP712Lib.sol";
  * @notice Handles disputes associated with exchanges within the protocol
  */
 contract DisputeHandlerFacet is IBosonDisputeHandler, ProtocolBase {
-    bytes32 private constant RESOLUTION_TYPEHASH = keccak256(bytes("Resolution(uint256 exchangeId,uint256 buyerPercent)")); // needed for verification during the resolveDispute
+    bytes32 private constant RESOLUTION_TYPEHASH =
+        keccak256(bytes("Resolution(uint256 exchangeId,uint256 buyerPercent)")); // needed for verification during the resolveDispute
 
     /**
      * @notice Facet Initializer
      */
-    function initialize()
-    public
-    onlyUnInitialized(type(IBosonDisputeHandler).interfaceId)
-    {
+    function initialize() public onlyUnInitialized(type(IBosonDisputeHandler).interfaceId) {
         DiamondLib.addSupportedInterface(type(IBosonDisputeHandler).interfaceId);
     }
 
@@ -40,13 +38,7 @@ contract DisputeHandlerFacet is IBosonDisputeHandler, ProtocolBase {
      * @param _exchangeId - the id of the associated exchange
      * @param _complaint - the buyer's complaint description
      */
-    function raiseDispute(
-        uint256 _exchangeId,
-        string calldata _complaint
-    )
-    external
-    override
-    {
+    function raiseDispute(uint256 _exchangeId, string calldata _complaint) external override {
         // Buyer must provide a reason to dispute
         require(bytes(_complaint).length > 0, COMPLAINT_MISSING);
 
@@ -74,7 +66,7 @@ contract DisputeHandlerFacet is IBosonDisputeHandler, ProtocolBase {
         // Update the disputeDates
         disputeDates.disputed = block.timestamp;
         disputeDates.timeout = block.timestamp + fetchOfferDurations(exchange.offerId).resolutionPeriod;
-        
+
         // Get the offer, which will exist if the exchange does
         (, Offer storage offer) = fetchOffer(exchange.offerId);
 
@@ -109,7 +101,7 @@ contract DisputeHandlerFacet is IBosonDisputeHandler, ProtocolBase {
         // If dispute was escalated, make sure that escalation period is not over yet
         if (dispute.state == DisputeState.Escalated) {
             // make sure the dispute escalation period not expired already
-            require(block.timestamp <= disputeDates.timeout, DISPUTE_HAS_EXPIRED);  
+            require(block.timestamp <= disputeDates.timeout, DISPUTE_HAS_EXPIRED);
         } else {
             // If dispute is not escalated, make sure the it is in the resolving state
             require(dispute.state == DisputeState.Resolving, INVALID_STATE);
@@ -121,7 +113,7 @@ contract DisputeHandlerFacet is IBosonDisputeHandler, ProtocolBase {
         // Notify watchers of state change
         emit DisputeRetracted(_exchangeId, msgSender());
     }
-    
+
     /**
      * @notice Extend the dispute timeout, allowing more time for mutual resolution.
      * As a consequnece also buyer gets more time to escalate the dispute
@@ -148,7 +140,7 @@ contract DisputeHandlerFacet is IBosonDisputeHandler, ProtocolBase {
         (, Offer storage offer) = fetchOffer(exchange.offerId);
 
         // Get seller, we assume seller exists if offer exists
-        (,Seller storage seller) = fetchSeller(offer.sellerId);
+        (, Seller storage seller) = fetchSeller(offer.sellerId);
 
         // Caller must be seller's operator address
         require(seller.operator == msgSender(), NOT_OPERATOR);
@@ -158,7 +150,7 @@ contract DisputeHandlerFacet is IBosonDisputeHandler, ProtocolBase {
 
         // Dispute must be in a resolving state
         require(dispute.state == DisputeState.Resolving, INVALID_STATE);
-        
+
         // If expired already, it cannot be extended
         require(block.timestamp <= disputeDates.timeout, DISPUTE_HAS_EXPIRED);
 
@@ -191,12 +183,12 @@ contract DisputeHandlerFacet is IBosonDisputeHandler, ProtocolBase {
 
         // Fetch the dispute and dispute dates
         (, Dispute storage dispute, DisputeDates storage disputeDates) = fetchDispute(_exchangeId);
-        
+
         // Make sure the dispute is in the resolving state
         require(dispute.state == DisputeState.Resolving, INVALID_STATE);
 
         // make sure the dispute not expired already
-        require(block.timestamp > disputeDates.timeout, DISPUTE_STILL_VALID);      
+        require(block.timestamp > disputeDates.timeout, DISPUTE_STILL_VALID);
 
         // Finalize the dispute
         finalizeDispute(_exchangeId, exchange, dispute, disputeDates, DisputeState.Retracted, 0);
@@ -220,12 +212,11 @@ contract DisputeHandlerFacet is IBosonDisputeHandler, ProtocolBase {
      *
      * @param _exchangeIds - the array of ids of the associated exchanges
      */
-    function expireDisputeBatch(uint256[] calldata _exchangeIds) external override
-    {
+    function expireDisputeBatch(uint256[] calldata _exchangeIds) external override {
         // limit maximum number of disputes to avoid running into block gas limit in a loop
         require(_exchangeIds.length <= protocolLimits().maxDisputesPerBatch, TOO_MANY_DISPUTES);
 
-        for (uint256 i = 0; i < _exchangeIds.length; i++) {        
+        for (uint256 i = 0; i < _exchangeIds.length; i++) {
             // create offer and update structs values to represent true state
             expireDispute(_exchangeIds[i]);
         }
@@ -252,9 +243,13 @@ contract DisputeHandlerFacet is IBosonDisputeHandler, ProtocolBase {
      * @param _sigS - s part of the signer's signature.
      * @param _sigV - v part of the signer's signature.
      */
-    function resolveDispute(uint256 _exchangeId, uint256 _buyerPercent, bytes32 _sigR,
+    function resolveDispute(
+        uint256 _exchangeId,
+        uint256 _buyerPercent,
+        bytes32 _sigR,
         bytes32 _sigS,
-        uint8 _sigV) external override {
+        uint8 _sigV
+    ) external override {
         // buyer should get at most 100%
         require(_buyerPercent <= 10000, INVALID_BUYER_PERCENT);
 
@@ -262,16 +257,16 @@ contract DisputeHandlerFacet is IBosonDisputeHandler, ProtocolBase {
         Exchange storage exchange = getValidExchange(_exchangeId, ExchangeState.Disputed);
 
         // Fetch teh dispute and dispute dates
-        (, Dispute storage dispute, DisputeDates storage disputeDates) = fetchDispute(_exchangeId); 
+        (, Dispute storage dispute, DisputeDates storage disputeDates) = fetchDispute(_exchangeId);
 
         // Make sure the dispute is in the resolving or escalated state
         require(dispute.state == DisputeState.Resolving || dispute.state == DisputeState.Escalated, INVALID_STATE);
 
-        // Make sure the dispute not expired already 
-        require(block.timestamp <= disputeDates.timeout, DISPUTE_HAS_EXPIRED);  
+        // Make sure the dispute not expired already
+        require(block.timestamp <= disputeDates.timeout, DISPUTE_HAS_EXPIRED);
 
-        // wrap the code in a separate block to avoid stack too deep error 
-        { 
+        // wrap the code in a separate block to avoid stack too deep error
+        {
             // Fetch the offer to get the info who the seller is
             (, Offer storage offer) = fetchOffer(exchange.offerId);
 
@@ -291,15 +286,18 @@ contract DisputeHandlerFacet is IBosonDisputeHandler, ProtocolBase {
                 uint256 buyerId;
                 (exists, buyerId) = getBuyerIdByWallet(msgSender());
                 require(exists && buyerId == exchange.buyerId, NOT_BUYER_OR_SELLER);
-                
+
                 // caller is the buyer
-                // get the seller's address, which should be the signer of the resolution         
+                // get the seller's address, which should be the signer of the resolution
                 (, Seller storage seller) = fetchSeller(offer.sellerId);
                 expectedSigner = seller.operator;
             }
 
             // verify that the signature belongs to the expectedSigner
-            require(EIP712Lib.verify(expectedSigner, hashResolution(_exchangeId, _buyerPercent), _sigR, _sigS, _sigV), SIGNER_AND_SIGNATURE_DO_NOT_MATCH);
+            require(
+                EIP712Lib.verify(expectedSigner, hashResolution(_exchangeId, _buyerPercent), _sigR, _sigS, _sigV),
+                SIGNER_AND_SIGNATURE_DO_NOT_MATCH
+            );
         }
 
         // finalize the dispute
@@ -331,16 +329,16 @@ contract DisputeHandlerFacet is IBosonDisputeHandler, ProtocolBase {
         checkBuyer(exchange.buyerId);
 
         // Fetch teh dispute and dispute dates
-        (, Dispute storage dispute, DisputeDates storage disputeDates) = fetchDispute(_exchangeId);   
-        
-        // make sure the dispute not expired already        
+        (, Dispute storage dispute, DisputeDates storage disputeDates) = fetchDispute(_exchangeId);
+
+        // make sure the dispute not expired already
         require(block.timestamp <= disputeDates.timeout, DISPUTE_HAS_EXPIRED);
 
-        // Make sure the dispute is in the resolving state             
+        // Make sure the dispute is in the resolving state
         require(dispute.state == DisputeState.Resolving, INVALID_STATE);
 
         // TODO: fetch the escalation period from the storage
-        uint256 escalationPeriod = 1000 weeks; // only for tests  
+        uint256 escalationPeriod = 1000 weeks; // only for tests
 
         // store the time of escalation
         disputeDates.escalated = block.timestamp;
@@ -377,7 +375,9 @@ contract DisputeHandlerFacet is IBosonDisputeHandler, ProtocolBase {
         require(_buyerPercent <= 10000, INVALID_BUYER_PERCENT);
 
         // Make sure the dispute is valid and the caller is the dispute resolver
-        (Exchange storage exchange, Dispute storage dispute, DisputeDates storage disputeDates) = disputeResolverChecks(_exchangeId);
+        (Exchange storage exchange, Dispute storage dispute, DisputeDates storage disputeDates) = disputeResolverChecks(
+            _exchangeId
+        );
 
         // finalize the dispute
         finalizeDispute(_exchangeId, exchange, dispute, disputeDates, DisputeState.Decided, _buyerPercent);
@@ -402,7 +402,9 @@ contract DisputeHandlerFacet is IBosonDisputeHandler, ProtocolBase {
      */
     function refuseEscalatedDispute(uint256 _exchangeId) external override {
         // Make sure the dispute is valid and the caller is the dispute resolver
-        (Exchange storage exchange, Dispute storage dispute, DisputeDates storage disputeDates) = disputeResolverChecks(_exchangeId);
+        (Exchange storage exchange, Dispute storage dispute, DisputeDates storage disputeDates) = disputeResolverChecks(
+            _exchangeId
+        );
 
         // Finalize the dispute
         finalizeDispute(_exchangeId, exchange, dispute, disputeDates, DisputeState.Refused, 0);
@@ -423,13 +425,21 @@ contract DisputeHandlerFacet is IBosonDisputeHandler, ProtocolBase {
      *
      * @param _exchangeId - the id of the associated exchange
      */
-    function disputeResolverChecks(uint256 _exchangeId) internal view returns (Exchange storage exchange , Dispute storage dispute, DisputeDates storage disputeDates) {
+    function disputeResolverChecks(uint256 _exchangeId)
+        internal
+        view
+        returns (
+            Exchange storage exchange,
+            Dispute storage dispute,
+            DisputeDates storage disputeDates
+        )
+    {
         // Get the exchange, should be in disputed state
         exchange = getValidExchange(_exchangeId, ExchangeState.Disputed);
 
         // Fetch the dispute and dispute dates
         (, dispute, disputeDates) = fetchDispute(_exchangeId);
-        
+
         // Make sure the dispute is in the escalated state
         require(dispute.state == DisputeState.Escalated, INVALID_STATE);
 
@@ -443,7 +453,7 @@ contract DisputeHandlerFacet is IBosonDisputeHandler, ProtocolBase {
         uint256 disputeResolverId = protocolLookups().disputeResolverIdByOperator[msgSender()];
         require(disputeResolverId == offer.disputeResolverId, NOT_DISPUTE_RESOLVER_OPERATOR);
     }
-    
+
     /**
      * @notice Expire the dispute in escalated state and release the funds
      *
@@ -463,12 +473,12 @@ contract DisputeHandlerFacet is IBosonDisputeHandler, ProtocolBase {
 
         // Fetch the dispute and dispute dates
         (, Dispute storage dispute, DisputeDates storage disputeDates) = fetchDispute(_exchangeId);
-        
+
         // Make sure the dispute is in the escalated state
         require(dispute.state == DisputeState.Escalated, INVALID_STATE);
 
         // make sure the dispute escalation has expired already
-        require(block.timestamp > disputeDates.timeout, DISPUTE_STILL_VALID);      
+        require(block.timestamp > disputeDates.timeout, DISPUTE_STILL_VALID);
 
         // Finalize the dispute
         finalizeDispute(_exchangeId, exchange, dispute, disputeDates, DisputeState.Refused, 0);
@@ -492,7 +502,14 @@ contract DisputeHandlerFacet is IBosonDisputeHandler, ProtocolBase {
      * @param _targetState - target final state
      * @param _buyerPercent - percentage of the pot that goes to the buyer
      */
-    function finalizeDispute(uint256 _exchangeId, Exchange storage _exchange, Dispute storage _dispute, DisputeDates storage _disputeDates, DisputeState _targetState, uint256 _buyerPercent) internal {
+    function finalizeDispute(
+        uint256 _exchangeId,
+        Exchange storage _exchange,
+        Dispute storage _dispute,
+        DisputeDates storage _disputeDates,
+        DisputeState _targetState,
+        uint256 _buyerPercent
+    ) internal {
         // update dispute and exchange
         _disputeDates.finalized = block.timestamp;
         _dispute.state = _targetState;
@@ -514,14 +531,7 @@ contract DisputeHandlerFacet is IBosonDisputeHandler, ProtocolBase {
      * @param _buyerPercent - percentage of the pot that goes to the buyer
      */
     function hashResolution(uint256 _exchangeId, uint256 _buyerPercent) internal pure returns (bytes32) {
-        return
-            keccak256(
-                abi.encode(
-                    RESOLUTION_TYPEHASH,
-                    _exchangeId,
-                    _buyerPercent
-                )
-            );
+        return keccak256(abi.encode(RESOLUTION_TYPEHASH, _exchangeId, _buyerPercent));
     }
 
     /**
@@ -533,10 +543,15 @@ contract DisputeHandlerFacet is IBosonDisputeHandler, ProtocolBase {
      * @return disputeDates - the dispute dates details {BosonTypes.DisputeDates}
      */
     function getDispute(uint256 _exchangeId)
-    external
-    view
-    override
-    returns(bool exists, Dispute memory dispute, DisputeDates memory disputeDates) {
+        external
+        view
+        override
+        returns (
+            bool exists,
+            Dispute memory dispute,
+            DisputeDates memory disputeDates
+        )
+    {
         return fetchDispute(_exchangeId);
     }
 
@@ -547,11 +562,7 @@ contract DisputeHandlerFacet is IBosonDisputeHandler, ProtocolBase {
      * @return exists - true if the dispute exists
      * @return state - the dispute state. See {BosonTypes.DisputeState}
      */
-    function getDisputeState(uint256 _exchangeId)
-    external
-    view
-    override
-    returns(bool exists, DisputeState state) {
+    function getDisputeState(uint256 _exchangeId) external view override returns (bool exists, DisputeState state) {
         Dispute storage dispute;
         (exists, dispute, ) = fetchDispute(_exchangeId);
         if (exists) state = dispute.state;
@@ -564,11 +575,7 @@ contract DisputeHandlerFacet is IBosonDisputeHandler, ProtocolBase {
      * @return exists - true if the dispute exists
      * @return timeout - the end of resolution period
      */
-    function getDisputeTimeout(uint256 _exchangeId)
-    external
-    view
-    override
-    returns(bool exists, uint256 timeout) {
+    function getDisputeTimeout(uint256 _exchangeId) external view override returns (bool exists, uint256 timeout) {
         DisputeDates storage disputeDates;
         (exists, , disputeDates) = fetchDispute(_exchangeId);
         if (exists) timeout = disputeDates.timeout;
@@ -584,11 +591,7 @@ contract DisputeHandlerFacet is IBosonDisputeHandler, ProtocolBase {
      * @return exists - true if the dispute exists
      * @return isFinalized - true if the dispute is finalized
      */
-    function isDisputeFinalized(uint256 _exchangeId)
-    external
-    view
-    override
-    returns(bool exists, bool isFinalized) {
+    function isDisputeFinalized(uint256 _exchangeId) external view override returns (bool exists, bool isFinalized) {
         Dispute storage dispute;
 
         // Get the dispute
@@ -597,12 +600,10 @@ contract DisputeHandlerFacet is IBosonDisputeHandler, ProtocolBase {
         // if exists, set isFinalized to true if state is a valid finalized state
         if (exists) {
             // Check for finalized dispute state
-            isFinalized = (
-                dispute.state == DisputeState.Retracted ||
+            isFinalized = (dispute.state == DisputeState.Retracted ||
                 dispute.state == DisputeState.Resolved ||
                 dispute.state == DisputeState.Decided ||
-                dispute.state == DisputeState.Refused
-            );
+                dispute.state == DisputeState.Refused);
         }
     }
 }

--- a/contracts/protocol/facets/MetaTransactionsHandlerFacet.sol
+++ b/contracts/protocol/facets/MetaTransactionsHandlerFacet.sol
@@ -6,7 +6,7 @@ import { IBosonDisputeHandler } from "../../interfaces/handlers/IBosonDisputeHan
 import { IBosonExchangeHandler } from "../../interfaces/handlers/IBosonExchangeHandler.sol";
 import { IBosonFundsHandler } from "../../interfaces/handlers/IBosonFundsHandler.sol";
 import { DiamondLib } from "../../diamond/DiamondLib.sol";
-import { ProtocolLib } from  "../libs/ProtocolLib.sol";
+import { ProtocolLib } from "../libs/ProtocolLib.sol";
 import { ProtocolBase } from "../bases/ProtocolBase.sol";
 import { EIP712Lib } from "../libs/EIP712Lib.sol";
 
@@ -17,17 +17,42 @@ import { EIP712Lib } from "../libs/EIP712Lib.sol";
  */
 contract MetaTransactionsHandlerFacet is IBosonMetaTransactionsHandler, ProtocolBase {
     // Structs
-    bytes32 private constant META_TRANSACTION_TYPEHASH = keccak256(bytes("MetaTransaction(uint256 nonce,address from,address contractAddress,string functionName,bytes functionSignature)"));
+    bytes32 private constant META_TRANSACTION_TYPEHASH =
+        keccak256(
+            bytes(
+                "MetaTransaction(uint256 nonce,address from,address contractAddress,string functionName,bytes functionSignature)"
+            )
+        );
     bytes32 private constant OFFER_DETAILS_TYPEHASH = keccak256("MetaTxOfferDetails(address buyer,uint256 offerId)");
-    bytes32 private constant META_TX_COMMIT_TO_OFFER_TYPEHASH = keccak256("MetaTxCommitToOffer(uint256 nonce,address from,address contractAddress,string functionName,MetaTxOfferDetails offerDetails)MetaTxOfferDetails(address buyer,uint256 offerId)");
+    bytes32 private constant META_TX_COMMIT_TO_OFFER_TYPEHASH =
+        keccak256(
+            "MetaTxCommitToOffer(uint256 nonce,address from,address contractAddress,string functionName,MetaTxOfferDetails offerDetails)MetaTxOfferDetails(address buyer,uint256 offerId)"
+        );
     bytes32 private constant EXCHANGE_DETAILS_TYPEHASH = keccak256("MetaTxExchangeDetails(uint256 exchangeId)");
-    bytes32 private constant META_TX_EXCHANGE_TYPEHASH = keccak256("MetaTxExchange(uint256 nonce,address from,address contractAddress,string functionName,MetaTxExchangeDetails exchangeDetails)MetaTxExchangeDetails(uint256 exchangeId)");
-    bytes32 private constant FUND_DETAILS_TYPEHASH = keccak256("MetaTxFundDetails(uint256 entityId,address[] tokenList,uint256[] tokenAmounts)");
-    bytes32 private constant META_TX_FUNDS_TYPEHASH = keccak256("MetaTxFund(uint256 nonce,address from,address contractAddress,string functionName,MetaTxFundDetails fundDetails)MetaTxFundDetails(uint256 entityId,address[] tokenList,uint256[] tokenAmounts)");
-    bytes32 private constant DISPUTE_DETAILS_TYPEHASH = keccak256("MetaTxDisputeDetails(uint256 exchangeId,string complaint)");
-    bytes32 private constant META_TX_DISPUTES_TYPEHASH = keccak256("MetaTxDispute(uint256 nonce,address from,address contractAddress,string functionName,MetaTxDisputeDetails disputeDetails)MetaTxDisputeDetails(uint256 exchangeId,string complaint)");
-    bytes32 private constant DISPUTE_RESOLUTION_DETAILS_TYPEHASH = keccak256("MetaTxDisputeResolutionDetails(uint256 exchangeId,uint256 buyerPercent,bytes32 sigR,bytes32 sigS,uint8 sigV)");
-    bytes32 private constant META_TX_DISPUTE_RESOLUTIONS_TYPEHASH = keccak256("MetaTxDisputeResolution(uint256 nonce,address from,address contractAddress,string functionName,MetaTxDisputeResolutionDetails disputeResolutionDetails)MetaTxDisputeResolutionDetails(uint256 exchangeId,uint256 buyerPercent,bytes32 sigR,bytes32 sigS,uint8 sigV)");
+    bytes32 private constant META_TX_EXCHANGE_TYPEHASH =
+        keccak256(
+            "MetaTxExchange(uint256 nonce,address from,address contractAddress,string functionName,MetaTxExchangeDetails exchangeDetails)MetaTxExchangeDetails(uint256 exchangeId)"
+        );
+    bytes32 private constant FUND_DETAILS_TYPEHASH =
+        keccak256("MetaTxFundDetails(uint256 entityId,address[] tokenList,uint256[] tokenAmounts)");
+    bytes32 private constant META_TX_FUNDS_TYPEHASH =
+        keccak256(
+            "MetaTxFund(uint256 nonce,address from,address contractAddress,string functionName,MetaTxFundDetails fundDetails)MetaTxFundDetails(uint256 entityId,address[] tokenList,uint256[] tokenAmounts)"
+        );
+    bytes32 private constant DISPUTE_DETAILS_TYPEHASH =
+        keccak256("MetaTxDisputeDetails(uint256 exchangeId,string complaint)");
+    bytes32 private constant META_TX_DISPUTES_TYPEHASH =
+        keccak256(
+            "MetaTxDispute(uint256 nonce,address from,address contractAddress,string functionName,MetaTxDisputeDetails disputeDetails)MetaTxDisputeDetails(uint256 exchangeId,string complaint)"
+        );
+    bytes32 private constant DISPUTE_RESOLUTION_DETAILS_TYPEHASH =
+        keccak256(
+            "MetaTxDisputeResolutionDetails(uint256 exchangeId,uint256 buyerPercent,bytes32 sigR,bytes32 sigS,uint8 sigV)"
+        );
+    bytes32 private constant META_TX_DISPUTE_RESOLUTIONS_TYPEHASH =
+        keccak256(
+            "MetaTxDisputeResolution(uint256 nonce,address from,address contractAddress,string functionName,MetaTxDisputeResolutionDetails disputeResolutionDetails)MetaTxDisputeResolutionDetails(uint256 exchangeId,uint256 buyerPercent,bytes32 sigR,bytes32 sigS,uint8 sigV)"
+        );
     // Function names
     string private constant COMMIT_TO_OFFER = "commitToOffer(address,uint256)";
     string private constant CANCEL_VOUCHER = "cancelVoucher(uint256)";
@@ -65,7 +90,10 @@ contract MetaTransactionsHandlerFacet is IBosonMetaTransactionsHandler, Protocol
         pmti.hashInfo[MetaTxInputType.Funds] = HashInfo(META_TX_FUNDS_TYPEHASH, hashFundDetails);
         pmti.hashInfo[MetaTxInputType.Exchange] = HashInfo(META_TX_EXCHANGE_TYPEHASH, hashExchangeDetails);
         pmti.hashInfo[MetaTxInputType.RaiseDispute] = HashInfo(META_TX_DISPUTES_TYPEHASH, hashDisputeDetails);
-        pmti.hashInfo[MetaTxInputType.ResolveDispute] = HashInfo(META_TX_DISPUTE_RESOLUTIONS_TYPEHASH, hashDisputeResolutionDetails);
+        pmti.hashInfo[MetaTxInputType.ResolveDispute] = HashInfo(
+            META_TX_DISPUTE_RESOLUTIONS_TYPEHASH,
+            hashDisputeResolutionDetails
+        );
     }
 
     /**
@@ -117,10 +145,7 @@ contract MetaTransactionsHandlerFacet is IBosonMetaTransactionsHandler, Protocol
      */
     function hashOfferDetails(bytes memory _offerDetails) internal pure returns (bytes32) {
         (address buyer, uint256 offerId) = abi.decode(_offerDetails, (address, uint256));
-        return
-            keccak256(
-                abi.encode(OFFER_DETAILS_TYPEHASH, buyer, offerId)
-            );
+        return keccak256(abi.encode(OFFER_DETAILS_TYPEHASH, buyer, offerId));
     }
 
     /**
@@ -129,11 +154,8 @@ contract MetaTransactionsHandlerFacet is IBosonMetaTransactionsHandler, Protocol
      * @param _exchangeDetails - the exchange details
      */
     function hashExchangeDetails(bytes memory _exchangeDetails) internal pure returns (bytes32) {
-        (uint256 exchangeId) = abi.decode(_exchangeDetails, (uint256));
-        return
-            keccak256(
-                abi.encode(EXCHANGE_DETAILS_TYPEHASH, exchangeId)
-            );
+        uint256 exchangeId = abi.decode(_exchangeDetails, (uint256));
+        return keccak256(abi.encode(EXCHANGE_DETAILS_TYPEHASH, exchangeId));
     }
 
     /**
@@ -142,7 +164,10 @@ contract MetaTransactionsHandlerFacet is IBosonMetaTransactionsHandler, Protocol
      * @param _fundDetails - the fund details
      */
     function hashFundDetails(bytes memory _fundDetails) internal pure returns (bytes32) {
-        (uint256 entityId, address[] memory tokenList, uint256[] memory tokenAmounts) = abi.decode(_fundDetails, (uint256, address[], uint256[]));
+        (uint256 entityId, address[] memory tokenList, uint256[] memory tokenAmounts) = abi.decode(
+            _fundDetails,
+            (uint256, address[], uint256[])
+        );
         return
             keccak256(
                 abi.encode(
@@ -161,14 +186,7 @@ contract MetaTransactionsHandlerFacet is IBosonMetaTransactionsHandler, Protocol
      */
     function hashDisputeDetails(bytes memory _disputeDetails) internal pure returns (bytes32) {
         (uint256 exchangeId, string memory complaint) = abi.decode(_disputeDetails, (uint256, string));
-        return
-            keccak256(
-                abi.encode(
-                    DISPUTE_DETAILS_TYPEHASH,
-                    exchangeId,
-                    keccak256(bytes(complaint))
-                )
-            );
+        return keccak256(abi.encode(DISPUTE_DETAILS_TYPEHASH, exchangeId, keccak256(bytes(complaint))));
     }
 
     /**
@@ -177,18 +195,11 @@ contract MetaTransactionsHandlerFacet is IBosonMetaTransactionsHandler, Protocol
      * @param _disputeResolutionDetails - the dispute resolution details
      */
     function hashDisputeResolutionDetails(bytes memory _disputeResolutionDetails) internal pure returns (bytes32) {
-        (uint256 exchangeId, uint256 buyerPercent, bytes32 sigR, bytes32 sigS, uint8 sigV) = abi.decode(_disputeResolutionDetails, (uint256, uint256, bytes32, bytes32, uint8));
-        return
-            keccak256(
-                abi.encode(
-                    DISPUTE_RESOLUTION_DETAILS_TYPEHASH,
-                    exchangeId,
-                    buyerPercent,
-                    sigR,
-                    sigS,
-                    sigV
-                )
-            );
+        (uint256 exchangeId, uint256 buyerPercent, bytes32 sigR, bytes32 sigS, uint8 sigV) = abi.decode(
+            _disputeResolutionDetails,
+            (uint256, uint256, bytes32, bytes32, uint8)
+        );
+        return keccak256(abi.encode(DISPUTE_RESOLUTION_DETAILS_TYPEHASH, exchangeId, buyerPercent, sigR, sigS, sigV));
     }
 
     /**
@@ -231,9 +242,7 @@ contract MetaTransactionsHandlerFacet is IBosonMetaTransactionsHandler, Protocol
      *
      * @param _functionName - the function name that we want to execute.
      */
-    function isSpecialFunction(
-        string memory _functionName
-    ) internal view returns (bool){
+    function isSpecialFunction(string memory _functionName) internal view returns (bool) {
         return protocolMetaTxInfo().inputType[_functionName] != MetaTxInputType.Generic;
     }
 

--- a/contracts/protocol/facets/OfferHandlerFacet.sol
+++ b/contracts/protocol/facets/OfferHandlerFacet.sol
@@ -11,14 +11,10 @@ import { OfferBase } from "../bases/OfferBase.sol";
  * @notice Handles offers within the protocol
  */
 contract OfferHandlerFacet is IBosonOfferHandler, OfferBase {
-
     /**
      * @notice Facet Initializer
      */
-    function initialize()
-    public
-    onlyUnInitialized(type(IBosonOfferHandler).interfaceId)
-    {
+    function initialize() public onlyUnInitialized(type(IBosonOfferHandler).interfaceId) {
         DiamondLib.addSupportedInterface(type(IBosonOfferHandler).interfaceId);
     }
 
@@ -48,11 +44,9 @@ contract OfferHandlerFacet is IBosonOfferHandler, OfferBase {
      */
     function createOffer(
         Offer memory _offer,
-        OfferDates calldata _offerDates, OfferDurations calldata _offerDurations
-    )
-    external
-    override
-    {    
+        OfferDates calldata _offerDates,
+        OfferDurations calldata _offerDurations
+    ) external override {
         createOfferInternal(_offer, _offerDates, _offerDurations);
     }
 
@@ -85,23 +79,21 @@ contract OfferHandlerFacet is IBosonOfferHandler, OfferBase {
      */
     function createOfferBatch(
         Offer[] calldata _offers,
-        OfferDates[] calldata _offerDates, OfferDurations[] calldata _offerDurations
-    )
-    external
-    override
-    {
+        OfferDates[] calldata _offerDates,
+        OfferDurations[] calldata _offerDurations
+    ) external override {
         // limit maximum number of offers to avoid running into block gas limit in a loop
         require(_offers.length <= protocolLimits().maxOffersPerBatch, TOO_MANY_OFFERS);
         // number of offer dates structs and offer durations structs must match the number of offers
         require(_offers.length == _offerDates.length, ARRAY_LENGTH_MISMATCH);
         require(_offers.length == _offerDurations.length, ARRAY_LENGTH_MISMATCH);
 
-        for (uint256 i = 0; i < _offers.length; i++) {        
+        for (uint256 i = 0; i < _offers.length; i++) {
             // create offer and update structs values to represent true state
             createOfferInternal(_offers[i], _offerDates[i], _offerDurations[i]);
         }
-    }   
-    
+    }
+
     /**
      * @notice Voids a given offer.
      *
@@ -118,10 +110,7 @@ contract OfferHandlerFacet is IBosonOfferHandler, OfferBase {
      *
      * @param _offerId - the id of the offer to check
      */
-    function voidOffer(uint256 _offerId)
-    public
-    override
-    {
+    function voidOffer(uint256 _offerId) public override {
         // Get offer, make sure the caller is the operator
         Offer storage offer = getValidOffer(_offerId);
 
@@ -130,7 +119,6 @@ contract OfferHandlerFacet is IBosonOfferHandler, OfferBase {
 
         // Notify listeners of state change
         emit OfferVoided(_offerId, offer.sellerId, msgSender());
-
     }
 
     /**
@@ -150,13 +138,10 @@ contract OfferHandlerFacet is IBosonOfferHandler, OfferBase {
      *
      * @param _offerIds - the id of the offer to check
      */
-    function voidOfferBatch(uint256[] calldata _offerIds)
-    external
-    override
-    {
+    function voidOfferBatch(uint256[] calldata _offerIds) external override {
         // limit maximum number of offers to avoid running into block gas limit in a loop
         require(_offerIds.length <= protocolLimits().maxOffersPerBatch, TOO_MANY_OFFERS);
-        for (uint i = 0; i < _offerIds.length; i++) { 
+        for (uint256 i = 0; i < _offerIds.length; i++) {
             voidOffer(_offerIds[i]);
         }
     }
@@ -175,24 +160,19 @@ contract OfferHandlerFacet is IBosonOfferHandler, OfferBase {
      *  @param _offerId - the id of the offer to check
      *  @param _validUntilDate - new valid until date
      */
-    function extendOffer(
-        uint256 _offerId, uint _validUntilDate
-    )
-    public
-    override
-    {
+    function extendOffer(uint256 _offerId, uint256 _validUntilDate) public override {
         // Make sure the caller is the operator, offer exists and is not voided
         Offer storage offer = getValidOffer(_offerId);
 
         // Fetch the offer dates
-        OfferDates storage offerDates = fetchOfferDates(_offerId); 
+        OfferDates storage offerDates = fetchOfferDates(_offerId);
 
         // New valid until date must be greater than existing one
         require(offerDates.validUntil < _validUntilDate, OFFER_PERIOD_INVALID);
 
         // If voucherRedeemableUntil is set, _validUntilDate must be less or equal than that
         if (offerDates.voucherRedeemableUntil > 0) {
-            require(_validUntilDate <=  offerDates.voucherRedeemableUntil, OFFER_PERIOD_INVALID);
+            require(_validUntilDate <= offerDates.voucherRedeemableUntil, OFFER_PERIOD_INVALID);
         }
 
         // Update the valid until property
@@ -221,7 +201,7 @@ contract OfferHandlerFacet is IBosonOfferHandler, OfferBase {
     function extendOfferBatch(uint256[] calldata _offerIds, uint256 _validUntilDate) external override {
         // limit maximum number of offers to avoid running into block gas limit in a loop
         require(_offerIds.length <= protocolLimits().maxOffersPerBatch, TOO_MANY_OFFERS);
-        for (uint i = 0; i < _offerIds.length; i++) { 
+        for (uint256 i = 0; i < _offerIds.length; i++) {
             extendOffer(_offerIds[i], _validUntilDate);
         }
     }
@@ -236,10 +216,16 @@ contract OfferHandlerFacet is IBosonOfferHandler, OfferBase {
      * @return offerDurations - the offer durations details. See {BosonTypes.OfferDurations}
      */
     function getOffer(uint256 _offerId)
-    external
-    override
-    view
-    returns(bool exists, Offer memory offer, OfferDates memory offerDates, OfferDurations memory offerDurations) {
+        external
+        view
+        override
+        returns (
+            bool exists,
+            Offer memory offer,
+            OfferDates memory offerDates,
+            OfferDurations memory offerDurations
+        )
+    {
         (exists, offer) = fetchOffer(_offerId);
         if (exists) {
             offerDates = fetchOfferDates(_offerId);
@@ -254,14 +240,8 @@ contract OfferHandlerFacet is IBosonOfferHandler, OfferBase {
      *
      * @return nextOfferId - the next offer id
      */
-    function getNextOfferId()
-    public
-    override
-    view
-    returns(uint256 nextOfferId) {
-
+    function getNextOfferId() public view override returns (uint256 nextOfferId) {
         nextOfferId = protocolCounters().nextOfferId;
-
     }
 
     /**
@@ -271,14 +251,9 @@ contract OfferHandlerFacet is IBosonOfferHandler, OfferBase {
      * @return exists - the offer was found
      * @return offerVoided - true if voided, false otherwise
      */
-    function isOfferVoided(uint256 _offerId)
-    public
-    override
-    view
-    returns(bool exists, bool offerVoided) {
+    function isOfferVoided(uint256 _offerId) public view override returns (bool exists, bool offerVoided) {
         Offer memory offer;
         (exists, offer) = fetchOffer(_offerId);
         offerVoided = offer.voided;
     }
-
 }

--- a/contracts/protocol/facets/OrchestrationHandlerFacet.sol
+++ b/contracts/protocol/facets/OrchestrationHandlerFacet.sol
@@ -14,15 +14,18 @@ import { BundleBase } from "../bases/BundleBase.sol";
  *
  * @notice Combines creation of multiple entities (accounts, offers, groups, twins, bundles) in a single transaction
  */
-contract OrchestrationHandlerFacet is AccountBase, OfferBase, GroupBase, TwinBase, BundleBase, IBosonOrchestrationHandler {
-
+contract OrchestrationHandlerFacet is
+    AccountBase,
+    OfferBase,
+    GroupBase,
+    TwinBase,
+    BundleBase,
+    IBosonOrchestrationHandler
+{
     /**
      * @notice Facet Initializer
      */
-    function initialize()
-    public
-    onlyUnInitialized(type(IBosonOrchestrationHandler).interfaceId)
-    {
+    function initialize() public onlyUnInitialized(type(IBosonOrchestrationHandler).interfaceId) {
         DiamondLib.addSupportedInterface(type(IBosonOrchestrationHandler).interfaceId);
     }
 
@@ -59,11 +62,9 @@ contract OrchestrationHandlerFacet is AccountBase, OfferBase, GroupBase, TwinBas
     function createSellerAndOffer(
         Seller memory _seller,
         Offer memory _offer,
-        OfferDates calldata _offerDates, OfferDurations calldata _offerDurations
-    )
-    external
-    override
-    {   
+        OfferDates calldata _offerDates,
+        OfferDurations calldata _offerDurations
+    ) external override {
         checkAndCreateSeller(_seller);
         createOfferInternal(_offer, _offerDates, _offerDurations);
     }
@@ -97,12 +98,10 @@ contract OrchestrationHandlerFacet is AccountBase, OfferBase, GroupBase, TwinBas
      */
     function createOfferWithCondition(
         Offer memory _offer,
-        OfferDates calldata _offerDates, OfferDurations calldata _offerDurations,
+        OfferDates calldata _offerDates,
+        OfferDurations calldata _offerDurations,
         Condition memory _condition
-    )
-    public
-    override
-    {   
+    ) public override {
         // create offer and update structs values to represent true state
         createOfferInternal(_offer, _offerDates, _offerDurations);
 
@@ -114,7 +113,7 @@ contract OrchestrationHandlerFacet is AccountBase, OfferBase, GroupBase, TwinBas
 
         // create group and update structs values to represent true state
         createGroupInternal(_group);
-    } 
+    }
 
     /**
      * @notice Takes an offer and group ID, creates an offer and adds it to the existing group with given id
@@ -147,10 +146,10 @@ contract OrchestrationHandlerFacet is AccountBase, OfferBase, GroupBase, TwinBas
      */
     function createOfferAddToGroup(
         Offer memory _offer,
-        OfferDates calldata _offerDates, OfferDurations calldata _offerDurations,
+        OfferDates calldata _offerDates,
+        OfferDurations calldata _offerDurations,
         uint256 _groupId
-    )
-    external override {
+    ) external override {
         // create offer and update structs values to represent true state
         createOfferInternal(_offer, _offerDates, _offerDurations);
 
@@ -190,11 +189,10 @@ contract OrchestrationHandlerFacet is AccountBase, OfferBase, GroupBase, TwinBas
      */
     function createOfferAndTwinWithBundle(
         Offer memory _offer,
-        OfferDates calldata _offerDates, OfferDurations calldata _offerDurations,
+        OfferDates calldata _offerDates,
+        OfferDurations calldata _offerDurations,
         Twin memory _twin
-    )
-    public 
-    override {
+    ) public override {
         // create seller and update structs values to represent true state
         createOfferInternal(_offer, _offerDates, _offerDurations);
 
@@ -234,11 +232,11 @@ contract OrchestrationHandlerFacet is AccountBase, OfferBase, GroupBase, TwinBas
      */
     function createOfferWithConditionAndTwinAndBundle(
         Offer memory _offer,
-        OfferDates calldata _offerDates, OfferDurations calldata _offerDurations,
+        OfferDates calldata _offerDates,
+        OfferDurations calldata _offerDurations,
         Condition memory _condition,
         Twin memory _twin
-    )
-    public override {
+    ) public override {
         // create offer with condition first
         createOfferWithCondition(_offer, _offerDates, _offerDurations, _condition);
         // create twin and pack everything into a bundle
@@ -259,7 +257,11 @@ contract OrchestrationHandlerFacet is AccountBase, OfferBase, GroupBase, TwinBas
      * @param _offerId - offerid, obtained in previous steps
      * @param _sellerId - sellerId, obtained in previous steps
      */
-    function createTwinAndBundleAfterOffer(Twin memory _twin, uint256 _offerId, uint256 _sellerId) internal {
+    function createTwinAndBundleAfterOffer(
+        Twin memory _twin,
+        uint256 _offerId,
+        uint256 _sellerId
+    ) internal {
         // create twin and update structs values to represent true state
         createTwinInternal(_twin);
 
@@ -271,7 +273,7 @@ contract OrchestrationHandlerFacet is AccountBase, OfferBase, GroupBase, TwinBas
         _bundle.twinIds[0] = _twin.id;
 
         // create bundle and update structs values to represent true state
-        createBundleInternal(_bundle);        
+        createBundleInternal(_bundle);
     }
 
     /**
@@ -310,14 +312,13 @@ contract OrchestrationHandlerFacet is AccountBase, OfferBase, GroupBase, TwinBas
     function createSellerAndOfferWithCondition(
         Seller memory _seller,
         Offer memory _offer,
-        OfferDates calldata _offerDates, OfferDurations calldata _offerDurations,
+        OfferDates calldata _offerDates,
+        OfferDurations calldata _offerDurations,
         Condition memory _condition
-    )
-    external 
-    override {
+    ) external override {
         checkAndCreateSeller(_seller);
         createOfferWithCondition(_offer, _offerDates, _offerDurations, _condition);
-    } 
+    }
 
     /**
      * @notice Takes a seller, an offer and a twin, creates a seller, creates an offer, creates a twin, then a bundle with that offer and the given twin
@@ -356,11 +357,10 @@ contract OrchestrationHandlerFacet is AccountBase, OfferBase, GroupBase, TwinBas
     function createSellerAndOfferAndTwinWithBundle(
         Seller memory _seller,
         Offer memory _offer,
-        OfferDates calldata _offerDates, OfferDurations calldata _offerDurations,
+        OfferDates calldata _offerDates,
+        OfferDurations calldata _offerDurations,
         Twin memory _twin
-    )
-    external 
-    override {
+    ) external override {
         checkAndCreateSeller(_seller);
         createOfferAndTwinWithBundle(_offer, _offerDates, _offerDurations, _twin);
     }
@@ -404,11 +404,11 @@ contract OrchestrationHandlerFacet is AccountBase, OfferBase, GroupBase, TwinBas
     function createSellerAndOfferWithConditionAndTwinAndBundle(
         Seller memory _seller,
         Offer memory _offer,
-        OfferDates calldata _offerDates, OfferDurations calldata _offerDurations,
+        OfferDates calldata _offerDates,
+        OfferDurations calldata _offerDurations,
         Condition memory _condition,
         Twin memory _twin
-    )
-    external override {
+    ) external override {
         checkAndCreateSeller(_seller);
         createOfferWithConditionAndTwinAndBundle(_offer, _offerDates, _offerDurations, _condition, _twin);
     }

--- a/contracts/protocol/facets/TwinHandlerFacet.sol
+++ b/contracts/protocol/facets/TwinHandlerFacet.sol
@@ -12,14 +12,10 @@ import { TwinBase } from "../bases/TwinBase.sol";
  * @notice Manages digital twinning associated with exchanges within the protocol
  */
 contract TwinHandlerFacet is IBosonTwinHandler, TwinBase {
-
     /**
      * @notice Facet Initializer
      */
-    function initialize()
-    public
-    onlyUnInitialized(type(IBosonTwinHandler).interfaceId)
-    {
+    function initialize() public onlyUnInitialized(type(IBosonTwinHandler).interfaceId) {
         DiamondLib.addSupportedInterface(type(IBosonTwinHandler).interfaceId);
     }
 
@@ -34,12 +30,7 @@ contract TwinHandlerFacet is IBosonTwinHandler, TwinBase {
      *
      * @param _twin - the fully populated struct with twin id set to 0x0
      */
-    function createTwin(
-        Twin memory _twin
-    )
-    external
-    override
-    {
+    function createTwin(Twin memory _twin) external override {
         createTwinInternal(_twin);
     }
 
@@ -50,11 +41,7 @@ contract TwinHandlerFacet is IBosonTwinHandler, TwinBase {
      * @return exists - the twin was found
      * @return twin - the twin details. See {BosonTypes.Twin}
      */
-    function getTwin(uint256 _twinId)
-    external
-    override
-    view
-    returns(bool exists, Twin memory twin) {
+    function getTwin(uint256 _twinId) external view override returns (bool exists, Twin memory twin) {
         return fetchTwin(_twinId);
     }
 
@@ -65,14 +52,8 @@ contract TwinHandlerFacet is IBosonTwinHandler, TwinBase {
      *
      * @return nextTwinId - the next twin id
      */
-    function getNextTwinId()
-    public
-    override
-    view
-    returns(uint256 nextTwinId) {
-
+    function getNextTwinId() public view override returns (uint256 nextTwinId) {
         nextTwinId = protocolCounters().nextTwinId;
-
     }
 
     /**

--- a/contracts/protocol/libs/ClientLib.sol
+++ b/contracts/protocol/libs/ClientLib.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {IAccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/IAccessControlUpgradeable.sol";
-import {IBosonConfigHandler} from "../../interfaces/handlers/IBosonConfigHandler.sol";
+import { IAccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/IAccessControlUpgradeable.sol";
+import { IBosonConfigHandler } from "../../interfaces/handlers/IBosonConfigHandler.sol";
 import { EIP712Lib } from "../libs/EIP712Lib.sol";
 
 /**
@@ -13,15 +13,11 @@ import { EIP712Lib } from "../libs/EIP712Lib.sol";
  * - Defines hasRole function
  */
 library ClientLib {
-
     struct ProxyStorage {
-
         // The AccessController address
         IAccessControlUpgradeable accessController;
-
         // The ProtocolDiamond address
         address protocolDiamond;
-
         // The client implementation address
         address implementation;
     }
@@ -57,5 +53,4 @@ library ClientLib {
         ProxyStorage storage ps = proxyStorage();
         return ps.accessController.hasRole(role, EIP712Lib.msgSender());
     }
-
 }

--- a/contracts/protocol/libs/EIP712Lib.sol
+++ b/contracts/protocol/libs/EIP712Lib.sol
@@ -10,7 +10,8 @@ import { INVALID_SIGNATURE } from "../../domain/BosonConstants.sol";
  * @dev Provides the domain seperator and chain id.
  */
 library EIP712Lib {
-    bytes32 internal constant EIP712_DOMAIN_TYPEHASH = keccak256(bytes("EIP712Domain(string name,string version,address verifyingContract,bytes32 salt)"));
+    bytes32 internal constant EIP712_DOMAIN_TYPEHASH =
+        keccak256(bytes("EIP712Domain(string name,string version,address verifyingContract,bytes32 salt)"));
 
     /**
      * @notice Get the domain separator
@@ -19,9 +20,16 @@ library EIP712Lib {
      * @param _version -  The version of the protocol.
      */
     function domainSeparator(string memory _name, string memory _version) internal view returns (bytes32) {
-        return keccak256(
-            abi.encode(EIP712_DOMAIN_TYPEHASH, keccak256(bytes(_name)), keccak256(bytes(_version)), address(this), getChainID())
-        );
+        return
+            keccak256(
+                abi.encode(
+                    EIP712_DOMAIN_TYPEHASH,
+                    keccak256(bytes(_name)),
+                    keccak256(bytes(_version)),
+                    address(this),
+                    getChainID()
+                )
+            );
     }
 
     /**

--- a/contracts/protocol/libs/FundsLib.sol
+++ b/contracts/protocol/libs/FundsLib.sol
@@ -1,23 +1,45 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {NATIVE_NOT_ALLOWED, TOKEN_TRANSFER_FAILED, INSUFFICIENT_VALUE_SENT, INSUFFICIENT_AVAILABLE_FUNDS} from "../../domain/BosonConstants.sol";
-import {BosonTypes} from "../../domain/BosonTypes.sol";
-import {EIP712Lib} from "../libs/EIP712Lib.sol";
-import {ProtocolLib} from "../libs/ProtocolLib.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { NATIVE_NOT_ALLOWED, TOKEN_TRANSFER_FAILED, INSUFFICIENT_VALUE_SENT, INSUFFICIENT_AVAILABLE_FUNDS } from "../../domain/BosonConstants.sol";
+import { BosonTypes } from "../../domain/BosonTypes.sol";
+import { EIP712Lib } from "../libs/EIP712Lib.sol";
+import { ProtocolLib } from "../libs/ProtocolLib.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 /**
  * @title FundsLib
  *
- * @dev 
+ * @dev
  */
 library FundsLib {
-    event FundsEncumbered(uint256 indexed entityId, address indexed exchangeToken, uint256 amount, address indexed executedBy);
-    event FundsReleased(uint256 indexed exchangeId, uint256 indexed entityId, address indexed exchangeToken, uint256 amount, address executedBy);
-    event ProtocolFeeCollected(uint256 indexed exchangeId, address indexed exchangeToken, uint256 amount, address indexed executedBy);
-    event FundsWithdrawn(uint256 indexed sellerId, address indexed withdrawnTo, address indexed tokenAddress, uint256 amount, address executedBy); 
-    
+    event FundsEncumbered(
+        uint256 indexed entityId,
+        address indexed exchangeToken,
+        uint256 amount,
+        address indexed executedBy
+    );
+    event FundsReleased(
+        uint256 indexed exchangeId,
+        uint256 indexed entityId,
+        address indexed exchangeToken,
+        uint256 amount,
+        address executedBy
+    );
+    event ProtocolFeeCollected(
+        uint256 indexed exchangeId,
+        address indexed exchangeToken,
+        uint256 amount,
+        address indexed executedBy
+    );
+    event FundsWithdrawn(
+        uint256 indexed sellerId,
+        address indexed withdrawnTo,
+        address indexed tokenAddress,
+        uint256 amount,
+        address executedBy
+    );
+
     /**
      * @notice Takes in the offer id and buyer id and encumbers buyer's and seller's funds during the commitToOffer
      *
@@ -35,7 +57,7 @@ library FundsLib {
         // Load protocol entities storage
         ProtocolLib.ProtocolEntities storage pe = ProtocolLib.protocolEntities();
 
-        // fetch offer to get the exchange token, price and seller 
+        // fetch offer to get the exchange token, price and seller
         // this will be called only from commitToOffer so we expect that exchange actually exist
         BosonTypes.Offer storage offer = pe.offers[_offerId];
         address exchangeToken = offer.exchangeToken;
@@ -87,7 +109,6 @@ library FundsLib {
         // sum of price and sellerDeposit occurs multiple times
         uint256 pot = price + sellerDeposit;
 
-
         // calculate the payoffs depending on state exchange is in
         uint256 sellerPayoff;
         uint256 buyerPayoff;
@@ -107,7 +128,7 @@ library FundsLib {
             uint256 buyerCancelPenalty = offer.buyerCancelPenalty;
             sellerPayoff = sellerDeposit + buyerCancelPenalty;
             buyerPayoff = price - buyerCancelPenalty;
-        } else  {
+        } else {
             // DISPUTED
             // get the information about the dispute, which must exist
             BosonTypes.Dispute storage dispute = pe.disputes[_exchangeId];
@@ -124,7 +145,7 @@ library FundsLib {
                 buyerPayoff = price;
             } else {
                 // RESOLVED or DECIDED
-                buyerPayoff = pot * dispute.buyerPercent/10000;
+                buyerPayoff = (pot * dispute.buyerPercent) / 10000;
                 sellerPayoff = pot - buyerPayoff;
             }
         }
@@ -136,7 +157,7 @@ library FundsLib {
         if (sellerPayoff > 0) {
             increaseAvailableFunds(sellerId, exchangeToken, sellerPayoff);
             emit FundsReleased(_exchangeId, sellerId, exchangeToken, sellerPayoff, EIP712Lib.msgSender());
-        } 
+        }
         if (buyerPayoff > 0) {
             increaseAvailableFunds(buyerId, exchangeToken, buyerPayoff);
             emit FundsReleased(_exchangeId, buyerId, exchangeToken, buyerPayoff, EIP712Lib.msgSender());
@@ -144,7 +165,7 @@ library FundsLib {
         if (protocolFee > 0) {
             increaseAvailableFunds(0, exchangeToken, protocolFee);
             emit ProtocolFeeCollected(_exchangeId, exchangeToken, protocolFee, EIP712Lib.msgSender());
-        }        
+        }
     }
 
     /**
@@ -159,8 +180,9 @@ library FundsLib {
      */
     function transferFundsToProtocol(address _tokenAddress, uint256 _amount) internal {
         // transfer ERC20 tokens from the caller
-        try IERC20(_tokenAddress).transferFrom(EIP712Lib.msgSender(), address(this), _amount)  {
-        } catch (bytes memory error) {
+        try IERC20(_tokenAddress).transferFrom(EIP712Lib.msgSender(), address(this), _amount) {} catch (
+            bytes memory error
+        ) {
             string memory reason = error.length == 0 ? TOKEN_TRANSFER_FAILED : string(error);
             revert(reason);
         }
@@ -178,18 +200,22 @@ library FundsLib {
      * @param _to - address of the recepient
      * @param _amount - amount to be transferred
      */
-    function transferFundsFromProtocol(uint256 _entityId, address _tokenAddress, address payable _to, uint256 _amount) internal {
+    function transferFundsFromProtocol(
+        uint256 _entityId,
+        address _tokenAddress,
+        address payable _to,
+        uint256 _amount
+    ) internal {
         // first decrease the amount to prevent the reentrancy attack
-        FundsLib.decreaseAvailableFunds(_entityId, _tokenAddress, _amount); 
+        FundsLib.decreaseAvailableFunds(_entityId, _tokenAddress, _amount);
 
         // try to transfer the funds
         if (_tokenAddress == address(0)) {
             // transfer native currency
-            (bool success, ) = _to.call{value: _amount}("");
+            (bool success, ) = _to.call{ value: _amount }("");
             require(success, TOKEN_TRANSFER_FAILED);
         } else {
-            try IERC20(_tokenAddress).transfer(_to, _amount)  {
-            } catch (bytes memory error) {
+            try IERC20(_tokenAddress).transfer(_to, _amount) {} catch (bytes memory error) {
                 string memory reason = error.length == 0 ? TOKEN_TRANSFER_FAILED : string(error);
                 revert(reason);
             }
@@ -207,7 +233,11 @@ library FundsLib {
      * @param _amount - amount to be credited
      */
 
-    function increaseAvailableFunds(uint256 _entityId, address _tokenAddress, uint256 _amount) internal {
+    function increaseAvailableFunds(
+        uint256 _entityId,
+        address _tokenAddress,
+        uint256 _amount
+    ) internal {
         ProtocolLib.ProtocolLookups storage pl = ProtocolLib.protocolLookups();
 
         // if the current amount of token is 0, the token address must be added to the token list
@@ -229,7 +259,11 @@ library FundsLib {
      * @param _tokenAddress - funds contract address or zero address for native currency
      * @param _amount - amount to be taken away
      */
-    function decreaseAvailableFunds(uint256 _entityId, address _tokenAddress, uint256 _amount) internal {
+    function decreaseAvailableFunds(
+        uint256 _entityId,
+        address _tokenAddress,
+        uint256 _amount
+    ) internal {
         ProtocolLib.ProtocolLookups storage pl = ProtocolLib.protocolLookups();
 
         // get available fnds from storage
@@ -241,10 +275,10 @@ library FundsLib {
 
         // if availableFunds are totally emptied, the token address is removed from the seller's tokenList
         if (availableFunds == _amount) {
-            uint len = pl.tokenList[_entityId].length;
-            for (uint i = 0; i < len; i++) {
+            uint256 len = pl.tokenList[_entityId].length;
+            for (uint256 i = 0; i < len; i++) {
                 if (pl.tokenList[_entityId][i] == _tokenAddress) {
-                    pl.tokenList[_entityId][i] = pl.tokenList[_entityId][len-1];
+                    pl.tokenList[_entityId][i] = pl.tokenList[_entityId][len - 1];
                     pl.tokenList[_entityId].pop();
                     break;
                 }

--- a/contracts/protocol/libs/ProtocolLib.sol
+++ b/contracts/protocol/libs/ProtocolLib.sol
@@ -149,7 +149,7 @@ library ProtocolLib {
         // map function name to input type
         mapping(string => BosonTypes.MetaTxInputType) inputType;
         // map input type => hash info
-        mapping (BosonTypes.MetaTxInputType => BosonTypes.HashInfo) hashInfo;
+        mapping(BosonTypes.MetaTxInputType => BosonTypes.HashInfo) hashInfo;
     }
 
     // Individual facet initialization states
@@ -200,7 +200,7 @@ library ProtocolLib {
      * @return pl the protocol lookups slot
      */
     function protocolLookups() internal pure returns (ProtocolLookups storage pl) {
-        bytes32 position = PROTOCOL_LOOKUPS_POSITION; 
+        bytes32 position = PROTOCOL_LOOKUPS_POSITION;
         assembly {
             pl.slot := position
         }

--- a/package.json
+++ b/package.json
@@ -1,65 +1,65 @@
 {
-    "name": "@bosonprotocol/boson-protocol-contracts",
-    "version": "0.2.0",
-    "description": "Boson Protocol core exchange mechanism",
-    "author": "Boson Protocol Maintainers",
-    "license": "GPL-3.0-or-later",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/bosonprotocol/boson-protocol-contracts.git"
-    },
-    "bugs": {
-        "url": "https://github.com/bosonprotocol/boson-protocol-contracts/issues"
-    },
-    "homepage": "https://github.com/bosonprotocol/boson-protocol-contracts",
-    "keywords": [
-        "blockchain",
-        "boson",
-        "ethereum",
-        "nft",
-        "solidity",
-        "web3"
-    ],
-    "scripts": {
-        "build": "npx hardhat compile",
-        "test": "npx hardhat test",
-        "check:contracts": "solhint 'contracts/**/*.sol' && prettier --list-different contracts/**/*.sol",
-        "check:scripts": "eslint test/** && prettier --list-different test/** && eslint scripts/** && prettier --list-different scripts/**",
-        "tidy:contracts": "solhint --fix contracts/**/*.sol && prettier --write contracts/**/*.sol",
-        "tidy:scripts": "eslint --fix test/** && prettier --write test/** && eslint --fix scripts/** && prettier --write scripts/**",
-        "size": "npx hardhat size-contracts",
-        "coverage": "npx hardhat coverage",
-        "deploy-suite:local": "npx hardhat run --network hardhat scripts/deploy-suite.js",
-        "deploy-suite:test": "npx hardhat run --network test scripts/deploy-suite.js  >> logs/test.deploy.contracts.txt",
-        "deploy-suite:ropsten": "npx hardhat run --network ropsten scripts/deploy-suite.js >> logs/ropsten.deploy.contracts.txt",
-        "deploy-suite:mainnet": "npx hardhat run --network mainnet scripts/deploy-suite.js >> logs/mainnet.deploy.contracts.txt",
-        "manage-roles:ropsten": " npx hardhat --network ropsten run scripts/manage-roles.js >> logs/ropsten.manage.roles.txt",
-        "manage-roles:mainnet": " npx hardhat --network mainnet run scripts/manage-roles.js >> logs/mainnet.manage.roles.txt"
-    },
-    "dependencies": {
-        "@openzeppelin/contracts": "^4.4.2",
-        "@openzeppelin/contracts-upgradeable": "^4.4.2"
-    },
-    "devDependencies": {
-        "@nomiclabs/hardhat-ethers": "^2.0.4",
-        "@nomiclabs/hardhat-etherscan": "^3.0.0",
-        "@nomiclabs/hardhat-waffle": "^2.0.2",
-        "@nomiclabs/hardhat-web3": "^2.0.0",
-        "@openzeppelin/test-helpers": "^0.5.15",
-        "chai": "^4.3.6",
-        "dotenv": "^16.0.0",
-        "eip55": "^2.1.0",
-        "eslint": "^8.12.0",
-        "eslint-config-prettier": "^8.5.0",
-        "ethereum-waffle": "^3.4.0",
-        "ethers": "^5.5.4",
-        "hardhat": "^2.8.3",
-        "hardhat-contract-sizer": "^2.4.0",
-        "hardhat-gas-reporter": "^1.0.7",
-        "prettier": "^2.6.1",
-        "prettier-plugin-solidity": "^1.0.0-beta.19",
-        "solidity-coverage": "^0.7.18-eip165.0",
-        "solhint": "^3.3.7",
-        "web3": "^1.7.0"
-    }
+  "name": "@bosonprotocol/boson-protocol-contracts",
+  "version": "0.2.0",
+  "description": "Boson Protocol core exchange mechanism",
+  "author": "Boson Protocol Maintainers",
+  "license": "GPL-3.0-or-later",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bosonprotocol/boson-protocol-contracts.git"
+  },
+  "bugs": {
+    "url": "https://github.com/bosonprotocol/boson-protocol-contracts/issues"
+  },
+  "homepage": "https://github.com/bosonprotocol/boson-protocol-contracts",
+  "keywords": [
+    "blockchain",
+    "boson",
+    "ethereum",
+    "nft",
+    "solidity",
+    "web3"
+  ],
+  "scripts": {
+    "build": "npx hardhat compile",
+    "test": "npx hardhat test",
+    "check:contracts": "solhint 'contracts/**/*.sol' && prettier --list-different contracts/**",
+    "check:scripts": "eslint test/** && prettier --list-different test/** && eslint scripts/** && prettier --list-different scripts/**",
+    "tidy:contracts": "solhint --fix contracts/**/*.sol && prettier --write contracts/**",
+    "tidy:scripts": "eslint --fix test/** && prettier --write test/** && eslint --fix scripts/** && prettier --write scripts/**",
+    "size": "npx hardhat size-contracts",
+    "coverage": "npx hardhat coverage",
+    "deploy-suite:local": "npx hardhat run --network hardhat scripts/deploy-suite.js",
+    "deploy-suite:test": "npx hardhat run --network test scripts/deploy-suite.js  >> logs/test.deploy.contracts.txt",
+    "deploy-suite:ropsten": "npx hardhat run --network ropsten scripts/deploy-suite.js >> logs/ropsten.deploy.contracts.txt",
+    "deploy-suite:mainnet": "npx hardhat run --network mainnet scripts/deploy-suite.js >> logs/mainnet.deploy.contracts.txt",
+    "manage-roles:ropsten": " npx hardhat --network ropsten run scripts/manage-roles.js >> logs/ropsten.manage.roles.txt",
+    "manage-roles:mainnet": " npx hardhat --network mainnet run scripts/manage-roles.js >> logs/mainnet.manage.roles.txt"
+  },
+  "dependencies": {
+    "@openzeppelin/contracts": "^4.4.2",
+    "@openzeppelin/contracts-upgradeable": "^4.4.2"
+  },
+  "devDependencies": {
+    "@nomiclabs/hardhat-ethers": "^2.0.4",
+    "@nomiclabs/hardhat-etherscan": "^3.0.0",
+    "@nomiclabs/hardhat-waffle": "^2.0.2",
+    "@nomiclabs/hardhat-web3": "^2.0.0",
+    "@openzeppelin/test-helpers": "^0.5.15",
+    "chai": "^4.3.6",
+    "dotenv": "^16.0.0",
+    "eip55": "^2.1.0",
+    "eslint": "^8.12.0",
+    "eslint-config-prettier": "^8.5.0",
+    "ethereum-waffle": "^3.4.0",
+    "ethers": "^5.5.4",
+    "hardhat": "^2.8.3",
+    "hardhat-contract-sizer": "^2.4.0",
+    "hardhat-gas-reporter": "^1.0.7",
+    "prettier": "^2.6.1",
+    "prettier-plugin-solidity": "^1.0.0-beta.19",
+    "solidity-coverage": "^0.7.18-eip165.0",
+    "solhint": "^3.3.7",
+    "web3": "^1.7.0"
+  }
 }


### PR DESCRIPTION
## Code changes

- 🐛: I noticed that `tidy:contracts` and `check:contracts` were not running in subfolders of subfolders. These changes to the rest of the files are because I fixed it and ran `tidy:contracts`* again.

