### PR TITLE
Code coverage

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -4,6 +4,7 @@ module.exports = {
     "protocol/bases/ClientBase.sol",
     "protocol/clients/proxy/ClientProxy.sol",
     "protocol/libs/ClientLib.sol",
+    "ext_libs",
   ],
   mocha: {
     grep: "@skip-on-coverage", // Find everything with this tag

--- a/contracts/protocol/bases/BundleBase.sol
+++ b/contracts/protocol/bases/BundleBase.sol
@@ -88,9 +88,7 @@ contract BundleBase is ProtocolBase, IBosonBundleEvents {
             (bool bundleForTwinExist, ) = fetchBundleIdByTwin(twinId);
             require(!bundleForTwinExist, BUNDLE_TWIN_MUST_BE_UNIQUE);
 
-            if (_bundle.offerIds.length > 0) {
-                bundleSupplyChecks(offersTotalQuantityAvailable, twinId);
-            }
+            bundleSupplyChecks(offersTotalQuantityAvailable, twinId);
 
             // Push to bundleIdsByTwin mapping
             lookups.bundleIdByTwin[_bundle.twinIds[i]] = bundleId;

--- a/contracts/protocol/facets/DisputeResolverHandlerFacet.sol
+++ b/contracts/protocol/facets/DisputeResolverHandlerFacet.sol
@@ -862,18 +862,16 @@ contract DisputeResolverHandlerFacet is IBosonAccountEvents, ProtocolBase {
         ProtocolLib.ProtocolLookups storage _lookups
     ) internal view {
         // Check that the role is unique to one dispute resolver id across all roles -- not used or is used by this dispute resolver id.
-        if (_role != address(0)) {
-            uint256 check1 = _lookups.disputeResolverIdByOperator[_role];
-            uint256 check2 = _lookups.disputeResolverIdByClerk[_role];
-            uint256 check3 = _lookups.disputeResolverIdByAdmin[_role];
+        uint256 check1 = _lookups.disputeResolverIdByOperator[_role];
+        uint256 check2 = _lookups.disputeResolverIdByClerk[_role];
+        uint256 check3 = _lookups.disputeResolverIdByAdmin[_role];
 
-            require(
-                (check1 == 0 || check1 == _disputeResolverId) &&
-                    (check2 == 0 || check2 == _disputeResolverId) &&
-                    (check3 == 0 || check3 == _disputeResolverId),
-                DISPUTE_RESOLVER_ADDRESS_MUST_BE_UNIQUE
-            );
-        }
+        require(
+            (check1 == 0 || check1 == _disputeResolverId) &&
+                (check2 == 0 || check2 == _disputeResolverId) &&
+                (check3 == 0 || check3 == _disputeResolverId),
+            DISPUTE_RESOLVER_ADDRESS_MUST_BE_UNIQUE
+        );
     }
 
     /**

--- a/contracts/protocol/facets/SellerHandlerFacet.sol
+++ b/contracts/protocol/facets/SellerHandlerFacet.sol
@@ -132,7 +132,6 @@ contract SellerHandlerFacet is SellerBase {
             }
         } else if (_seller.admin != seller.admin) {
             preUpdateSellerCheck(_seller.id, _seller.admin, lookups);
-            require(_seller.admin != address(0), INVALID_ADDRESS);
             // If admin address exists, admin address owner must approve the update to prevent front-running
             sellerPendingUpdate.admin = _seller.admin;
             needsApproval = true;

--- a/scripts/config/revert-reasons.js
+++ b/scripts/config/revert-reasons.js
@@ -6,6 +6,7 @@ exports.RevertReasons = {
   ACCESS_DENIED: "Access denied, caller doesn't have role",
   NOT_BUYER_OR_SELLER: "Not buyer or seller",
   NOT_VOUCHER_HOLDER: "Not current voucher holder",
+  CAN_ONLY_REVOKE_SELF: "AccessControl: can only renounce roles for self",
 
   // Pause related
   NO_REGIONS_SPECIFIED: "Must specify at least one region to pause",

--- a/scripts/config/supported-interfaces.js
+++ b/scripts/config/supported-interfaces.js
@@ -53,6 +53,7 @@ const otherInterfaces = {
   IERC1155: "0xd9b67a26",
   IERC721: "0x80ac58cd",
   IERC2981: "0x2a55205a",
+  IAccessControl: "0x7965db0b",
 };
 
 async function getInterfaceIds() {

--- a/test/access/AccessControllerTest.js
+++ b/test/access/AccessControllerTest.js
@@ -304,7 +304,7 @@ describe("AccessController", function () {
     });
 
     it("Should not emit 'RoleRevoked' event if revoking a role that was not granted", async function () {
-      // Renounce Role, should not emit the event
+      // Revoke Role, should not emit the event
       await expect(accessController.connect(admin).revokeRole(Role.ADMIN, rando.address)).to.not.emit(
         accessController,
         "RoleRevoked"
@@ -452,7 +452,7 @@ describe("AccessController", function () {
     });
 
     it("Should revert if caller tries to grantRole but doesn't have ADMIN role", async function () {
-      // Renounce Role, expecting revert
+      // Grant Role, expecting revert
       await expect(accessController.connect(rando).grantRole(Role.ADMIN, rando.address)).to.be.revertedWith(
         `AccessControl: account ${rando.address.toLowerCase()} is missing role ${Role.ADMIN}`
       );

--- a/test/access/AccessControllerTest.js
+++ b/test/access/AccessControllerTest.js
@@ -304,7 +304,7 @@ describe("AccessController", function () {
     });
 
     it("Should not emit 'RoleRevoked' event if revoking a role that was not granted", async function () {
-      // Renounce Role, expecting the event
+      // Renounce Role, should not emit the event
       await expect(accessController.connect(admin).revokeRole(Role.ADMIN, rando.address)).to.not.emit(
         accessController,
         "RoleRevoked"
@@ -405,7 +405,7 @@ describe("AccessController", function () {
     });
 
     it("Should not emit 'RoleRevoked' event if renouncing a role that was not granted", async function () {
-      // Renounce Role, expecting the event
+      // Renounce Role, should not emit the event
       await expect(accessController.connect(rando).renounceRole(Role.ADMIN, rando.address)).to.not.emit(
         accessController,
         "RoleRevoked"
@@ -445,14 +445,14 @@ describe("AccessController", function () {
 
   context("💔 Revert Reasons", async function () {
     it("Caller is different from account to be renounced", async function () {
-      // Renounce Role, expecting the event
+      // Renounce Role, expecting revert
       await expect(accessController.connect(admin).renounceRole(Role.ADMIN, deployer.address)).to.be.revertedWith(
         RevertReasons.CAN_ONLY_REVOKE_SELF
       );
     });
 
-    it("Should revert if caller has no role", async function () {
-      // Renounce Role, expecting the event
+    it("Should revert if caller tries to grantRole but doesn't have ADMIN role", async function () {
+      // Renounce Role, expecting revert
       await expect(accessController.connect(rando).grantRole(Role.ADMIN, rando.address)).to.be.revertedWith(
         `AccessControl: account ${rando.address.toLowerCase()} is missing role ${Role.ADMIN}`
       );

--- a/test/access/AccessControllerTest.js
+++ b/test/access/AccessControllerTest.js
@@ -2,23 +2,43 @@ const hre = require("hardhat");
 const ethers = hre.ethers;
 const { expect } = require("chai");
 const Role = require("../../scripts/domain/Role");
+const { getInterfaceIds } = require("../../scripts/config/supported-interfaces.js");
+const { RevertReasons } = require("../../scripts/config/revert-reasons.js");
 
 /**
  *  Test the AccessController contract
  */
 describe("AccessController", function () {
   // Shared args
-  let deployer, admin, protocol, upgrader, associate, pauser, client, feeCollector;
+  let deployer, admin, protocol, upgrader, associate, pauser, client, feeCollector, rando;
   let AccessController, accessController, roleAdmin;
+  let InterfaceIds;
+
+  before(async function () {
+    // get interface Ids
+    InterfaceIds = await getInterfaceIds();
+  });
 
   beforeEach(async function () {
     // Make accounts available
-    [deployer, admin, protocol, upgrader, associate, pauser, client, feeCollector] = await ethers.getSigners();
+    [deployer, admin, protocol, upgrader, associate, pauser, client, feeCollector, rando] = await ethers.getSigners();
 
     // Deploy the contract
     AccessController = await ethers.getContractFactory("AccessController");
     accessController = await AccessController.deploy();
     await accessController.deployed();
+  });
+
+  context("📋 Interfaces", async function () {
+    context("👉 supportsInterface()", async function () {
+      it("should indicate support for IAccessControl interface", async function () {
+        // Current interfaceId for IAccessControl
+        const support = await accessController.supportsInterface(InterfaceIds.IAccessControl);
+
+        // Test
+        expect(support, "IAccessControl interface not supported").is.true;
+      });
+    });
   });
 
   context("📋 Deployer is limited to initial ADMIN role", async function () {
@@ -282,6 +302,17 @@ describe("AccessController", function () {
         "ADMIN role can't revoke FEE_COLLECTOR role"
       ).is.false;
     });
+
+    it("Should not emit 'RoleRevoked' event if revoking a role that was not granted", async function () {
+      // Renounce Role, expecting the event
+      await expect(accessController.connect(admin).revokeRole(Role.ADMIN, rando.address)).to.not.emit(
+        accessController,
+        "RoleRevoked"
+      );
+
+      // Test
+      expect(await accessController.hasRole(Role.ADMIN, rando.address)).is.false;
+    });
   });
 
   context("📋 Any roled address can renounce its roles", async function () {
@@ -372,6 +403,17 @@ describe("AccessController", function () {
         "FEE_COLLECTOR role can't renounce FEE_COLLECTOR role"
       ).is.false;
     });
+
+    it("Should not emit 'RoleRevoked' event if renouncing a role that was not granted", async function () {
+      // Renounce Role, expecting the event
+      await expect(accessController.connect(rando).renounceRole(Role.ADMIN, rando.address)).to.not.emit(
+        accessController,
+        "RoleRevoked"
+      );
+
+      // Test
+      expect(await accessController.hasRole(Role.ADMIN, rando.address)).is.false;
+    });
   });
 
   context("📋 Any address can have multiple roles", async function () {
@@ -398,6 +440,22 @@ describe("AccessController", function () {
       expect(await accessController.hasRole(Role.PAUSER, associate.address)).is.true;
       expect(await accessController.hasRole(Role.CLIENT, associate.address)).is.true;
       expect(await accessController.hasRole(Role.FEE_COLLECTOR, associate.address)).is.true;
+    });
+  });
+
+  context("💔 Revert Reasons", async function () {
+    it("Caller is different from account to be renounced", async function () {
+      // Renounce Role, expecting the event
+      await expect(accessController.connect(admin).renounceRole(Role.ADMIN, deployer.address)).to.be.revertedWith(
+        RevertReasons.CAN_ONLY_REVOKE_SELF
+      );
+    });
+
+    it("Should revert if caller has no role", async function () {
+      // Renounce Role, expecting the event
+      await expect(accessController.connect(rando).grantRole(Role.ADMIN, rando.address)).to.be.revertedWith(
+        `AccessControl: account ${rando.address.toLowerCase()} is missing role ${Role.ADMIN}`
+      );
     });
   });
 });

--- a/test/protocol/DisputeResolverHandlerTest.js
+++ b/test/protocol/DisputeResolverHandlerTest.js
@@ -2454,7 +2454,7 @@ describe("DisputeResolverHandler", function () {
           );
       });
 
-      it("Should not emit 'DisputeResolverUpdateApplied' event if caller doesn't especify any field", async function () {
+      it("Should not emit 'DisputeResolverUpdateApplied' event if caller doesn't specify any field", async function () {
         disputeResolver.operator = other1.address;
         await accountHandler.connect(admin).updateDisputeResolver(disputeResolver);
 
@@ -2464,7 +2464,7 @@ describe("DisputeResolverHandler", function () {
         );
       });
 
-      it("Should not emit 'DisputeResolverUpdateApplied'event if there is no pending update for especified field", async function () {
+      it("Should not emit 'DisputeResolverUpdateApplied'event if there is no pending update for specified field", async function () {
         disputeResolver.operator = other1.address;
         await accountHandler.connect(admin).updateDisputeResolver(disputeResolver);
 

--- a/test/protocol/DisputeResolverHandlerTest.js
+++ b/test/protocol/DisputeResolverHandlerTest.js
@@ -2454,6 +2454,27 @@ describe("DisputeResolverHandler", function () {
           );
       });
 
+      it("Should not emit 'DisputeResolverUpdateApplied' event if caller doesn't especify any field", async function () {
+        disputeResolver.operator = other1.address;
+        await accountHandler.connect(admin).updateDisputeResolver(disputeResolver);
+
+        await expect(accountHandler.connect(other1).optInToDisputeResolverUpdate(disputeResolver.id, [])).to.not.emit(
+          accountHandler,
+          "DisputeResolverUpdateApplied"
+        );
+      });
+
+      it("Should not emit 'DisputeResolverUpdateApplied'event if there is no pending update for especified field", async function () {
+        disputeResolver.operator = other1.address;
+        await accountHandler.connect(admin).updateDisputeResolver(disputeResolver);
+
+        await expect(
+          accountHandler
+            .connect(other1)
+            .optInToDisputeResolverUpdate(disputeResolver.id, [DisputeResolverUpdateFields.Clerk])
+        ).to.not.emit(accountHandler, "DisputeResolverUpdateApplied");
+      });
+
       context("💔 Revert Reasons", async function () {
         it("There are no pending updates", async function () {
           disputeResolver.clerk = other1.address;

--- a/test/protocol/ProtocolDiamondTest.js
+++ b/test/protocol/ProtocolDiamondTest.js
@@ -172,7 +172,7 @@ describe("ProtocolDiamond", async function () {
       });
     });
 
-    context("👉 facetAddresses()", async () => {
+    context.only("👉 facetAddresses()", async () => {
       it("should return three facet addresses", async () => {
         // Make sure the count is correct
         assert.equal(addresses.length, 3);
@@ -187,6 +187,39 @@ describe("ProtocolDiamond", async function () {
 
         // ERC165Facet was last cut
         assert.equal(addresses[2], erc165.address);
+      });
+
+      it("Should return correct addresses even when selectorCount is greater than 8", async () => {
+        // Deploy Test1Facet to have more selectors
+        Test1Facet = await ethers.getContractFactory("Test1Facet");
+        test1Facet = await Test1Facet.deploy();
+        await test1Facet.deployed();
+
+        // Get the Test1Facet function selectors from the abi
+        selectors = getSelectors(test1Facet);
+
+        // Define the facet cut
+        facetCuts = [
+          {
+            facetAddress: test1Facet.address,
+            action: FacetCutAction.Add,
+            functionSelectors: selectors,
+          },
+        ];
+
+        // Send the DiamondCut transaction
+        await cutFacetViaDiamond
+          .connect(upgrader)
+          .diamondCut(facetCuts, ethers.constants.AddressZero, "0x", { gasLimit });
+
+        const addresses = await loupeFacetViaDiamond.facetAddresses();
+
+        assert.equal(addresses[0], diamondLoupe.address);
+        assert.equal(addresses[1], diamondCut.address);
+        assert.equal(addresses[2], erc165.address);
+        assert.equal(addresses[3], test1Facet.address);
+
+        assert.equal(addresses.length, 4);
       });
     });
 
@@ -787,6 +820,22 @@ describe("ProtocolDiamond", async function () {
           cutFacetViaDiamond.connect(upgrader).diamondCut(facetCuts, ethers.constants.AddressZero, "0x", { gasLimit })
         ).to.be.revertedWith(RevertReasons.REPLACING_FUNCTION_DOES_NOT_EXIST);
       });
+    });
+
+    it("Should revert when action is not supported", async function () {
+      // Define the facet cuts
+      facetCuts = [
+        {
+          facetAddress: test1Facet.address,
+          action: 3,
+          functionSelectors: getSelectors(test1Facet),
+        },
+      ];
+
+      // Send the DiamondCut transaction
+      await expect(
+        cutFacetViaDiamond.connect(upgrader).diamondCut(facetCuts, ethers.constants.AddressZero, "0x", { gasLimit })
+      ).to.be.reverted;
     });
   });
 

--- a/test/protocol/ProtocolDiamondTest.js
+++ b/test/protocol/ProtocolDiamondTest.js
@@ -172,7 +172,7 @@ describe("ProtocolDiamond", async function () {
       });
     });
 
-    context.only("👉 facetAddresses()", async () => {
+    context("👉 facetAddresses()", async () => {
       it("should return three facet addresses", async () => {
         // Make sure the count is correct
         assert.equal(addresses.length, 3);

--- a/test/protocol/SellerHandlerTest.js
+++ b/test/protocol/SellerHandlerTest.js
@@ -906,6 +906,17 @@ describe("SellerHandler", function () {
           ).to.revertedWith(RevertReasons.NOT_OPERATOR_AND_CLERK);
         });
 
+        it("addresses are the zero address", async function () {
+          seller.operator = ethers.constants.AddressZero;
+          seller.treasury = ethers.constants.AddressZero;
+          seller.clerk = ethers.constants.AddressZero;
+
+          // Attempt to update a seller, expecting revert
+          await expect(
+            accountHandler.connect(rando).createSeller(seller, emptyAuthToken, voucherInitValues)
+          ).to.revertedWith(RevertReasons.INVALID_ADDRESS);
+        });
+
         it("Operator address is zero address", async function () {
           seller.operator = ethers.constants.AddressZero;
 

--- a/test/protocol/SellerHandlerTest.js
+++ b/test/protocol/SellerHandlerTest.js
@@ -2199,7 +2199,7 @@ describe("SellerHandler", function () {
 
         it("addresses are the zero address", async function () {
           seller.operator = ethers.constants.AddressZero;
-          seller.admin = ethers.constants.AddressZero;
+          seller.treasury = ethers.constants.AddressZero;
           seller.clerk = ethers.constants.AddressZero;
 
           // Attempt to update a seller, expecting revert
@@ -2631,7 +2631,7 @@ describe("SellerHandler", function () {
           );
       });
 
-      it("Should not emit 'SellerUpdateApplied' event if caller doesn't especify any field", async function () {
+      it("Should not emit 'SellerUpdateApplied' event if caller doesn't specify any field", async function () {
         seller.operator = other1.address;
         await accountHandler.connect(admin).updateSeller(seller, emptyAuthToken);
 
@@ -2641,7 +2641,7 @@ describe("SellerHandler", function () {
         );
       });
 
-      it("Should not emit 'SellerUpdateApplied'event if there is no pending update for especified field", async function () {
+      it("Should not emit 'SellerUpdateApplied'event if there is no pending update for specified field", async function () {
         seller.operator = other1.address;
         await accountHandler.connect(admin).updateSeller(seller, emptyAuthToken);
 

--- a/test/protocol/SellerHandlerTest.js
+++ b/test/protocol/SellerHandlerTest.js
@@ -2203,7 +2203,7 @@ describe("SellerHandler", function () {
           seller.clerk = ethers.constants.AddressZero;
 
           // Attempt to update a seller, expecting revert
-          await expect(accountHandler.connect(authTokenOwner).updateSeller(seller, authToken)).to.revertedWith(
+          await expect(accountHandler.connect(authTokenOwner).updateSeller(seller, emptyAuthToken)).to.revertedWith(
             RevertReasons.INVALID_ADDRESS
           );
         });

--- a/test/protocol/SellerHandlerTest.js
+++ b/test/protocol/SellerHandlerTest.js
@@ -905,6 +905,33 @@ describe("SellerHandler", function () {
             accountHandler.connect(rando).createSeller(seller, emptyAuthToken, voucherInitValues)
           ).to.revertedWith(RevertReasons.NOT_OPERATOR_AND_CLERK);
         });
+
+        it("Operator address is zero address", async function () {
+          seller.operator = ethers.constants.AddressZero;
+
+          // Attempt to Create a seller with operator == zero address
+          await expect(
+            accountHandler.connect(authTokenOwner).createSeller(seller, emptyAuthToken, voucherInitValues)
+          ).to.revertedWith(RevertReasons.INVALID_ADDRESS);
+        });
+
+        it("Clerk address is zero address", async function () {
+          seller.clerk = ethers.constants.AddressZero;
+
+          // Attempt to Create a seller with clerk == zero address
+          await expect(
+            accountHandler.connect(authTokenOwner).createSeller(seller, emptyAuthToken, voucherInitValues)
+          ).to.revertedWith(RevertReasons.INVALID_ADDRESS);
+        });
+
+        it("Treasury address is zero address", async function () {
+          seller.treasury = ethers.constants.AddressZero;
+
+          // Attempt to Create a seller with treasury == zero address
+          await expect(
+            accountHandler.connect(authTokenOwner).createSeller(seller, emptyAuthToken, voucherInitValues)
+          ).to.revertedWith(RevertReasons.INVALID_ADDRESS);
+        });
       });
     });
 
@@ -2181,6 +2208,33 @@ describe("SellerHandler", function () {
           );
         });
 
+        it("Operator is the zero address", async function () {
+          seller.operator = ethers.constants.AddressZero;
+
+          // Attempt to update a seller, expecting revert
+          await expect(accountHandler.connect(authTokenOwner).updateSeller(seller, emptyAuthToken)).to.revertedWith(
+            RevertReasons.INVALID_ADDRESS
+          );
+        });
+
+        it("Clerk is the zero address", async function () {
+          seller.clerk = ethers.constants.AddressZero;
+
+          // Attempt to update a seller, expecting revert
+          await expect(accountHandler.connect(authTokenOwner).updateSeller(seller, emptyAuthToken)).to.revertedWith(
+            RevertReasons.INVALID_ADDRESS
+          );
+        });
+
+        it("Treasury is the zero address", async function () {
+          seller.treasury = ethers.constants.AddressZero;
+
+          // Attempt to update a seller, expecting revert
+          await expect(accountHandler.connect(authTokenOwner).updateSeller(seller, emptyAuthToken)).to.revertedWith(
+            RevertReasons.INVALID_ADDRESS
+          );
+        });
+
         it("addresses are not unique to this seller Id when addresses used for same role", async function () {
           seller.id = accountId.next().value;
           seller.operator = other1.address;
@@ -2575,6 +2629,25 @@ describe("SellerHandler", function () {
             emptyAuthTokenStruct,
             rando.address
           );
+      });
+
+      it("Should not emit 'SellerUpdateApplied' event if caller doesn't especify any field", async function () {
+        seller.operator = other1.address;
+        await accountHandler.connect(admin).updateSeller(seller, emptyAuthToken);
+
+        await expect(accountHandler.connect(other1).optInToSellerUpdate(seller.id, [])).to.not.emit(
+          accountHandler,
+          "SellerUpdateApplied"
+        );
+      });
+
+      it("Should not emit 'SellerUpdateApplied'event if there is no pending update for especified field", async function () {
+        seller.operator = other1.address;
+        await accountHandler.connect(admin).updateSeller(seller, emptyAuthToken);
+
+        await expect(
+          accountHandler.connect(other1).optInToSellerUpdate(seller.id, [SellerUpdateFields.Clerk])
+        ).to.not.emit(accountHandler, "SellerUpdateApplied");
       });
 
       context("💔 Revert Reasons", async function () {


### PR DESCRIPTION
**This PR adds new unit tests to cover uncovered branches and statements and remove some unachieved code on contracts**

The impossible test cases were described here https://docs.google.com/document/d/1K4YGbpV4QevqxfsJQOfsJAisco2udJ-ltC94MCQK8wk/edit

### Contract changes 

- Remove the if statement on
```solidity
      if (_bundle.offerIds.length > 0) {
                 bundleSupplyChecks(offersTotalQuantityAvailable, twinId);
       }
```

because `offerIds` length has to be greater than 0 (we revert above on line 51 when offerIds length is 0). See https://github.com/bosonprotocol/boson-protocol-contracts/blob/fbb731bfb513b5e281bf8aadb425a5831338a332/contracts/protocol/bases/BundleBase.sol#L51-L53

- Remove the if statement on 
```solidity
    if (_role != address(0)) {
            uint256 check1 = _lookups.disputeResolverIdByOperator[_role];
            uint256 check2 = _lookups.disputeResolverIdByClerk[_role];
            uint256 check3 = _lookups.disputeResolverIdByAdmin[_role];

            require(
                (check1 == 0 || check1 == _disputeResolverId) &&
                    (check2 == 0 || check2 == _disputeResolverId) &&
                    (check3 == 0 || check3 == _disputeResolverId),
                DISPUTE_RESOLVER_ADDRESS_MUST_BE_UNIQUE
            );
        }
```
because on `updateDisputeResolver` we're reverting when any address is 0
https://github.com/bosonprotocol/boson-protocol-contracts/blob/fbb731bfb513b5e281bf8aadb425a5831338a332/contracts/protocol/facets/DisputeResolverHandlerFacet.sol#L189-L195
and on `optInToUpdateDisputeResolver` we have an if statement that prevents from calling that function with role = address(0)
https://github.com/bosonprotocol/boson-protocol-contracts/blob/fbb731bfb513b5e281bf8aadb425a5831338a332/contracts/protocol/facets/DisputeResolverHandlerFacet.sol#L327

- Remove the revert on 
https://github.com/bosonprotocol/boson-protocol-contracts/blob/fbb731bfb513b5e281bf8aadb425a5831338a332/contracts/protocol/facets/SellerHandlerFacet.sol#L135
since when admin address is 0 means that auth token has been used and we never achieve this line 

## Notes

I don't know if its a bug in the code coverage library but yesterday the code coverage on BeaconClientProxy and Proxy contracts were reported with very low coverage so I was writing unit tests on `BeaconClientProxy.js` but today, when I ran it again they were reported with 100% coverage. 

[coverage-all.zip](https://github.com/bosonprotocol/boson-protocol-contracts/files/9938469/coverage-all.zip)

