### PR TITLE
Integration tests #4: Dispute resolver removes fee

### DIFF
--- a/test/integration/04-DR-removes-fees.js
+++ b/test/integration/04-DR-removes-fees.js
@@ -10,7 +10,6 @@ const {
   mockVoucherInitValues,
   mockOffer,
   mockDisputeResolver,
-  mockAgent,
   accountId,
   mockExchange,
   mockVoucher,
@@ -35,16 +34,16 @@ const {
 describe("DR removes fee", function () {
   let accountHandler, offerHandler, exchangeHandler, fundsHandler, disputeHandler;
   let expectedCloneAddress, emptyAuthToken, voucherInitValues;
-  let deployer, operator, admin, clerk, treasury, buyer, rando, operatorDR, adminDR, clerkDR, treasuryDR, agent;
+  let deployer, operator, admin, clerk, treasury, buyer, rando, operatorDR, adminDR, clerkDR, treasuryDR;
   let buyerEscalationDepositPercentage;
-  let buyerAccount, seller, disputeResolver, agentAccount;
+  let buyerAccount, seller, disputeResolver;
   let offer, offerDates, offerDurations, disputeResolverId;
   let exchangeId;
   let disputeResolverFeeNative;
 
   beforeEach(async function () {
     // Make accounts available
-    [deployer, operator, admin, clerk, treasury, buyer, rando, operatorDR, adminDR, clerkDR, treasuryDR, agent] =
+    [deployer, operator, admin, clerk, treasury, buyer, rando, operatorDR, adminDR, clerkDR, treasuryDR] =
       await ethers.getSigners();
 
     // Deploy the Protocol Diamond


### PR DESCRIPTION
This PR adds integration tests to check if operations remain possible after DR removes fees from the fees list. 

The following tests were added:
- Buyer should be able to commit to offer even when DR removes fee
- Buyer should be able to escalate a dispute even when DR removes fee
- DR should be able to decide dispute even when DR removes fee
- DR should be able to refuse to decide dispute even when DR removes fee