### PR TITLE
CEA-02S: Inexistent Sanitization of Input Addresses

### DIFF
--- a/contracts/protocol/bases/ClientExternalAddressesBase.sol
+++ b/contracts/protocol/bases/ClientExternalAddressesBase.sol
@@ -63,9 +63,15 @@ contract ClientExternalAddressesBase is IClientExternalAddresses {
     /**
      * @notice Sets the implementation address.
      *
+     * Emits an Upgraded event.
+     *
+     * Reverts if _impl is the zero address
+     *
      * @param _impl - the implementation address
      */
     function setImplementation(address _impl) external override onlyRole(UPGRADER) {
+        require(_impl != address(0), INVALID_ADDRESS);
+
         // Get the ProxyStorage struct
         ClientLib.ProxyStorage storage ps = ClientLib.proxyStorage();
 
@@ -103,9 +109,13 @@ contract ClientExternalAddressesBase is IClientExternalAddresses {
      *
      * Emits a ProtocolAddressChanged event.
      *
+     * Reverts if _protocolAddress is the zero address
+     *
      * @param _protocolAddress - the ProtocolDiamond address
      */
     function setProtocolAddress(address _protocolAddress) external override onlyRole(UPGRADER) {
+        require(_protocolAddress != address(0), INVALID_ADDRESS);
+
         // Get the ProxyStorage struct
         ClientLib.ProxyStorage storage ps = ClientLib.proxyStorage();
 

--- a/test/protocol/clients/ClientExternalAddreses.js
+++ b/test/protocol/clients/ClientExternalAddreses.js
@@ -106,6 +106,13 @@ describe("IClientExternalAddresses", function () {
             RevertReasons.ACCESS_DENIED
           );
         });
+
+        it("implementation address is the zero address", async function () {
+          // Attempt to set new implementation, expecting revert
+          await expect(beacon.connect(deployer).setImplementation(ethers.constants.AddressZero)).to.revertedWith(
+            RevertReasons.INVALID_ADDRESS
+          );
+        });
       });
     });
 
@@ -135,6 +142,13 @@ describe("IClientExternalAddresses", function () {
           // Attempt to set new protocol address, expecting revert
           await expect(beacon.connect(rando).setProtocolAddress(protocolAddress)).to.revertedWith(
             RevertReasons.ACCESS_DENIED
+          );
+        });
+
+        it("protocol address is the zero address", async function () {
+          // Attempt to set new protocol address, expecting revert
+          await expect(beacon.connect(deployer).setProtocolAddress(ethers.constants.AddressZero)).to.revertedWith(
+            RevertReasons.INVALID_ADDRESS
           );
         });
       });


### PR DESCRIPTION
Added checks for zero address to `setImplementation` and `setProtocolAddress` in `ClientExternalAddreses`