### PR TITLE
Deploy or upgrade facets with initialize arguments

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -100,7 +100,9 @@ To perform the upgrade you then
 - Update config file `scripts/config/facet-upgrade.js`:
   - "addOrUpgrade" is the list of facets that will be upgraded or added,
   - "remove": list of facets that will be completely removed
-  - "skip" allows you to specify methods that will be ignored during the process.
+  - "skipSelectors" allows you to specify methods that will be ignored during the process.
+  - "initArgs": if facet initializer expects arguments, provide it here. For no-arg initializers you don't have to specify anything.
+  - "skipInit": list of facets for which you want to skip initialization call.
 - Update `version` in `package.json`. If the version in `package.json` matches the existing version in addresses file, you will have to explicitly confirm that you want to proceed.
 - Run `npm run upgrade-facets:local`. This will deploy new facets and make all necessary diamond cuts. It also updates the existing addresses file `addresses/<chain-id>-<environment>.json` (for example `addresses/31337-localhost.json` if you are using a default local hardhat node) and outputs the upgrade log to the console.
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -101,7 +101,7 @@ To perform the upgrade you then
   - "addOrUpgrade" is the list of facets that will be upgraded or added,
   - "remove": list of facets that will be completely removed
   - "skipSelectors" allows you to specify methods that will be ignored during the process.
-  - "initArgs": if facet initializer expects arguments, provide it here. For no-arg initializers you don't have to specify anything.
+  - "initArgs": if facet initializer expects arguments, provide them here. For no-arg initializers you don't have to specify anything.
   - "skipInit": list of facets for which you want to skip initialization call.
 - Update `version` in `package.json`. If the version in `package.json` matches the existing version in addresses file, you will have to explicitly confirm that you want to proceed.
 - Run `npm run upgrade-facets:local`. This will deploy new facets and make all necessary diamond cuts. It also updates the existing addresses file `addresses/<chain-id>-<environment>.json` (for example `addresses/31337-localhost.json` if you are using a default local hardhat node) and outputs the upgrade log to the console.

--- a/scripts/config/facet-deploy.js
+++ b/scripts/config/facet-deploy.js
@@ -1,0 +1,25 @@
+/**
+ * Config file used to upgrade the facets
+ *
+ * - noArgFacets: list of facet names that don't expect any argument passed into initializer
+ * - argFacets: object that specify facet names and arguments that needs to be passed into initializer in format object {facetName: initializerArguments}
+ */
+module.exports = {
+  noArgFacets: [
+    "AccountHandlerFacet",
+    "SellerHandlerFacet",
+    "BuyerHandlerFacet",
+    "DisputeResolverHandlerFacet",
+    "AgentHandlerFacet",
+    "BundleHandlerFacet",
+    "DisputeHandlerFacet",
+    "ExchangeHandlerFacet",
+    "FundsHandlerFacet",
+    "GroupHandlerFacet",
+    "OfferHandlerFacet",
+    "OrchestrationHandlerFacet",
+    "TwinHandlerFacet",
+    "PauseHandlerFacet",
+  ],
+  argFacets: { MetaTransactionsHandlerFacet: [[]] },
+};

--- a/scripts/config/facet-deploy.js
+++ b/scripts/config/facet-deploy.js
@@ -20,6 +20,7 @@ module.exports = {
     "OrchestrationHandlerFacet",
     "TwinHandlerFacet",
     "PauseHandlerFacet",
+    "MetaTransactionsHandlerFacet",
   ],
-  argFacets: { MetaTransactionsHandlerFacet: [[]] },
+  argFacets: {},
 };

--- a/scripts/config/facet-deploy.js
+++ b/scripts/config/facet-deploy.js
@@ -1,8 +1,17 @@
 /**
- * Config file used to upgrade the facets
+ * Config file used to deploy the facets
  *
  * - noArgFacets: list of facet names that don't expect any argument passed into initializer
  * - argFacets: object that specify facet names and arguments that needs to be passed into initializer in format object {facetName: initializerArguments}
+ * 
+ * Example: 
+    {
+      noArgFacets: ["Facet1", "Facet2", "Facet3"],
+      argFacets: { 
+        Facet4: ["0xb0b1d2659e8d5846432c66de8615841cc7bcaf49", 3, true],  // Facet4 expects address, uint256 and bool
+        Facet5: [[2, 3, 5, 7, 11]] },                                     // Facet5 uint256 array
+    }
+ * 
  */
 module.exports = {
   noArgFacets: [

--- a/scripts/config/facet-upgrade.js
+++ b/scripts/config/facet-upgrade.js
@@ -3,14 +3,16 @@
  *
  * - addOrUpgrade: list of facets that will be upgraded or added
  * - remove: list of facets that will be completely removed
- * - skip:  mapping "facetName":"listOfFunctionsToBeSkipped". With this you can specify functions that will be ignored during the update.
+ * - skipSelectors:  mapping "facetName":"listOfFunctionsToBeSkipped". With this you can specify functions that will be ignored during the update.
  *          You don't have to specify "initialize()" since it's ignored by default.
  *          Skip does not apply to facets that are completely removed.
  * - initArgs: if facet initializer expects arguments, provide it here. For no-arg initializers you don't have to specify anything.
+ * - skipInit": list of facets for which you want to skip initialization call.
  */
 exports.Facets = {
-  addOrUpgrade: ["SellerHandlerFacet", "BuyerHandlerFacet", "MetaTransactionsHandlerFacet"],
+  addOrUpgrade: ["MetaTransactionsHandlerFacet"],
   remove: [],
-  skip: { SellerHandlerFacet: [] },
+  skipSelectors: { SellerHandlerFacet: [] },
   initArgs: { MetaTransactionsHandlerFacet: [[]] },
+  skipInit: ["MetaTransactionsHandlerFacet"],
 };

--- a/scripts/config/facet-upgrade.js
+++ b/scripts/config/facet-upgrade.js
@@ -6,9 +6,11 @@
  * - skip:  mapping "facetName":"listOfFunctionsToBeSkipped". With this you can specify functions that will be ignored during the update.
  *          You don't have to specify "initialize()" since it's ignored by default.
  *          Skip does not apply to facets that are completely removed.
+ * - initArgs: if facet initializer expects arguments, provide it here. For no-arg initializers you don't have to specify anything.
  */
 exports.Facets = {
-  addOrUpgrade: ["SellerHandlerFacet", "BuyerHandlerFacet"],
+  addOrUpgrade: ["SellerHandlerFacet", "BuyerHandlerFacet", "MetaTransactionsHandlerFacet"],
   remove: [],
   skip: { SellerHandlerFacet: [] },
+  initArgs: { MetaTransactionsHandlerFacet: [[]] },
 };

--- a/scripts/config/facet-upgrade.js
+++ b/scripts/config/facet-upgrade.js
@@ -10,9 +10,9 @@
  * - skipInit": list of facets for which you want to skip initialization call.
  */
 exports.Facets = {
-  addOrUpgrade: ["MetaTransactionsHandlerFacet"],
+  addOrUpgrade: [],
   remove: [],
-  skipSelectors: { SellerHandlerFacet: [] },
-  initArgs: { MetaTransactionsHandlerFacet: [[]] },
-  skipInit: ["MetaTransactionsHandlerFacet"],
+  skipSelectors: {},
+  initArgs: {},
+  skipInit: [],
 };

--- a/scripts/config/facet-upgrade.js
+++ b/scripts/config/facet-upgrade.js
@@ -6,8 +6,20 @@
  * - skipSelectors:  mapping "facetName":"listOfFunctionsToBeSkipped". With this you can specify functions that will be ignored during the update.
  *          You don't have to specify "initialize()" since it's ignored by default.
  *          Skip does not apply to facets that are completely removed.
- * - initArgs: if facet initializer expects arguments, provide it here. For no-arg initializers you don't have to specify anything.
+ * - initArgs: if facet initializer expects arguments, provide them here. For no-arg initializers you don't have to specify anything.
  * - skipInit": list of facets for which you want to skip initialization call.
+ *
+ * Example:
+    {
+      addOrUpgrade: ["Facet1", "Facet2"],
+      remove: ["Facet3"],
+      skipSelectors: { Facet1: ["function1(address)", "function2(uint256,bool)"] },
+      initArgs: { 
+        Facet4: ["0xb0b1d2659e8d5846432c66de8615841cc7bcaf49", [2, 3, 5]], 
+        Facet5: ["v1.1.0"]
+      },
+      skipInit: ["Facet2"],
+    }
  */
 exports.Facets = {
   addOrUpgrade: [],

--- a/scripts/upgrade-facets.js
+++ b/scripts/upgrade-facets.js
@@ -121,12 +121,12 @@ async function main() {
   const diamondLoupe = await ethers.getContractAt("DiamondLoupeFacet", protocolAddress);
   const erc165Extended = await ethers.getContractAt("IERC165Extended", protocolAddress);
 
-  // All handler facets currently have no-arg initializers
+  // Initialization data for facets with no-arg initializers
   const noArgInitFunction = "initialize()";
   const noArgInitInterface = new ethers.utils.Interface([`function ${noArgInitFunction}`]);
   const noArgCallData = noArgInitInterface.encodeFunctionData("initialize");
 
-  // manage new or upgraded facets
+  // Manage new or upgraded facets
   for (const newFacet of deployedFacets) {
     console.log(`\n📋 Facet: ${newFacet.name}`);
 

--- a/scripts/util/deploy-protocol-handler-facets.js
+++ b/scripts/util/deploy-protocol-handler-facets.js
@@ -17,47 +17,14 @@ const { getFees } = require("./utils");
  * @returns {Promise<(*|*|*)[]>}
  */
 async function deployProtocolHandlerFacets(diamond, facetNames, maxPriorityFeePerGas, doCut = true) {
-  let deployedFacets = [];
-
-  // Deploy all the no-arg initializer handler facets
-  while (facetNames.length) {
-    let facetName = facetNames.shift();
-    let FacetContractFactory = await ethers.getContractFactory(facetName);
-    const facetContract = await FacetContractFactory.deploy(await getFees(maxPriorityFeePerGas));
-    await facetContract.deployTransaction.wait(confirmations);
-
-    deployedFacets.push({
-      name: facetName,
-      contract: facetContract,
-    });
+  // Convert facetNames into expected facetData format
+  let facetData = {};
+  for (const facetName of facetNames) {
+    facetData[facetName] = "";
   }
 
-  if (doCut) {
-    // Cast Diamond to DiamondCutFacet
-    const diamondCutFacet = await ethers.getContractAt("DiamondCutFacet", diamond.address);
-
-    // All handler facets currently have no-arg initializers
-    let initFunction = "initialize()";
-    let initInterface = new ethers.utils.Interface([`function ${initFunction}`]);
-    let callData = initInterface.encodeFunctionData("initialize");
-
-    // Cut all the facets into the diamond
-    for (let i = 0; i < deployedFacets.length; i++) {
-      const deployedFacet = deployedFacets[i];
-
-      const facetCut = getFacetAddCut(deployedFacet.contract, [initFunction]);
-      const transactionResponse = await diamondCutFacet.diamondCut(
-        [facetCut],
-        deployedFacet.contract.address,
-        callData,
-        await getFees(maxPriorityFeePerGas)
-      );
-      await transactionResponse.wait(confirmations);
-    }
-  }
-
-  // Return an array of objects with facet name and contract properties
-  return deployedFacets;
+  // Make the deployment with generic method
+  return deployProtocolHandlerFacetsWithArgs(diamond, facetData, maxPriorityFeePerGas, doCut);
 }
 
 /**

--- a/scripts/util/deploy-protocol-handler-facets.js
+++ b/scripts/util/deploy-protocol-handler-facets.js
@@ -6,7 +6,7 @@ const confirmations = hre.network.name == "hardhat" ? 1 : environments.confirmat
 const { getFees } = require("./utils");
 
 /**
- * Cut the Protocol Handler facets
+ * Cut the Protocol Handler facets with no-arg initializers
  *
  * Reused between deployment script and unit tests for consistency.
  *
@@ -60,6 +60,59 @@ async function deployProtocolHandlerFacets(diamond, facetNames, maxPriorityFeePe
   return deployedFacets;
 }
 
+/**
+ * Cut the Protocol Handler facets with initializers with arguments
+ *
+ * Reused between deployment script and unit tests for consistency.
+ *
+ * @param diamond
+ * @param facetNames - list of facet names to deploy and cut
+ * @param args - object {facetName: initializerArguments}
+ * @param maxPriorityFeePerGas - maxPriorityFeePerGas for transactions
+ * @param doCut - boolean that tells if cut transaction should be done or not (default: true)
+ * @returns {Promise<(*|*|*)[]>}
+ */
+async function deployProtocolHandlerFacetsWithArgs(diamond, facetData, maxPriorityFeePerGas, doCut = true) {
+  let deployedFacets = [];
+
+  // Deploy all the handler facets
+  for (const facetName of Object.keys(facetData)) {
+    // let facetName = facetNames.shift();
+    let FacetContractFactory = await ethers.getContractFactory(facetName);
+    const facetContract = await FacetContractFactory.deploy(await getFees(maxPriorityFeePerGas));
+    await facetContract.deployTransaction.wait(confirmations);
+
+    deployedFacets.push({
+      name: facetName,
+      contract: facetContract,
+    });
+  }
+
+  if (doCut) {
+    // Cast Diamond to DiamondCutFacet
+    const diamondCutFacet = await ethers.getContractAt("DiamondCutFacet", diamond.address);
+
+    // Cut all the facets into the diamond
+    for (let i = 0; i < deployedFacets.length; i++) {
+      const deployedFacet = deployedFacets[i];
+
+      const callData = deployedFacet.contract.interface.encodeFunctionData("initialize", facetData[deployedFacet.name]);
+      const facetCut = getFacetAddCut(deployedFacet.contract, [callData.slice(0, 10)]);
+      const transactionResponse = await diamondCutFacet.diamondCut(
+        [facetCut],
+        deployedFacet.contract.address,
+        callData,
+        await getFees(maxPriorityFeePerGas)
+      );
+      await transactionResponse.wait(confirmations);
+      deployedFacets[i].cutTransaction = transactionResponse;
+    }
+  }
+
+  // Return an array of objects with facet name and contract properties
+  return deployedFacets;
+}
+
 if (require.main === module) {
   deployProtocolHandlerFacets()
     .then(() => process.exit(0))
@@ -70,3 +123,4 @@ if (require.main === module) {
 }
 
 exports.deployProtocolHandlerFacets = deployProtocolHandlerFacets;
+exports.deployProtocolHandlerFacetsWithArgs = deployProtocolHandlerFacetsWithArgs;

--- a/scripts/util/deploy-protocol-handler-facets.js
+++ b/scripts/util/deploy-protocol-handler-facets.js
@@ -33,8 +33,7 @@ async function deployProtocolHandlerFacets(diamond, facetNames, maxPriorityFeePe
  * Reused between deployment script and unit tests for consistency.
  *
  * @param diamond
- * @param facetNames - list of facet names to deploy and cut
- * @param args - object {facetName: initializerArguments}
+ * @param facetData - object with facet names and corresponding initialization arguments {facetName1: initializerArguments1, facetName2: initializerArguments2, ...}
  * @param maxPriorityFeePerGas - maxPriorityFeePerGas for transactions
  * @param doCut - boolean that tells if cut transaction should be done or not (default: true)
  * @returns {Promise<(*|*|*)[]>}
@@ -42,9 +41,8 @@ async function deployProtocolHandlerFacets(diamond, facetNames, maxPriorityFeePe
 async function deployProtocolHandlerFacetsWithArgs(diamond, facetData, maxPriorityFeePerGas, doCut = true) {
   let deployedFacets = [];
 
-  // Deploy all the handler facets
+  // Deploy all handler facets
   for (const facetName of Object.keys(facetData)) {
-    // let facetName = facetNames.shift();
     let FacetContractFactory = await ethers.getContractFactory(facetName);
     const facetContract = await FacetContractFactory.deploy(await getFees(maxPriorityFeePerGas));
     await facetContract.deployTransaction.wait(confirmations);


### PR DESCRIPTION
So far, deployment and upgrade script assumed that all facets have initalizers without arguments. The only exception was `configHandlerFacet` which has its own script `deploy-protocol-config-facet`.

This PR introduces new method `deployProtocolHandlerFacetsWithArgs` where you can pass in the initializer arguments.
Existing methods `deployProtocolHandlerFacets` and `deployProtocolConfigFacet` were refactored so now they both use `deployProtocolHandlerFacetsWithArgs`. They were still kept in, since they are used all over the code and replacing them everywhere would be tedious and error prone.

I had to slightly modify `scripts/config/facet-upgrade.js` and I added a new config file `scripts/config/facet-deploy.js`

In this branch only the configHandler accepts the arguments, so you can test only with it. In my other branch https://github.com/bosonprotocol/boson-protocol-contracts/tree/whitelist-metatx-initializer `MetaTransactionHandler` also accepts init args, and that branch has the same deploy/upgrade script as this, so you can test there as well.