### PR TITLE
Use tip to ensure each transaction's inclusion in the next block. 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,10 @@ DEPLOYER_GAS_LIMIT=10000000
 DEPLOYER_GAS_LIMIT_TEST=8000000
 
 # Number of confirmations to wait for after each transaction
-CONFIRMATIONS=1
+CONFIRMATIONS=3
+
+# Amount to multiply the suggested tip for each transaction
+TIP_MULTIPLIER=10
 
 # Etherscan API for verifying contracts on etherscan
 DEPLOYER_ETHERSCAN_API_KEY=000000000000000000000000000000000000000

--- a/environments.js
+++ b/environments.js
@@ -8,7 +8,9 @@
 require("dotenv").config();
 
 module.exports = {
+  // Transaction controls
   confirmations: parseInt(process.env.CONFIRMATIONS),
+  tipMultiplier: parseInt(process.env.TIP_MULTIPLIER),
 
   // Needed for verifying contract code on Etherscan
   etherscan: {

--- a/scripts/util/create-and-activate-DR.js
+++ b/scripts/util/create-and-activate-DR.js
@@ -3,7 +3,7 @@ const ethers = hre.ethers;
 const fs = require("fs").promises;
 const environments = require("../../environments");
 const network = hre.network.name;
-const confirmations = environments.confirmations;
+const confirmations = hre.network.name == "hardhat" ? 1 : environments.confirmations;
 const DisputeResolver = require("../../scripts/domain/DisputeResolver");
 const Role = require("../domain/Role");
 

--- a/scripts/util/deploy-mock-tokens.js
+++ b/scripts/util/deploy-mock-tokens.js
@@ -3,7 +3,7 @@ const { expect } = require("chai");
 const environments = require("../../environments");
 const ethers = hre.ethers;
 const network = hre.network.name;
-const confirmations = environments.confirmations;
+const confirmations = hre.network.name == "hardhat" ? 1 : environments.confirmations;
 
 /**
  * Deploy mock tokens for unit tests

--- a/scripts/util/deploy-protocol-client-beacons.js
+++ b/scripts/util/deploy-protocol-client-beacons.js
@@ -2,6 +2,7 @@ const hre = require("hardhat");
 const ethers = hre.ethers;
 const environments = require("../../environments");
 const confirmations = hre.network.name == "hardhat" ? 1 : environments.confirmations;
+const { getFees } = require("./utils");
 
 /**
  * Deploy the Protocol Client Beacon contracts
@@ -28,9 +29,11 @@ async function deployProtocolClientBeacons(protocolClients, protocolClientArgs, 
 
   // Deploy the ClientBeacon for BosonVoucher
   const ClientBeacon = await ethers.getContractFactory("BosonClientBeacon");
-  const clientBeacon = await ClientBeacon.deploy(...protocolClientArgs, bosonVoucherImpl.address, {
-    maxPriorityFeePerGas,
-  });
+  const clientBeacon = await ClientBeacon.deploy(
+    ...protocolClientArgs,
+    bosonVoucherImpl.address,
+    await getFees(maxPriorityFeePerGas)
+  );
   await clientBeacon.deployTransaction.wait(confirmations);
 
   return [clientBeacon];

--- a/scripts/util/deploy-protocol-client-beacons.js
+++ b/scripts/util/deploy-protocol-client-beacons.js
@@ -1,7 +1,7 @@
 const hre = require("hardhat");
 const ethers = hre.ethers;
 const environments = require("../../environments");
-const confirmations = environments.confirmations;
+const confirmations = hre.network.name == "hardhat" ? 1 : environments.confirmations;
 
 /**
  * Deploy the Protocol Client Beacon contracts

--- a/scripts/util/deploy-protocol-client-beacons.js
+++ b/scripts/util/deploy-protocol-client-beacons.js
@@ -17,10 +17,10 @@ const confirmations = environments.confirmations;
  *
  * @param protocolClients
  * @param protocolClientArgs
- * @param gasLimit - gasLimit for transactions
+ * @param maxPriorityFeePerGas - maxPriorityFeePerGas for transactions
  * @returns {Promise<(*|*|*)[]>}
  */
-async function deployProtocolClientBeacons(protocolClients, protocolClientArgs, gasLimit) {
+async function deployProtocolClientBeacons(protocolClients, protocolClientArgs, maxPriorityFeePerGas) {
   let bosonVoucherImpl;
 
   // Destructure the protocol client implementations
@@ -28,7 +28,9 @@ async function deployProtocolClientBeacons(protocolClients, protocolClientArgs, 
 
   // Deploy the ClientBeacon for BosonVoucher
   const ClientBeacon = await ethers.getContractFactory("BosonClientBeacon");
-  const clientBeacon = await ClientBeacon.deploy(...protocolClientArgs, bosonVoucherImpl.address, { gasLimit });
+  const clientBeacon = await ClientBeacon.deploy(...protocolClientArgs, bosonVoucherImpl.address, {
+    maxPriorityFeePerGas,
+  });
   await clientBeacon.deployTransaction.wait(confirmations);
 
   return [clientBeacon];

--- a/scripts/util/deploy-protocol-client-impls.js
+++ b/scripts/util/deploy-protocol-client-impls.js
@@ -14,13 +14,13 @@ const confirmations = environments.confirmations;
  *
  *  N.B. Intended for use with both test and deployment scripts
  *
- * @param gasLimit - gasLimit for transactions
+ * @param maxPriorityFeePerGas - maxPriorityFeePerGas for transactions
  * @returns {Promise<(*|*|*)[]>}
  */
-async function deployProtocolClientImpls(gasLimit) {
+async function deployProtocolClientImpls(maxPriorityFeePerGas) {
   // Deploy the BosonVoucher contract
   const BosonVoucher = await ethers.getContractFactory("BosonVoucher");
-  const bosonVoucher = await BosonVoucher.deploy({ gasLimit });
+  const bosonVoucher = await BosonVoucher.deploy({ maxPriorityFeePerGas });
   await bosonVoucher.deployTransaction.wait(confirmations);
 
   return [bosonVoucher];

--- a/scripts/util/deploy-protocol-client-impls.js
+++ b/scripts/util/deploy-protocol-client-impls.js
@@ -1,7 +1,7 @@
 const hre = require("hardhat");
 const ethers = hre.ethers;
 const environments = require("../../environments");
-const confirmations = environments.confirmations;
+const confirmations = hre.network.name == "hardhat" ? 1 : environments.confirmations;
 
 /**
  * Deploy the Protocol Client implementation contracts

--- a/scripts/util/deploy-protocol-client-impls.js
+++ b/scripts/util/deploy-protocol-client-impls.js
@@ -2,6 +2,7 @@ const hre = require("hardhat");
 const ethers = hre.ethers;
 const environments = require("../../environments");
 const confirmations = hre.network.name == "hardhat" ? 1 : environments.confirmations;
+const { getFees } = require("./utils");
 
 /**
  * Deploy the Protocol Client implementation contracts
@@ -20,7 +21,7 @@ const confirmations = hre.network.name == "hardhat" ? 1 : environments.confirmat
 async function deployProtocolClientImpls(maxPriorityFeePerGas) {
   // Deploy the BosonVoucher contract
   const BosonVoucher = await ethers.getContractFactory("BosonVoucher");
-  const bosonVoucher = await BosonVoucher.deploy({ maxPriorityFeePerGas });
+  const bosonVoucher = await BosonVoucher.deploy(await getFees(maxPriorityFeePerGas));
   await bosonVoucher.deployTransaction.wait(confirmations);
 
   return [bosonVoucher];

--- a/scripts/util/deploy-protocol-client-proxies.js
+++ b/scripts/util/deploy-protocol-client-proxies.js
@@ -1,7 +1,7 @@
 const hre = require("hardhat");
 const ethers = hre.ethers;
 const environments = require("../../environments");
-const confirmations = environments.confirmations;
+const confirmations = hre.network.name == "hardhat" ? 1 : environments.confirmations;
 
 /**
  * Deploy the Protocol Client Proxy contracts

--- a/scripts/util/deploy-protocol-client-proxies.js
+++ b/scripts/util/deploy-protocol-client-proxies.js
@@ -2,6 +2,7 @@ const hre = require("hardhat");
 const ethers = hre.ethers;
 const environments = require("../../environments");
 const confirmations = hre.network.name == "hardhat" ? 1 : environments.confirmations;
+const { getFees } = require("./utils");
 
 /**
  * Deploy the Protocol Client Proxy contracts
@@ -30,7 +31,7 @@ async function deployProtocolClientProxies(protocolClients, maxPriorityFeePerGas
 
   // Deploy the ClientProxy for BosonVoucher
   const ClientProxy = await ethers.getContractFactory("BeaconClientProxy");
-  const clientProxy = await ClientProxy.deploy({ maxPriorityFeePerGas });
+  const clientProxy = await ClientProxy.deploy(await getFees(maxPriorityFeePerGas));
   await clientProxy.deployTransaction.wait(confirmations);
 
   // init instead of constructors

--- a/scripts/util/deploy-protocol-client-proxies.js
+++ b/scripts/util/deploy-protocol-client-proxies.js
@@ -19,10 +19,10 @@ const confirmations = environments.confirmations;
  *
  * @param protocolClients
  * @param protocolClientArgs
- * @param gasLimit - gasLimit for transactions
+ * @param maxPriorityFeePerGas - maxPriorityFeePerGas for transactions
  * @returns {Promise<(*|*|*)[]>}
  */
-async function deployProtocolClientProxies(protocolClients, gasLimit) {
+async function deployProtocolClientProxies(protocolClients, maxPriorityFeePerGas) {
   let bosonClientBeacon;
 
   // Destructure the protocol client implementations
@@ -30,7 +30,7 @@ async function deployProtocolClientProxies(protocolClients, gasLimit) {
 
   // Deploy the ClientProxy for BosonVoucher
   const ClientProxy = await ethers.getContractFactory("BeaconClientProxy");
-  const clientProxy = await ClientProxy.deploy({ gasLimit });
+  const clientProxy = await ClientProxy.deploy({ maxPriorityFeePerGas });
   await clientProxy.deployTransaction.wait(confirmations);
 
   // init instead of constructors

--- a/scripts/util/deploy-protocol-client-proxies.js
+++ b/scripts/util/deploy-protocol-client-proxies.js
@@ -35,7 +35,10 @@ async function deployProtocolClientProxies(protocolClients, maxPriorityFeePerGas
   await clientProxy.deployTransaction.wait(confirmations);
 
   // init instead of constructors
-  let transactionResponse = await clientProxy.initialize(bosonClientBeacon.address);
+  let transactionResponse = await clientProxy.initialize(
+    bosonClientBeacon.address,
+    await getFees(maxPriorityFeePerGas)
+  );
   await transactionResponse.wait(confirmations);
 
   return [clientProxy];

--- a/scripts/util/deploy-protocol-clients.js
+++ b/scripts/util/deploy-protocol-clients.js
@@ -15,18 +15,22 @@ const { castProtocolClientProxies } = require("./cast-protocol-client-proxies.js
  *  N.B. Intended for use with both test and deployment scripts
  *
  * @param protocolClientArgs
- * @param gasLimit - gasLimit for transactions
+ * @param maxPriorityFeePerGas - maxPriorityFeePerGas for transactions
  * @returns {Promise<(*|*|*)[]>}
  */
-async function deployProtocolClients(protocolClientArgs, gasLimit) {
+async function deployProtocolClients(protocolClientArgs, maxPriorityFeePerGas) {
   // Deploy Protocol Client implementation contracts
-  const protocolClientImpls = await deployProtocolClientImpls(gasLimit);
+  const protocolClientImpls = await deployProtocolClientImpls(maxPriorityFeePerGas);
 
   // Deploy Protocol Client beacon contracts
-  const protocolClientBeacons = await deployProtocolClientBeacons(protocolClientImpls, protocolClientArgs, gasLimit);
+  const protocolClientBeacons = await deployProtocolClientBeacons(
+    protocolClientImpls,
+    protocolClientArgs,
+    maxPriorityFeePerGas
+  );
 
   // Deploy Protocol Client proxy contracts
-  const protocolClientProxies = await deployProtocolClientProxies(protocolClientBeacons, gasLimit);
+  const protocolClientProxies = await deployProtocolClientProxies(protocolClientBeacons, maxPriorityFeePerGas);
 
   // Cast the proxies to their implementation interfaces
   const protocolClients = await castProtocolClientProxies(protocolClientProxies);

--- a/scripts/util/deploy-protocol-config-facet.js
+++ b/scripts/util/deploy-protocol-config-facet.js
@@ -2,7 +2,7 @@ const { getFacetAddCut } = require("./diamond-utils.js");
 const hre = require("hardhat");
 const ethers = hre.ethers;
 const environments = require("../../environments");
-const confirmations = environments.confirmations;
+const confirmations = hre.network.name == "hardhat" ? 1 : environments.confirmations;
 
 /**
  * Cut the Config Handler facet

--- a/scripts/util/deploy-protocol-config-facet.js
+++ b/scripts/util/deploy-protocol-config-facet.js
@@ -3,6 +3,7 @@ const hre = require("hardhat");
 const ethers = hre.ethers;
 const environments = require("../../environments");
 const confirmations = hre.network.name == "hardhat" ? 1 : environments.confirmations;
+const { getFees } = require("./utils");
 
 /**
  * Cut the Config Handler facet
@@ -18,7 +19,7 @@ const confirmations = hre.network.name == "hardhat" ? 1 : environments.confirmat
 async function deployProtocolConfigFacet(diamond, config, maxPriorityFeePerGas) {
   // Deploy the ConfigHandler Facet
   const ConfigHandlerFacet = await ethers.getContractFactory("ConfigHandlerFacet");
-  const configHandlerFacet = await ConfigHandlerFacet.deploy({ maxPriorityFeePerGas });
+  const configHandlerFacet = await ConfigHandlerFacet.deploy(await getFees(maxPriorityFeePerGas));
   await configHandlerFacet.deployTransaction.wait(confirmations);
 
   // Cast Diamond to DiamondCutFacet
@@ -27,9 +28,12 @@ async function deployProtocolConfigFacet(diamond, config, maxPriorityFeePerGas) 
   // Cut ConfigHandler facet, initializing
   const configCallData = ConfigHandlerFacet.interface.encodeFunctionData("initialize", config);
   const configHandlerCut = getFacetAddCut(configHandlerFacet, [configCallData.slice(0, 10)]);
-  const diamondCut = await cutFacet.diamondCut([configHandlerCut], configHandlerFacet.address, configCallData, {
-    maxPriorityFeePerGas,
-  });
+  const diamondCut = await cutFacet.diamondCut(
+    [configHandlerCut],
+    configHandlerFacet.address,
+    configCallData,
+    await getFees(maxPriorityFeePerGas)
+  );
 
   await diamondCut.wait(confirmations);
 

--- a/scripts/util/deploy-protocol-config-facet.js
+++ b/scripts/util/deploy-protocol-config-facet.js
@@ -12,13 +12,13 @@ const confirmations = environments.confirmations;
  *
  * @param diamond
  * @param config
- * @param gasLimit - gasLimit for transactions
+ * @param maxPriorityFeePerGas - maxPriorityFeePerGas for transactions
  * @returns {Promise<(*|*|*)[]>}
  */
-async function deployProtocolConfigFacet(diamond, config, gasLimit) {
+async function deployProtocolConfigFacet(diamond, config, maxPriorityFeePerGas) {
   // Deploy the ConfigHandler Facet
   const ConfigHandlerFacet = await ethers.getContractFactory("ConfigHandlerFacet");
-  const configHandlerFacet = await ConfigHandlerFacet.deploy({ gasLimit });
+  const configHandlerFacet = await ConfigHandlerFacet.deploy({ maxPriorityFeePerGas });
   await configHandlerFacet.deployTransaction.wait(confirmations);
 
   // Cast Diamond to DiamondCutFacet
@@ -28,7 +28,7 @@ async function deployProtocolConfigFacet(diamond, config, gasLimit) {
   const configCallData = ConfigHandlerFacet.interface.encodeFunctionData("initialize", config);
   const configHandlerCut = getFacetAddCut(configHandlerFacet, [configCallData.slice(0, 10)]);
   const diamondCut = await cutFacet.diamondCut([configHandlerCut], configHandlerFacet.address, configCallData, {
-    gasLimit,
+    maxPriorityFeePerGas,
   });
 
   await diamondCut.wait(confirmations);

--- a/scripts/util/deploy-protocol-diamond.js
+++ b/scripts/util/deploy-protocol-diamond.js
@@ -10,10 +10,10 @@ const confirmations = environments.confirmations;
  *
  * Reused between deployment script and unit tests for consistency
  *
- * @param gasLimit - gasLimit for transactions
+ * @param maxPriorityFeePerGas - maxPriorityFeePerGas for transactions
  * @returns {Promise<(*|*|*)[]>}
  */
-async function deployProtocolDiamond(gasLimit) {
+async function deployProtocolDiamond(maxPriorityFeePerGas) {
   // Get interface Ids
   const InterfaceIds = await getInterfaceIds();
 
@@ -22,22 +22,22 @@ async function deployProtocolDiamond(gasLimit) {
 
   // Deploy the AccessController contract
   const AccessController = await ethers.getContractFactory("AccessController");
-  const accessController = await AccessController.deploy({ gasLimit });
+  const accessController = await AccessController.deploy({ maxPriorityFeePerGas });
   await accessController.deployTransaction.wait(confirmations);
 
   // Diamond Loupe Facet
   const DiamondLoupeFacet = await ethers.getContractFactory("DiamondLoupeFacet");
-  const dlf = await DiamondLoupeFacet.deploy({ gasLimit });
+  const dlf = await DiamondLoupeFacet.deploy({ maxPriorityFeePerGas });
   await dlf.deployTransaction.wait(confirmations);
 
   // Diamond Cut Facet
   const DiamondCutFacet = await ethers.getContractFactory("DiamondCutFacet");
-  const dcf = await DiamondCutFacet.deploy({ gasLimit });
+  const dcf = await DiamondCutFacet.deploy({ maxPriorityFeePerGas });
   await dcf.deployTransaction.wait(confirmations);
 
   // ERC165 Facet
   const ERC165Facet = await ethers.getContractFactory("ERC165Facet");
-  const erc165f = await ERC165Facet.deploy({ gasLimit });
+  const erc165f = await ERC165Facet.deploy({ maxPriorityFeePerGas });
   await erc165f.deployTransaction.wait(confirmations);
 
   // Arguments for Diamond constructor
@@ -49,7 +49,7 @@ async function deployProtocolDiamond(gasLimit) {
 
   // Deploy Protocol Diamond
   const ProtocolDiamond = await ethers.getContractFactory("ProtocolDiamond");
-  const protocolDiamond = await ProtocolDiamond.deploy(...diamondArgs, { gasLimit });
+  const protocolDiamond = await ProtocolDiamond.deploy(...diamondArgs, { maxPriorityFeePerGas });
   await protocolDiamond.deployTransaction.wait(confirmations);
 
   return [protocolDiamond, dlf, dcf, erc165f, accessController, diamondArgs];

--- a/scripts/util/deploy-protocol-diamond.js
+++ b/scripts/util/deploy-protocol-diamond.js
@@ -4,6 +4,7 @@ const hre = require("hardhat");
 const ethers = hre.ethers;
 const environments = require("../../environments");
 const confirmations = hre.network.name == "hardhat" ? 1 : environments.confirmations;
+const { getFees } = require("./utils");
 
 /**
  * Deploy the ProtocolDiamond
@@ -22,22 +23,22 @@ async function deployProtocolDiamond(maxPriorityFeePerGas) {
 
   // Deploy the AccessController contract
   const AccessController = await ethers.getContractFactory("AccessController");
-  const accessController = await AccessController.deploy({ maxPriorityFeePerGas });
+  const accessController = await AccessController.deploy(await getFees(maxPriorityFeePerGas));
   await accessController.deployTransaction.wait(confirmations);
 
   // Diamond Loupe Facet
   const DiamondLoupeFacet = await ethers.getContractFactory("DiamondLoupeFacet");
-  const dlf = await DiamondLoupeFacet.deploy({ maxPriorityFeePerGas });
+  const dlf = await DiamondLoupeFacet.deploy(await getFees(maxPriorityFeePerGas));
   await dlf.deployTransaction.wait(confirmations);
 
   // Diamond Cut Facet
   const DiamondCutFacet = await ethers.getContractFactory("DiamondCutFacet");
-  const dcf = await DiamondCutFacet.deploy({ maxPriorityFeePerGas });
+  const dcf = await DiamondCutFacet.deploy(await getFees(maxPriorityFeePerGas));
   await dcf.deployTransaction.wait(confirmations);
 
   // ERC165 Facet
   const ERC165Facet = await ethers.getContractFactory("ERC165Facet");
-  const erc165f = await ERC165Facet.deploy({ maxPriorityFeePerGas });
+  const erc165f = await ERC165Facet.deploy(await getFees(maxPriorityFeePerGas));
   await erc165f.deployTransaction.wait(confirmations);
 
   // Arguments for Diamond constructor
@@ -49,7 +50,7 @@ async function deployProtocolDiamond(maxPriorityFeePerGas) {
 
   // Deploy Protocol Diamond
   const ProtocolDiamond = await ethers.getContractFactory("ProtocolDiamond");
-  const protocolDiamond = await ProtocolDiamond.deploy(...diamondArgs, { maxPriorityFeePerGas });
+  const protocolDiamond = await ProtocolDiamond.deploy(...diamondArgs, await getFees(maxPriorityFeePerGas));
   await protocolDiamond.deployTransaction.wait(confirmations);
 
   return [protocolDiamond, dlf, dcf, erc165f, accessController, diamondArgs];

--- a/scripts/util/deploy-protocol-diamond.js
+++ b/scripts/util/deploy-protocol-diamond.js
@@ -3,7 +3,7 @@ const { getInterfaceIds } = require("../config/supported-interfaces.js");
 const hre = require("hardhat");
 const ethers = hre.ethers;
 const environments = require("../../environments");
-const confirmations = environments.confirmations;
+const confirmations = hre.network.name == "hardhat" ? 1 : environments.confirmations;
 
 /**
  * Deploy the ProtocolDiamond

--- a/scripts/util/deploy-protocol-handler-facets.js
+++ b/scripts/util/deploy-protocol-handler-facets.js
@@ -11,17 +11,17 @@ const confirmations = environments.confirmations;
  *
  * @param diamond
  * @param facetNames - list of facet names to deploy and cut
- * @param gasLimit - gasLimit for transactions
+ * @param maxPriorityFeePerGas - maxPriorityFeePerGas for transactions
  * @returns {Promise<(*|*|*)[]>}
  */
-async function deployProtocolHandlerFacets(diamond, facetNames, gasLimit) {
+async function deployProtocolHandlerFacets(diamond, facetNames, maxPriorityFeePerGas) {
   let deployedFacets = [];
 
   // Deploy all the no-arg initializer handler facets
   while (facetNames.length) {
     let facetName = facetNames.shift();
     let FacetContractFactory = await ethers.getContractFactory(facetName);
-    const facetContract = await FacetContractFactory.deploy({ gasLimit });
+    const facetContract = await FacetContractFactory.deploy({ maxPriorityFeePerGas });
     await facetContract.deployTransaction.wait(confirmations);
 
     deployedFacets.push({
@@ -43,7 +43,7 @@ async function deployProtocolHandlerFacets(diamond, facetNames, gasLimit) {
     const deployedFacet = deployedFacets[i];
     const facetCut = getFacetAddCut(deployedFacet.contract, [initFunction]);
     const transactionResponse = await diamondCutFacet.diamondCut([facetCut], deployedFacet.contract.address, callData, {
-      gasLimit,
+      maxPriorityFeePerGas,
     });
     await transactionResponse.wait(confirmations);
   }

--- a/scripts/util/deploy-protocol-handler-facets.js
+++ b/scripts/util/deploy-protocol-handler-facets.js
@@ -2,7 +2,7 @@ const { getFacetAddCut } = require("./diamond-utils.js");
 const hre = require("hardhat");
 const ethers = hre.ethers;
 const environments = require("../../environments");
-const confirmations = environments.confirmations;
+const confirmations = hre.network.name == "hardhat" ? 1 : environments.confirmations;
 
 /**
  * Cut the Protocol Handler facets

--- a/test/integration/04-DR-removes-fees.js
+++ b/test/integration/04-DR-removes-fees.js
@@ -2,7 +2,6 @@ const hre = require("hardhat");
 const ethers = hre.ethers;
 const { expect } = require("chai");
 
-const { gasLimit } = require("../../environments");
 const {
   mockBuyer,
   mockSeller,
@@ -20,7 +19,7 @@ const { deployProtocolDiamond } = require("../../scripts/util/deploy-protocol-di
 const { deployProtocolHandlerFacets } = require("../../scripts/util/deploy-protocol-handler-facets.js");
 const { deployProtocolConfigFacet } = require("../../scripts/util/deploy-protocol-config-facet.js");
 const { deployProtocolClients } = require("../../scripts/util/deploy-protocol-clients");
-const { oneMonth, oneWeek } = require("../util/constants");
+const { oneMonth, oneWeek, maxPriorityFeePerGas } = require("../util/constants");
 const { setNextBlockTimestamp, calculateContractAddress, applyPercentage } = require("../util/utils.js");
 
 /**
@@ -57,7 +56,7 @@ describe("[@skip-on-coverage] DR removes fee", function () {
     operatorDR = clerkDR = adminDR;
 
     // Deploy the Protocol Diamond
-    const [protocolDiamond, , , , accessController] = await deployProtocolDiamond();
+    const [protocolDiamond, , , , accessController] = await deployProtocolDiamond(maxPriorityFeePerGas);
 
     // Temporarily grant UPGRADER role to deployer account
     await accessController.grantRole(Role.UPGRADER, deployer.address);
@@ -66,21 +65,25 @@ describe("[@skip-on-coverage] DR removes fee", function () {
     await accessController.grantRole(Role.PROTOCOL, protocolDiamond.address);
 
     // Cut the protocol handler facets into the Diamond
-    await deployProtocolHandlerFacets(protocolDiamond, [
-      "AccountHandlerFacet",
-      "SellerHandlerFacet",
-      "BuyerHandlerFacet",
-      "DisputeResolverHandlerFacet",
-      "AgentHandlerFacet",
-      "OfferHandlerFacet",
-      "ExchangeHandlerFacet",
-      "FundsHandlerFacet",
-      "DisputeHandlerFacet",
-    ]);
+    await deployProtocolHandlerFacets(
+      protocolDiamond,
+      [
+        "AccountHandlerFacet",
+        "SellerHandlerFacet",
+        "BuyerHandlerFacet",
+        "DisputeResolverHandlerFacet",
+        "AgentHandlerFacet",
+        "OfferHandlerFacet",
+        "ExchangeHandlerFacet",
+        "FundsHandlerFacet",
+        "DisputeHandlerFacet",
+      ],
+      maxPriorityFeePerGas
+    );
 
     // Deploy the Protocol client implementation/proxy pairs (currently just the Boson Voucher)
     const protocolClientArgs = [protocolDiamond.address];
-    const [, beacons, proxies] = await deployProtocolClients(protocolClientArgs, gasLimit);
+    const [, beacons, proxies] = await deployProtocolClients(protocolClientArgs, maxPriorityFeePerGas);
     const [beacon] = beacons;
     const [proxy] = proxies;
 
@@ -123,7 +126,7 @@ describe("[@skip-on-coverage] DR removes fee", function () {
       },
     ];
 
-    await deployProtocolConfigFacet(protocolDiamond, protocolConfig, gasLimit);
+    await deployProtocolConfigFacet(protocolDiamond, protocolConfig, maxPriorityFeePerGas);
 
     // Cast Diamond to IBosonAccountHandler. Use this interface to call all individual account handlers
     accountHandler = await ethers.getContractAt("IBosonAccountHandler", protocolDiamond.address);

--- a/test/protocol/BundleHandlerTest.js
+++ b/test/protocol/BundleHandlerTest.js
@@ -24,7 +24,7 @@ const {
   mockAuthToken,
   accountId,
 } = require("../util/mock");
-const { oneWeek, oneMonth } = require("../util/constants");
+const { oneWeek, oneMonth, maxPriorityFeePerGas } = require("../util/constants");
 
 /**
  *  Test the Boson Bundle Handler interface
@@ -99,7 +99,7 @@ describe("IBosonBundleHandler", function () {
     operatorDR = clerkDR = adminDR;
 
     // Deploy the Protocol Diamond
-    [protocolDiamond, , , , accessController] = await deployProtocolDiamond();
+    [protocolDiamond, , , , accessController] = await deployProtocolDiamond(maxPriorityFeePerGas);
 
     // Temporarily grant UPGRADER role to deployer account
     await accessController.grantRole(Role.UPGRADER, deployer.address);
@@ -111,20 +111,24 @@ describe("IBosonBundleHandler", function () {
     await accessController.grantRole(Role.PAUSER, pauser.address);
 
     // Cut the protocol handler facets into the Diamond
-    await deployProtocolHandlerFacets(protocolDiamond, [
-      "SellerHandlerFacet",
-      "DisputeResolverHandlerFacet",
-      "TwinHandlerFacet",
-      "OfferHandlerFacet",
-      "BundleHandlerFacet",
-      "ExchangeHandlerFacet",
-      "FundsHandlerFacet",
-      "PauseHandlerFacet",
-    ]);
+    await deployProtocolHandlerFacets(
+      protocolDiamond,
+      [
+        "SellerHandlerFacet",
+        "DisputeResolverHandlerFacet",
+        "TwinHandlerFacet",
+        "OfferHandlerFacet",
+        "BundleHandlerFacet",
+        "ExchangeHandlerFacet",
+        "FundsHandlerFacet",
+        "PauseHandlerFacet",
+      ],
+      maxPriorityFeePerGas
+    );
 
     // Deploy the Protocol client implementation/proxy pairs (currently just the Boson Voucher)
     const protocolClientArgs = [protocolDiamond.address];
-    const [, beacons, proxies] = await deployProtocolClients(protocolClientArgs, gasLimit);
+    const [, beacons, proxies] = await deployProtocolClients(protocolClientArgs, maxPriorityFeePerGas);
     const [beacon] = beacons;
     const [proxy] = proxies;
 
@@ -170,7 +174,7 @@ describe("IBosonBundleHandler", function () {
       },
     ];
     // Deploy the Config facet, initializing the protocol config
-    await deployProtocolConfigFacet(protocolDiamond, protocolConfig, gasLimit);
+    await deployProtocolConfigFacet(protocolDiamond, protocolConfig, maxPriorityFeePerGas);
 
     // Cast Diamond to IERC165
     erc165 = await ethers.getContractAt("ERC165Facet", protocolDiamond.address);

--- a/test/protocol/BuyerHandlerTest.js
+++ b/test/protocol/BuyerHandlerTest.js
@@ -12,7 +12,7 @@ const { deployProtocolHandlerFacets } = require("../../scripts/util/deploy-proto
 const { deployProtocolConfigFacet } = require("../../scripts/util/deploy-protocol-config-facet.js");
 const { deployProtocolClients } = require("../../scripts/util/deploy-protocol-clients");
 const { calculateContractAddress } = require("../util/utils.js");
-const { oneWeek, oneMonth } = require("../util/constants");
+const { oneWeek, oneMonth, maxPriorityFeePerGas } = require("../util/constants");
 const {
   mockOffer,
   mockSeller,
@@ -41,14 +41,7 @@ describe("BuyerHandler", function () {
     other4,
     protocolTreasury,
     bosonToken;
-  let protocolDiamond,
-    accessController,
-    accountHandler,
-    exchangeHandler,
-    offerHandler,
-    fundsHandler,
-    pauseHandler,
-    gasLimit;
+  let protocolDiamond, accessController, accountHandler, exchangeHandler, offerHandler, fundsHandler, pauseHandler;
   let seller;
   let emptyAuthToken;
   let buyer, buyerStruct, buyer2, buyer2Struct, expectedBuyer, expectedBuyerStruct;
@@ -70,7 +63,7 @@ describe("BuyerHandler", function () {
     operator = clerk = admin;
 
     // Deploy the Protocol Diamond
-    [protocolDiamond, , , , accessController] = await deployProtocolDiamond();
+    [protocolDiamond, , , , accessController] = await deployProtocolDiamond(maxPriorityFeePerGas);
 
     // Temporarily grant UPGRADER role to deployer account
     await accessController.grantRole(Role.UPGRADER, deployer.address);
@@ -82,20 +75,24 @@ describe("BuyerHandler", function () {
     await accessController.grantRole(Role.PAUSER, pauser.address);
 
     // Cut the protocol handler facets into the Diamond
-    await deployProtocolHandlerFacets(protocolDiamond, [
-      "AccountHandlerFacet",
-      "SellerHandlerFacet",
-      "BuyerHandlerFacet",
-      "DisputeResolverHandlerFacet",
-      "ExchangeHandlerFacet",
-      "OfferHandlerFacet",
-      "FundsHandlerFacet",
-      "PauseHandlerFacet",
-    ]);
+    await deployProtocolHandlerFacets(
+      protocolDiamond,
+      [
+        "AccountHandlerFacet",
+        "SellerHandlerFacet",
+        "BuyerHandlerFacet",
+        "DisputeResolverHandlerFacet",
+        "ExchangeHandlerFacet",
+        "OfferHandlerFacet",
+        "FundsHandlerFacet",
+        "PauseHandlerFacet",
+      ],
+      maxPriorityFeePerGas
+    );
 
     // Deploy the Protocol client implementation/proxy pairs (currently just the Boson Voucher)
     const protocolClientArgs = [protocolDiamond.address];
-    const [, beacons, proxies] = await deployProtocolClients(protocolClientArgs, gasLimit);
+    const [, beacons, proxies] = await deployProtocolClients(protocolClientArgs, maxPriorityFeePerGas);
     const [beacon] = beacons;
     const [proxy] = proxies;
 
@@ -138,7 +135,7 @@ describe("BuyerHandler", function () {
       },
     ];
 
-    await deployProtocolConfigFacet(protocolDiamond, protocolConfig, gasLimit);
+    await deployProtocolConfigFacet(protocolDiamond, protocolConfig, maxPriorityFeePerGas);
 
     // Cast Diamond to IBosonAccountHandler. Use this interface to call all individual account handler
     accountHandler = await ethers.getContractAt("IBosonAccountHandler", protocolDiamond.address);

--- a/test/protocol/ConfigHandlerTest.js
+++ b/test/protocol/ConfigHandlerTest.js
@@ -7,7 +7,7 @@ const { getInterfaceIds } = require("../../scripts/config/supported-interfaces.j
 const { RevertReasons } = require("../../scripts/config/revert-reasons.js");
 const { deployProtocolDiamond } = require("../../scripts/util/deploy-protocol-diamond.js");
 const { deployProtocolConfigFacet } = require("../../scripts/util/deploy-protocol-config-facet.js");
-const { oneWeek, oneMonth } = require("../util/constants");
+const { oneWeek, oneMonth, maxPriorityFeePerGas } = require("../util/constants");
 const AuthTokenType = require("../../scripts/domain/AuthTokenType");
 
 /**
@@ -33,7 +33,7 @@ describe("IBosonConfigHandler", function () {
     maxResolutionPeriod,
     minDisputePeriod;
   let protocolFeePercentage, protocolFeeFlatBoson;
-  let erc165, protocolDiamond, accessController, configHandler, gasLimit;
+  let erc165, protocolDiamond, accessController, configHandler;
   let authTokenContract;
 
   before(async function () {
@@ -52,7 +52,7 @@ describe("IBosonConfigHandler", function () {
     proxy = accounts[5];
 
     // Deploy the Protocol Diamond
-    [protocolDiamond, , , , accessController] = await deployProtocolDiamond();
+    [protocolDiamond, , , , accessController] = await deployProtocolDiamond(maxPriorityFeePerGas);
 
     // Temporarily grant UPGRADER role to deployer account
     await accessController.grantRole(Role.UPGRADER, deployer.address);
@@ -119,7 +119,11 @@ describe("IBosonConfigHandler", function () {
           },
         ];
 
-        const { cutTransaction } = await deployProtocolConfigFacet(protocolDiamond, protocolConfig, gasLimit);
+        const { cutTransaction } = await deployProtocolConfigFacet(
+          protocolDiamond,
+          protocolConfig,
+          maxPriorityFeePerGas
+        );
 
         await expect(cutTransaction)
           .to.emit(configHandler, "TokenAddressChanged")
@@ -239,7 +243,7 @@ describe("IBosonConfigHandler", function () {
           buyerEscalationDepositPercentage,
         },
       ];
-      await deployProtocolConfigFacet(protocolDiamond, protocolConfig, gasLimit);
+      await deployProtocolConfigFacet(protocolDiamond, protocolConfig, maxPriorityFeePerGas);
     });
 
     // Interface support (ERC-156 provided by ProtocolDiamond, others by deployed facets)

--- a/test/protocol/DisputeHandlerTest.js
+++ b/test/protocol/DisputeHandlerTest.js
@@ -17,7 +17,7 @@ const { deployProtocolConfigFacet } = require("../../scripts/util/deploy-protoco
 const { deployProtocolClients } = require("../../scripts/util/deploy-protocol-clients");
 const { deployMockTokens } = require("../../scripts/util/deploy-mock-tokens");
 const { setNextBlockTimestamp, prepareDataSignatureParameters, applyPercentage } = require("../util/utils.js");
-const { oneWeek, oneMonth } = require("../util/constants");
+const { oneWeek, oneMonth, maxPriorityFeePerGas } = require("../util/constants");
 const {
   mockOffer,
   mockDisputeResolver,
@@ -100,7 +100,7 @@ describe("IBosonDisputeHandler", function () {
     operatorDR = clerkDR = adminDR;
 
     // Deploy the Protocol Diamond
-    [protocolDiamond, , , , accessController] = await deployProtocolDiamond();
+    [protocolDiamond, , , , accessController] = await deployProtocolDiamond(maxPriorityFeePerGas);
 
     // Temporarily grant UPGRADER role to deployer account
     await accessController.grantRole(Role.UPGRADER, deployer.address);
@@ -112,20 +112,24 @@ describe("IBosonDisputeHandler", function () {
     await accessController.grantRole(Role.PAUSER, pauser.address);
 
     // Cut the protocol handler facets into the Diamond
-    await deployProtocolHandlerFacets(protocolDiamond, [
-      "SellerHandlerFacet",
-      "BuyerHandlerFacet",
-      "DisputeResolverHandlerFacet",
-      "ExchangeHandlerFacet",
-      "OfferHandlerFacet",
-      "FundsHandlerFacet",
-      "DisputeHandlerFacet",
-      "PauseHandlerFacet",
-    ]);
+    await deployProtocolHandlerFacets(
+      protocolDiamond,
+      [
+        "SellerHandlerFacet",
+        "BuyerHandlerFacet",
+        "DisputeResolverHandlerFacet",
+        "ExchangeHandlerFacet",
+        "OfferHandlerFacet",
+        "FundsHandlerFacet",
+        "DisputeHandlerFacet",
+        "PauseHandlerFacet",
+      ],
+      maxPriorityFeePerGas
+    );
 
     // Deploy the Protocol client implementation/proxy pairs (currently just the Boson Voucher)
     const protocolClientArgs = [protocolDiamond.address];
-    const [, beacons, proxies] = await deployProtocolClients(protocolClientArgs, gasLimit);
+    const [, beacons, proxies] = await deployProtocolClients(protocolClientArgs, maxPriorityFeePerGas);
     const [beacon] = beacons;
     const [proxy] = proxies;
 
@@ -172,7 +176,7 @@ describe("IBosonDisputeHandler", function () {
     ];
 
     // Deploy the Config facet, initializing the protocol config
-    await deployProtocolConfigFacet(protocolDiamond, protocolConfig, gasLimit);
+    await deployProtocolConfigFacet(protocolDiamond, protocolConfig, maxPriorityFeePerGas);
 
     // Cast Diamond to IERC165
     erc165 = await ethers.getContractAt("ERC165Facet", protocolDiamond.address);

--- a/test/protocol/ExchangeHandlerTest.js
+++ b/test/protocol/ExchangeHandlerTest.js
@@ -767,7 +767,7 @@ describe("IBosonExchangeHandler", function () {
 
           // set validFrom date in the past
           offerDates.validFrom = ethers.BigNumber.from(now)
-            .add((oneMonth) * 6)
+            .add(oneMonth * 6)
             .toString(); // 6 months in the future
           offerDates.validUntil = ethers.BigNumber.from(offerDates.validFrom).add(10).toString(); // just after the valid from so it succeeds.
 

--- a/test/protocol/ExchangeHandlerTest.js
+++ b/test/protocol/ExchangeHandlerTest.js
@@ -46,7 +46,7 @@ const {
   calculateContractAddress,
   applyPercentage,
 } = require("../util/utils.js");
-const { oneWeek, oneMonth } = require("../util/constants");
+const { oneWeek, oneMonth, maxPriorityFeePerGas } = require("../util/constants");
 const { FundsList } = require("../../scripts/domain/Funds");
 const { getSelectors, FacetCutAction } = require("../../scripts/util/diamond-utils.js");
 
@@ -136,7 +136,7 @@ describe("IBosonExchangeHandler", function () {
     operatorDR = clerkDR = adminDR;
 
     // Deploy the Protocol Diamond
-    [protocolDiamond, , , , accessController] = await deployProtocolDiamond();
+    [protocolDiamond, , , , accessController] = await deployProtocolDiamond(maxPriorityFeePerGas);
 
     // Temporarily grant UPGRADER role to deployer account
     await accessController.grantRole(Role.UPGRADER, deployer.address);
@@ -148,25 +148,32 @@ describe("IBosonExchangeHandler", function () {
     await accessController.grantRole(Role.PAUSER, pauser.address);
 
     // Cut the protocol handler facets into the Diamond
-    await deployProtocolHandlerFacets(protocolDiamond, [
-      "AccountHandlerFacet",
-      "AgentHandlerFacet",
-      "SellerHandlerFacet",
-      "BuyerHandlerFacet",
-      "DisputeResolverHandlerFacet",
-      "ExchangeHandlerFacet",
-      "OfferHandlerFacet",
-      "FundsHandlerFacet",
-      "DisputeHandlerFacet",
-      "TwinHandlerFacet",
-      "BundleHandlerFacet",
-      "GroupHandlerFacet",
-      "PauseHandlerFacet",
-    ]);
+    await deployProtocolHandlerFacets(
+      protocolDiamond,
+      [
+        "AccountHandlerFacet",
+        "AgentHandlerFacet",
+        "SellerHandlerFacet",
+        "BuyerHandlerFacet",
+        "DisputeResolverHandlerFacet",
+        "ExchangeHandlerFacet",
+        "OfferHandlerFacet",
+        "FundsHandlerFacet",
+        "DisputeHandlerFacet",
+        "TwinHandlerFacet",
+        "BundleHandlerFacet",
+        "GroupHandlerFacet",
+        "PauseHandlerFacet",
+      ],
+      maxPriorityFeePerGas
+    );
 
     // Deploy the Protocol client implementation/proxy pairs (currently just the Boson Voucher)
     const protocolClientArgs = [protocolDiamond.address];
-    const [implementations, beacons, proxies, clients] = await deployProtocolClients(protocolClientArgs, gasLimit);
+    const [implementations, beacons, proxies, clients] = await deployProtocolClients(
+      protocolClientArgs,
+      maxPriorityFeePerGas
+    );
     [bosonVoucher] = clients;
     const [beacon] = beacons;
     const [proxy] = proxies;
@@ -215,7 +222,7 @@ describe("IBosonExchangeHandler", function () {
     ];
 
     // Deploy the Config facet, initializing the protocol config
-    await deployProtocolConfigFacet(protocolDiamond, protocolConfig, gasLimit);
+    await deployProtocolConfigFacet(protocolDiamond, protocolConfig, maxPriorityFeePerGas);
 
     // Cast Diamond to IERC165
     erc165 = await ethers.getContractAt("ERC165Facet", protocolDiamond.address);

--- a/test/protocol/ExchangeHandlerTest.js
+++ b/test/protocol/ExchangeHandlerTest.js
@@ -767,7 +767,7 @@ describe("IBosonExchangeHandler", function () {
 
           // set validFrom date in the past
           offerDates.validFrom = ethers.BigNumber.from(now)
-            .add((oneMonth / 1000) * 6)
+            .add((oneMonth) * 6)
             .toString(); // 6 months in the future
           offerDates.validUntil = ethers.BigNumber.from(offerDates.validFrom).add(10).toString(); // just after the valid from so it succeeds.
 

--- a/test/protocol/GroupHandlerTest.js
+++ b/test/protocol/GroupHandlerTest.js
@@ -18,7 +18,7 @@ const { deployProtocolConfigFacet } = require("../../scripts/util/deploy-protoco
 const { deployProtocolClients } = require("../../scripts/util/deploy-protocol-clients");
 const { deployMockTokens } = require("../../scripts/util/deploy-mock-tokens");
 const { getEvent } = require("../util/utils.js");
-const { oneWeek, oneMonth } = require("../util/constants");
+const { oneWeek, oneMonth, maxPriorityFeePerGas } = require("../util/constants");
 const {
   mockOffer,
   mockDisputeResolver,
@@ -80,7 +80,7 @@ describe("IBosonGroupHandler", function () {
     operatorDR = clerkDR = adminDR;
 
     // Deploy the Protocol Diamond
-    [protocolDiamond, , , , accessController] = await deployProtocolDiamond();
+    [protocolDiamond, , , , accessController] = await deployProtocolDiamond(maxPriorityFeePerGas);
 
     // Temporarily grant UPGRADER role to deployer account
     await accessController.grantRole(Role.UPGRADER, deployer.address);
@@ -89,17 +89,21 @@ describe("IBosonGroupHandler", function () {
     await accessController.grantRole(Role.PAUSER, pauser.address);
 
     // Cut the protocol handler facets into the Diamond
-    await deployProtocolHandlerFacets(protocolDiamond, [
-      "SellerHandlerFacet",
-      "DisputeResolverHandlerFacet",
-      "OfferHandlerFacet",
-      "GroupHandlerFacet",
-      "PauseHandlerFacet",
-    ]);
+    await deployProtocolHandlerFacets(
+      protocolDiamond,
+      [
+        "SellerHandlerFacet",
+        "DisputeResolverHandlerFacet",
+        "OfferHandlerFacet",
+        "GroupHandlerFacet",
+        "PauseHandlerFacet",
+      ],
+      maxPriorityFeePerGas
+    );
 
     // Deploy the Protocol client implementation/proxy pairs (currently just the Boson Voucher)
     const protocolClientArgs = [protocolDiamond.address];
-    const [, beacons, proxies] = await deployProtocolClients(protocolClientArgs, gasLimit);
+    const [, beacons, proxies] = await deployProtocolClients(protocolClientArgs, maxPriorityFeePerGas);
     const [beacon] = beacons;
     const [proxy] = proxies;
 
@@ -144,7 +148,7 @@ describe("IBosonGroupHandler", function () {
         buyerEscalationDepositPercentage,
       },
     ];
-    await deployProtocolConfigFacet(protocolDiamond, protocolConfig, gasLimit);
+    await deployProtocolConfigFacet(protocolDiamond, protocolConfig, maxPriorityFeePerGas);
 
     // Cast Diamond to IERC165
     erc165 = await ethers.getContractAt("ERC165Facet", protocolDiamond.address);

--- a/test/protocol/MetaTransactionsHandlerTest.js
+++ b/test/protocol/MetaTransactionsHandlerTest.js
@@ -28,7 +28,7 @@ const {
   accountId,
   mockExchange,
 } = require("../util/mock");
-const { oneWeek, oneMonth } = require("../util/constants");
+const { oneWeek, oneMonth, maxPriorityFeePerGas } = require("../util/constants");
 const { getSelectors, FacetCutAction } = require("../../scripts/util/diamond-utils.js");
 
 /**
@@ -116,7 +116,7 @@ describe("IBosonMetaTransactionsHandler", function () {
     operatorDR = clerkDR = adminDR;
 
     // Deploy the Protocol Diamond
-    [protocolDiamond, , , , accessController] = await deployProtocolDiamond();
+    [protocolDiamond, , , , accessController] = await deployProtocolDiamond(maxPriorityFeePerGas);
 
     // Temporarily grant UPGRADER role to deployer account
     await accessController.grantRole(Role.UPGRADER, deployer.address);
@@ -128,22 +128,26 @@ describe("IBosonMetaTransactionsHandler", function () {
     await accessController.grantRole(Role.PAUSER, pauser.address);
 
     // Cut the protocol handler facets into the Diamond
-    await deployProtocolHandlerFacets(protocolDiamond, [
-      "SellerHandlerFacet",
-      "DisputeResolverHandlerFacet",
-      "FundsHandlerFacet",
-      "ExchangeHandlerFacet",
-      "OfferHandlerFacet",
-      "TwinHandlerFacet",
-      "DisputeHandlerFacet",
-      "MetaTransactionsHandlerFacet",
-      "PauseHandlerFacet",
-      "BuyerHandlerFacet",
-    ]);
+    await deployProtocolHandlerFacets(
+      protocolDiamond,
+      [
+        "SellerHandlerFacet",
+        "DisputeResolverHandlerFacet",
+        "FundsHandlerFacet",
+        "ExchangeHandlerFacet",
+        "OfferHandlerFacet",
+        "TwinHandlerFacet",
+        "DisputeHandlerFacet",
+        "MetaTransactionsHandlerFacet",
+        "PauseHandlerFacet",
+        "BuyerHandlerFacet",
+      ],
+      maxPriorityFeePerGas
+    );
 
     // Deploy the Protocol client implementation/proxy pairs (currently just the Boson Voucher)
     const protocolClientArgs = [protocolDiamond.address];
-    const [, beacons, proxies] = await deployProtocolClients(protocolClientArgs, gasLimit);
+    const [, beacons, proxies] = await deployProtocolClients(protocolClientArgs, maxPriorityFeePerGas);
     const [beacon] = beacons;
     const [proxy] = proxies;
 
@@ -192,7 +196,7 @@ describe("IBosonMetaTransactionsHandler", function () {
     ];
 
     // Deploy the Config facet, initializing the protocol config
-    await deployProtocolConfigFacet(protocolDiamond, protocolConfig, gasLimit);
+    await deployProtocolConfigFacet(protocolDiamond, protocolConfig, maxPriorityFeePerGas);
 
     // Cast Diamond to IERC165
     erc165 = await ethers.getContractAt("ERC165Facet", protocolDiamond.address);

--- a/test/protocol/OfferHandlerTest.js
+++ b/test/protocol/OfferHandlerTest.js
@@ -19,7 +19,7 @@ const { deployProtocolConfigFacet } = require("../../scripts/util/deploy-protoco
 const { deployProtocolClients } = require("../../scripts/util/deploy-protocol-clients");
 const { deployMockTokens } = require("../../scripts/util/deploy-mock-tokens");
 const { applyPercentage } = require("../util/utils.js");
-const { oneWeek, oneMonth } = require("../util/constants");
+const { oneWeek, oneMonth, oneDay } = require("../util/constants");
 const {
   mockOffer,
   mockDisputeResolver,
@@ -627,10 +627,10 @@ describe("IBosonOfferHandler", function () {
           const now = block.timestamp.toString();
 
           // set validFrom date in the past
-          offerDates.validFrom = ethers.BigNumber.from(now - (oneMonth / 1000) * 6).toString(); // 6 months ago
+          offerDates.validFrom = ethers.BigNumber.from(now - (oneMonth) * 6).toString(); // 6 months ago
 
           // set valid until > valid from
-          offerDates.validUntil = ethers.BigNumber.from(now - oneMonth / 1000).toString(); // 1 month ago
+          offerDates.validUntil = ethers.BigNumber.from(now - oneMonth).toString(); // 1 month ago
 
           // Attempt to Create an offer, expecting revert
           await expect(
@@ -725,7 +725,7 @@ describe("IBosonOfferHandler", function () {
 
         it("Resolution period is greater than protocol max resolution period", async function () {
           // Set max resolution period to 1 day
-          await configHandler.setMaxResolutionPeriod(86400 * 1000); // 24 hours
+          await configHandler.setMaxResolutionPeriod(oneDay); // 24 hours
 
           // Attempt to Create an offer, expecting revert
           await expect(
@@ -1195,7 +1195,7 @@ describe("IBosonOfferHandler", function () {
 
           it("Valid until date is not in the future", async function () {
             // Set until date in the past
-            offerDates.validUntil = ethers.BigNumber.from(offerDates.validFrom - (oneMonth / 1000) * 6).toString(); // 6 months ago
+            offerDates.validUntil = ethers.BigNumber.from(offerDates.validFrom - (oneMonth) * 6).toString(); // 6 months ago
 
             // Attempt to update an offer, expecting revert
             await expect(offerHandler.connect(operator).extendOffer(offer.id, offerDates.validUntil)).to.revertedWith(
@@ -1931,10 +1931,10 @@ describe("IBosonOfferHandler", function () {
           let now = offerDatesList[0].validFrom;
 
           // set validFrom date in the past
-          offerDatesList[0].validFrom = ethers.BigNumber.from(now - (oneMonth / 1000) * 6).toString(); // 6 months ago
+          offerDatesList[0].validFrom = ethers.BigNumber.from(now - (oneMonth) * 6).toString(); // 6 months ago
 
           // set valid until > valid from
-          offerDatesList[0].validUntil = ethers.BigNumber.from(now - oneMonth / 1000).toString(); // 1 month ago
+          offerDatesList[0].validUntil = ethers.BigNumber.from(now - oneMonth).toString(); // 1 month ago
 
           // Attempt to Create an offer, expecting revert
           await expect(
@@ -2696,7 +2696,7 @@ describe("IBosonOfferHandler", function () {
 
         it("Valid until date is not in the future", async function () {
           // Set until date in the past
-          newValidUntilDate = ethers.BigNumber.from(offerDatesList[0].validFrom - (oneMonth / 1000) * 6).toString(); // 6 months ago
+          newValidUntilDate = ethers.BigNumber.from(offerDatesList[0].validFrom - (oneMonth) * 6).toString(); // 6 months ago
 
           // Attempt to extend the offers, expecting revert
           await expect(

--- a/test/protocol/OfferHandlerTest.js
+++ b/test/protocol/OfferHandlerTest.js
@@ -627,7 +627,7 @@ describe("IBosonOfferHandler", function () {
           const now = block.timestamp.toString();
 
           // set validFrom date in the past
-          offerDates.validFrom = ethers.BigNumber.from(now - (oneMonth) * 6).toString(); // 6 months ago
+          offerDates.validFrom = ethers.BigNumber.from(now - oneMonth * 6).toString(); // 6 months ago
 
           // set valid until > valid from
           offerDates.validUntil = ethers.BigNumber.from(now - oneMonth).toString(); // 1 month ago
@@ -1195,7 +1195,7 @@ describe("IBosonOfferHandler", function () {
 
           it("Valid until date is not in the future", async function () {
             // Set until date in the past
-            offerDates.validUntil = ethers.BigNumber.from(offerDates.validFrom - (oneMonth) * 6).toString(); // 6 months ago
+            offerDates.validUntil = ethers.BigNumber.from(offerDates.validFrom - oneMonth * 6).toString(); // 6 months ago
 
             // Attempt to update an offer, expecting revert
             await expect(offerHandler.connect(operator).extendOffer(offer.id, offerDates.validUntil)).to.revertedWith(
@@ -1931,7 +1931,7 @@ describe("IBosonOfferHandler", function () {
           let now = offerDatesList[0].validFrom;
 
           // set validFrom date in the past
-          offerDatesList[0].validFrom = ethers.BigNumber.from(now - (oneMonth) * 6).toString(); // 6 months ago
+          offerDatesList[0].validFrom = ethers.BigNumber.from(now - oneMonth * 6).toString(); // 6 months ago
 
           // set valid until > valid from
           offerDatesList[0].validUntil = ethers.BigNumber.from(now - oneMonth).toString(); // 1 month ago
@@ -2696,7 +2696,7 @@ describe("IBosonOfferHandler", function () {
 
         it("Valid until date is not in the future", async function () {
           // Set until date in the past
-          newValidUntilDate = ethers.BigNumber.from(offerDatesList[0].validFrom - (oneMonth) * 6).toString(); // 6 months ago
+          newValidUntilDate = ethers.BigNumber.from(offerDatesList[0].validFrom - oneMonth * 6).toString(); // 6 months ago
 
           // Attempt to extend the offers, expecting revert
           await expect(

--- a/test/protocol/OfferHandlerTest.js
+++ b/test/protocol/OfferHandlerTest.js
@@ -19,7 +19,7 @@ const { deployProtocolConfigFacet } = require("../../scripts/util/deploy-protoco
 const { deployProtocolClients } = require("../../scripts/util/deploy-protocol-clients");
 const { deployMockTokens } = require("../../scripts/util/deploy-mock-tokens");
 const { applyPercentage } = require("../util/utils.js");
-const { oneWeek, oneMonth, oneDay } = require("../util/constants");
+const { oneWeek, oneMonth, oneDay, maxPriorityFeePerGas } = require("../util/constants");
 const {
   mockOffer,
   mockDisputeResolver,
@@ -112,7 +112,7 @@ describe("IBosonOfferHandler", function () {
     operatorDR = clerkDR = adminDR;
 
     // Deploy the Protocol Diamond
-    [protocolDiamond, , , , accessController] = await deployProtocolDiamond();
+    [protocolDiamond, , , , accessController] = await deployProtocolDiamond(maxPriorityFeePerGas);
 
     // Temporarily grant UPGRADER role to deployer account
     await accessController.grantRole(Role.UPGRADER, deployer.address);
@@ -128,17 +128,21 @@ describe("IBosonOfferHandler", function () {
     await accessController.grantRole(Role.PAUSER, pauser.address);
 
     // Cut the protocol handler facets into the Diamond
-    await deployProtocolHandlerFacets(protocolDiamond, [
-      "SellerHandlerFacet",
-      "AgentHandlerFacet",
-      "DisputeResolverHandlerFacet",
-      "OfferHandlerFacet",
-      "PauseHandlerFacet",
-    ]);
+    await deployProtocolHandlerFacets(
+      protocolDiamond,
+      [
+        "SellerHandlerFacet",
+        "AgentHandlerFacet",
+        "DisputeResolverHandlerFacet",
+        "OfferHandlerFacet",
+        "PauseHandlerFacet",
+      ],
+      maxPriorityFeePerGas
+    );
 
     // Deploy the Protocol client implementation/proxy pairs (currently just the Boson Voucher)
     const protocolClientArgs = [protocolDiamond.address];
-    const [, beacons, proxies] = await deployProtocolClients(protocolClientArgs, gasLimit);
+    const [, beacons, proxies] = await deployProtocolClients(protocolClientArgs, maxPriorityFeePerGas);
     const [beacon] = beacons;
     const [proxy] = proxies;
 
@@ -184,7 +188,7 @@ describe("IBosonOfferHandler", function () {
       },
     ];
 
-    await deployProtocolConfigFacet(protocolDiamond, protocolConfig, gasLimit);
+    await deployProtocolConfigFacet(protocolDiamond, protocolConfig, maxPriorityFeePerGas);
 
     // Cast Diamond to IERC165
     erc165 = await ethers.getContractAt("ERC165Facet", protocolDiamond.address);

--- a/test/protocol/PauseHandlerTest.js
+++ b/test/protocol/PauseHandlerTest.js
@@ -8,6 +8,7 @@ const { getInterfaceIds } = require("../../scripts/config/supported-interfaces.j
 const { RevertReasons } = require("../../scripts/config/revert-reasons.js");
 const { deployProtocolDiamond } = require("../../scripts/util/deploy-protocol-diamond.js");
 const { deployProtocolHandlerFacets } = require("../../scripts/util/deploy-protocol-handler-facets.js");
+const { maxPriorityFeePerGas } = require("../util/constants");
 
 /**
  *  Test the Boson Pause Handler interface
@@ -33,7 +34,7 @@ describe("IBosonPauseHandler", function () {
     [deployer, pauser, rando] = await ethers.getSigners();
 
     // Deploy the Protocol Diamond
-    [protocolDiamond, , , , accessController] = await deployProtocolDiamond();
+    [protocolDiamond, , , , accessController] = await deployProtocolDiamond(maxPriorityFeePerGas);
 
     // Temporarily grant UPGRADER role to deployer account
     await accessController.grantRole(Role.UPGRADER, deployer.address);
@@ -42,7 +43,7 @@ describe("IBosonPauseHandler", function () {
     await accessController.grantRole(Role.PAUSER, pauser.address);
 
     // Cut the protocol handler facets into the Diamond
-    await deployProtocolHandlerFacets(protocolDiamond, ["PauseHandlerFacet"]);
+    await deployProtocolHandlerFacets(protocolDiamond, ["PauseHandlerFacet"], maxPriorityFeePerGas);
 
     // Cast Diamond to IERC165
     erc165 = await ethers.getContractAt("ERC165Facet", protocolDiamond.address);

--- a/test/protocol/ProtocolDiamondTest.js
+++ b/test/protocol/ProtocolDiamondTest.js
@@ -13,6 +13,7 @@ const {
 } = require("../../scripts/util/diamond-utils.js");
 const { getInterfaceIds } = require("../../scripts/config/supported-interfaces");
 const { RevertReasons } = require("../../scripts/config/revert-reasons.js");
+const { maxPriorityFeePerGas } = require("../util/constants");
 
 /**
  * Test the Protocol Diamond contract and its core facets
@@ -59,7 +60,9 @@ describe("ProtocolDiamond", async function () {
     [deployer, admin, upgrader, rando] = await ethers.getSigners();
 
     // Deploy the Diamond
-    [protocolDiamond, diamondLoupe, diamondCut, erc165, accessController] = await deployProtocolDiamond();
+    [protocolDiamond, diamondLoupe, diamondCut, erc165, accessController] = await deployProtocolDiamond(
+      maxPriorityFeePerGas
+    );
 
     // Cast Diamond to DiamondLoupeFacet
     loupeFacetViaDiamond = await ethers.getContractAt("DiamondLoupeFacet", protocolDiamond.address);

--- a/test/protocol/clients/BeaconClientProxy.js
+++ b/test/protocol/clients/BeaconClientProxy.js
@@ -1,9 +1,9 @@
 const hre = require("hardhat");
 const ethers = hre.ethers;
 
-const { gasLimit } = require("../../../environments");
 const { deployProtocolClients } = require("../../../scripts/util/deploy-protocol-clients");
 const { expect } = require("chai");
+const { maxPriorityFeePerGas } = require("../../util/constants");
 
 describe("BeaconClientProxy", function () {
   let protocol, rando;
@@ -15,7 +15,7 @@ describe("BeaconClientProxy", function () {
 
     // deploy proxy
     const protocolClientArgs = [protocol.address];
-    const [, , proxies] = await deployProtocolClients(protocolClientArgs, gasLimit);
+    const [, , proxies] = await deployProtocolClients(protocolClientArgs, maxPriorityFeePerGas);
     [proxy] = proxies;
   });
 

--- a/test/protocol/clients/ClientExternalAddreses.js
+++ b/test/protocol/clients/ClientExternalAddreses.js
@@ -10,7 +10,7 @@ const { deployProtocolConfigFacet } = require("../../../scripts/util/deploy-prot
 const Role = require("../../../scripts/domain/Role");
 const { expect } = require("chai");
 const { RevertReasons } = require("../../../scripts/config/revert-reasons");
-const { oneWeek, oneMonth } = require("../../util/constants.js");
+const { oneWeek, oneMonth, maxPriorityFeePerGas } = require("../../util/constants.js");
 
 describe("IClientExternalAddresses", function () {
   let accessController, protocolDiamond;
@@ -24,14 +24,14 @@ describe("IClientExternalAddresses", function () {
     [deployer, rando, other1, other3, proxy, protocolTreasury, bosonToken] = await ethers.getSigners();
 
     // Deploy accessController
-    [protocolDiamond, , , , accessController] = await deployProtocolDiamond();
+    [protocolDiamond, , , , accessController] = await deployProtocolDiamond(maxPriorityFeePerGas);
 
     // grant upgrader role
     await accessController.grantRole(Role.UPGRADER, deployer.address);
 
     // Deploy client
     const protocolClientArgs = [protocolDiamond.address];
-    const [, beacons] = await deployProtocolClients(protocolClientArgs, gasLimit);
+    const [, beacons] = await deployProtocolClients(protocolClientArgs, maxPriorityFeePerGas);
     [beacon] = beacons;
 
     // set protocolFees
@@ -73,7 +73,7 @@ describe("IClientExternalAddresses", function () {
       },
     ];
 
-    await deployProtocolConfigFacet(protocolDiamond, protocolConfig, gasLimit);
+    await deployProtocolConfigFacet(protocolDiamond, protocolConfig, maxPriorityFeePerGas);
   });
 
   // Interface support
@@ -158,13 +158,13 @@ describe("IClientExternalAddresses", function () {
       context("💔 Revert Reasons", async function () {
         it("_protocolAddress address is the zero address", async function () {
           // Deploy Protocol Client implementation contracts
-          const protocolClientImpls = await deployProtocolClientImpls(gasLimit);
+          const protocolClientImpls = await deployProtocolClientImpls(maxPriorityFeePerGas);
 
           // Deploy Protocol Client beacon contracts
           const protocolClientArgs = [ethers.constants.AddressZero];
-          await expect(deployProtocolClientBeacons(protocolClientImpls, protocolClientArgs, gasLimit)).to.revertedWith(
-            RevertReasons.INVALID_ADDRESS
-          );
+          await expect(
+            deployProtocolClientBeacons(protocolClientImpls, protocolClientArgs, maxPriorityFeePerGas)
+          ).to.revertedWith(RevertReasons.INVALID_ADDRESS);
         });
 
         it("_impl address is the zero address", async function () {

--- a/test/util/constants.js
+++ b/test/util/constants.js
@@ -1,3 +1,7 @@
+const environments = require("../../environments");
+const hre = require("hardhat");
+const ethers = hre.ethers;
+
 // Some periods in milliseconds
 const oneDay = 86400; //  1 day in seconds
 const ninetyDays = oneDay * 90; // 90 days in seconds
@@ -6,9 +10,14 @@ const oneMonth = 2678400; // 31 days in seconds
 const VOUCHER_NAME = "Boson Voucher";
 const VOUCHER_SYMBOL = "BOSON_VOUCHER";
 
+const tipMultiplier = ethers.BigNumber.from(environments.tipMultiplier);
+const tipSuggestion = "1500000000"; // ethers.js always returns this constant, it does not vary per block
+const maxPriorityFeePerGas = ethers.BigNumber.from(tipSuggestion).mul(tipMultiplier);
+
 exports.oneDay = oneDay;
 exports.ninetyDays = ninetyDays;
 exports.oneWeek = oneWeek;
 exports.oneMonth = oneMonth;
 exports.VOUCHER_NAME = VOUCHER_NAME;
 exports.VOUCHER_SYMBOL = VOUCHER_SYMBOL;
+exports.maxPriorityFeePerGas = maxPriorityFeePerGas;


### PR DESCRIPTION
## What is this
Refactor the deployment script to use tip rather than gas price and/or limit to ensure a each transaction's inclusion in the block.

## Why 
* For details of the strategy, see https://docs.alchemy.com/docs/maxpriorityfeepergas-vs-maxfeepergas

* Suffice it to say, supplying only an attractive tip amount is the best way to ensure inclusion in the next block.

## What changed
* In env.example
  - set CONFIRMATIONS to 3 (we cannot run with only one confirmation on polygon with high uncle rate. Probably this needs to be between 5 and 10, we'll see

* In deploy-protocol-*.js,
  - replaced gasLimit with maxPriorityFeePerGas

* In deploy-suite.js,
  - fetch tipMultiplier from environment
  - set tipSuggestion to amount that is always returned from ethers
  - create maxPriorityFeePerGas as bignumber with tipMultiplier times tipSuggestion
  - remove fetch of gasLimit from environment, no longer needed (pre-1559)
  - in all deployment calls that passed gasLimit, now pass maxPriorityFeePerGas

* In environments.js,
  - fetch tipMultiplier from process.env.TIP_MULTIPLIER