### PR TITLE
Anyone can call completeExchange after fulfillment period has elapsed.

### DIFF
--- a/contracts/interfaces/handlers/IBosonExchangeHandler.sol
+++ b/contracts/interfaces/handlers/IBosonExchangeHandler.sol
@@ -44,8 +44,7 @@ interface IBosonExchangeHandler is IBosonExchangeEvents, IBosonFundsLibEvents {
      * Reverts if
      * - Exchange does not exist
      * - Exchange is not in redeemed state
-     * - Caller is not buyer or seller's operator
-     * - Caller is seller's operator and offer fulfillment period has not elapsed
+     * - Caller is not buyer and offer fulfillment period has not elapsed
      *
      * Emits
      * - ExchangeCompleted

--- a/test/protocol/ExchangeHandlerTest.js
+++ b/test/protocol/ExchangeHandlerTest.js
@@ -820,13 +820,33 @@ describe("IBosonExchangeHandler", function () {
           .withArgs(offerId, buyerId, exchange.id, operator.address);
       });
 
+      it("should emit an ExchangeCompleted event if anyone calls after fulfillment period", async function () {
+        // Set time forward to the offer's voucherRedeemableFrom
+        await setNextBlockTimestamp(Number(voucherRedeemableFrom));
+
+        // Redeem the voucher
+        await exchangeHandler.connect(buyer).redeemVoucher(exchange.id);
+
+        // Get the current block info
+        blockNumber = await ethers.provider.getBlockNumber();
+        block = await ethers.provider.getBlock(blockNumber);
+
+        // Set time forward to run out the fulfillment period
+        newTime = ethers.BigNumber.from(block.timestamp).add(fulfillmentPeriod).add(1).toNumber();
+        await setNextBlockTimestamp(newTime);
+
+        // Complete exchange
+        await expect(exchangeHandler.connect(rando).completeExchange(exchange.id))
+          .to.emit(exchangeHandler, "ExchangeCompleted")
+          .withArgs(offerId, buyerId, exchange.id, rando.address);
+      });
+
       context("💔 Revert Reasons", async function () {
         /*
          * Reverts if:
          * - Exchange does not exist
          * - Exchange is not in redeemed state
-         * - Caller is not buyer or seller's operator
-         * - Caller is seller's operator and offer fulfillment period has not elapsed
+         * - Caller is not buyer and offer fulfillment period has not elapsed
          */
 
         it("exchange id is invalid", async function () {
@@ -849,7 +869,7 @@ describe("IBosonExchangeHandler", function () {
           );
         });
 
-        it("caller is not buyer or seller's operator", async function () {
+        it("caller is not buyer and offer fulfillment period has not elapsed", async function () {
           // Set time forward to the offer's voucherRedeemableFrom
           await setNextBlockTimestamp(Number(voucherRedeemableFrom));
 
@@ -858,7 +878,7 @@ describe("IBosonExchangeHandler", function () {
 
           // Attempt to complete the exchange, expecting revert
           await expect(exchangeHandler.connect(rando).completeExchange(exchange.id)).to.revertedWith(
-            RevertReasons.NOT_BUYER_OR_SELLER
+            RevertReasons.FULFILLMENT_PERIOD_NOT_ELAPSED
           );
         });
 


### PR DESCRIPTION
View the [Asana card](https://app.asana.com/0/1200973286514456/1202561625701934) 

### Changes
* In ExchangeHandlerFacet.sol and IBosonExchangeHandler.sol,
  - changed revert reasons in docs for completeExchange method

* In ExchangeHandlerFacet.sol,
  - in completeExchange method,
    - remove call to get seller id / existence
    - if caller is not buyer or the buyer is not the buyer for this exchange, revert if fulfillment period has not elapsed

* In ExchangeHandlerTest.js,
  - in commitToOffer context,
    - added test
      - "should emit an ExchangeCompleted event if anyone calls after fulfillment period"
    - in Revert Reasons, added test
      - "caller is not buyer and offer fulfillment period has not elapsed"