### PR TITLE
Fix limit estimation script

### DIFF
--- a/scripts/util/estimate-limits.js
+++ b/scripts/util/estimate-limits.js
@@ -28,7 +28,7 @@ const {
   mockTwin,
   accountId,
 } = require("../../test/util/mock");
-const { setNextBlockTimestamp } = require("../util/test-utils.js");
+const { setNextBlockTimestamp } = require("../../test/util/utils.js");
 
 // Common vars
 let deployer,
@@ -841,8 +841,8 @@ async function setupCommonEnvironment() {
   const protocolConfig = [
     // Protocol addresses
     {
-      treasury: ethers.constants.AddressZero,
-      token: ethers.constants.AddressZero,
+      treasury: rando.address,
+      token: rando.address,
       voucherBeacon: beacon.address,
       beaconProxy: proxy.address,
     },
@@ -867,8 +867,8 @@ async function setupCommonEnvironment() {
     {
       percentage: protocolFeePercentage,
       flatBoson: protocolFeeFlatBoson,
+      buyerEscalationDepositPercentage,
     },
-    buyerEscalationDepositPercentage,
   ];
 
   await deployProtocolConfigFacet(protocolDiamond, protocolConfig, gasLimit);


### PR DESCRIPTION
Recent changes broke the limit estimation scripts, this PR fixes it.

Changes:
- fixed import of test utils
- fixed protocol config that is passed in during the deployment