### PR TITLE
Grant ADMIN role for test env deployment

### DIFF
--- a/scripts/deploy-suite.js
+++ b/scripts/deploy-suite.js
@@ -215,6 +215,14 @@ async function main() {
 
   //Verify on test node if test env
   if (hre.network.name === "test") {
+    //******TODO: This is a quick-and-dirty impl so that DRs can be activated in the test env. Will be replaced with a
+    //proper implementation for all networks!  *******/
+
+    // Grant admin role to an address that can execute certain functions in the test env.
+    await accessController.grantRole(Role.ADMIN, "0x57faFe1fB7C682216FCe44e50946C5249192b9D5");
+
+    console.log(`✅ Granted ADMIN role to appropriate test env address.`);
+
     await verifyOnTestEnv(contracts);
   }
 


### PR DESCRIPTION
This PR is the implementation of the quick-and-dirty solution to grant a test env address the ADMIN role so that DRs can be activated in the test env.  A proper solution for all networks that uses env variables and GitHub secrets will replace this solution in the near future.

I also modified the` activateDisputeResolver() `test cases. Previously, the deployer address, which has the PROTOCOL role, had been used. I had copied this from the ConfigHandlerTest.js. It's more appropriate for an address to have the ADMIN role when calling the `activateDisputeResolver()` function.
