### PR TITLE
removeTwin should make range available again 

### DIFF
--- a/contracts/protocol/facets/TwinHandlerFacet.sol
+++ b/contracts/protocol/facets/TwinHandlerFacet.sol
@@ -93,9 +93,11 @@ contract TwinHandlerFacet is IBosonTwinHandler, TwinBase {
         if (twin.tokenType == TokenType.NonFungibleToken) {
             TokenRange[] storage twinRanges = protocolLookups().twinRangesBySeller[sellerId][twin.tokenAddress];
             for (uint256 index = 0; index < twinRanges.length; index++) {
-                twinRanges[index] = twinRanges[twinRanges.length - 1];
-                twinRanges.pop();
-                break;
+                if (twinRanges[index].start == twin.tokenId) {
+                    twinRanges[index] = twinRanges[twinRanges.length - 1];
+                    twinRanges.pop();
+                    break;
+                }
             }
         }
 

--- a/test/protocol/TwinHandlerTest.js
+++ b/test/protocol/TwinHandlerTest.js
@@ -552,6 +552,21 @@ describe("IBosonTwinHandler", function () {
         expect(success).to.be.false;
       });
 
+      it("should make twin range available again if token type is NonFungible", async function () {
+        twin.tokenType = TokenType.NonFungibleToken;
+        twin.amount = "0";
+        const expectedNewTwinId = "2";
+
+        // Create a twin with range: [0,1499]
+        await twinHandler.connect(operator).createTwin(twin);
+
+        // Remove twin
+        await twinHandler.connect(operator).removeTwin(expectedNewTwinId);
+
+        // Twin range must be available and createTwin transaction with same range should succeed
+        await expect(twinHandler.connect(operator).createTwin(twin)).to.not.reverted;
+      });
+
       context("💔 Revert Reasons", async function () {
         it("Twin does not exist", async function () {
           let nonExistantTwinId = "999";


### PR DESCRIPTION
This PR fixes a bug when removing Twin. 

When removing a twin, we should loop twinRangesBySeller and remove the correct range.
The correct range will be the range whose start is equal to Twin tokenId. 

Thank you for reporting this on my [previous PR](https://github.com/bosonprotocol/boson-protocol-contracts/pull/208#discussion_r926290621) @zajck 
