### PR TITLE
Remediate FHF-01M: Inexistent Validation of Token Type

### DIFF
--- a/contracts/protocol/bases/OfferBase.sol
+++ b/contracts/protocol/bases/OfferBase.sol
@@ -191,6 +191,8 @@ contract OfferBase is ProtocolBase, IBosonOfferEvents {
             }
         }
 
+            protocolLookups().acceptsToken[_offer.sellerId][_offer.exchangeToken] = true;
+
         // Get storage location for offer fees
         OfferFees storage offerFees = fetchOfferFees(_offer.id);
 

--- a/contracts/protocol/facets/FundsHandlerFacet.sol
+++ b/contracts/protocol/facets/FundsHandlerFacet.sol
@@ -49,10 +49,19 @@ contract FundsHandlerFacet is IBosonFundsHandler, ProtocolBase {
         uint256 _amount
     ) external payable override fundsNotPaused nonReentrant {
         // Check seller exists in sellers mapping
-        (bool exists, , ) = fetchSeller(_sellerId);
+        (bool exists, Seller storage seller, ) = fetchSeller(_sellerId);
 
         // Seller must exist
         require(exists, NO_SUCH_SELLER);
+
+        
+        
+        ProtocolLib.ProtocolLookups storage lookups = ProtocolLib.protocolLookups();
+
+        if(!lookups.acceptsToken[_sellerId][_tokenAddress]){
+            require(msgSender() == seller.operator , "TOKEN NOT ACCEPTED");
+            lookups.acceptsToken[_sellerId][_tokenAddress] = true;
+        }
 
         if (msg.value != 0) {
             // Receiving native currency

--- a/contracts/protocol/libs/ProtocolLib.sol
+++ b/contracts/protocol/libs/ProtocolLib.sol
@@ -124,6 +124,8 @@ library ProtocolLib {
         mapping(uint256 => uint256) groupIdByOffer;
         // offer id => agent id
         mapping(uint256 => uint256) agentIdByOffer;
+        // seller id => token address => acceptsToken
+        mapping(uint256 => mapping(address => bool)) acceptsToken;
         // seller operator address => sellerId
         mapping(address => uint256) sellerIdByOperator;
         // seller admin address => sellerId

--- a/test/protocol/OfferHandlerTest.js
+++ b/test/protocol/OfferHandlerTest.js
@@ -333,9 +333,14 @@ describe("IBosonOfferHandler", function () {
 
       it("should update state", async function () {
         // Create an offer
-        await offerHandler
-          .connect(operator)
-          .createOffer(offer, offerDates, offerDurations, disputeResolver.id, agentId);
+        for (let i = 0; i < 30; i++) {
+          await offerHandler
+            .connect(operator)
+            .createOffer(offer, offerDates, offerDurations, disputeResolver.id, agentId);
+        }
+        // await offerHandler
+        //   .connect(operator)
+        //   .createOffer(offer, offerDates, offerDurations, disputeResolver.id, agentId);
 
         // Get the offer as a struct
         [, offerStruct, offerDatesStruct, offerDurationsStruct, disputeResolutionTermsStruct, offerFeesStruct] =


### PR DESCRIPTION
We have decided not to remediate this. 
See @cliffhall  answer on https://github.com/bosonprotocol/boson-protocol-contracts/issues/322