### PR TITLE
Remove unusable CLI support

### DIFF
--- a/scripts/util/cast-protocol-client-proxies.js
+++ b/scripts/util/cast-protocol-client-proxies.js
@@ -30,13 +30,4 @@ async function castProtocolClientProxies(protocolClientProxies) {
   return [bosonVoucher];
 }
 
-if (require.main === module) {
-  castProtocolClientProxies()
-    .then(() => process.exit(0))
-    .catch((error) => {
-      console.error(error);
-      process.exit(1);
-    });
-}
-
 exports.castProtocolClientProxies = castProtocolClientProxies;

--- a/scripts/util/deploy-protocol-client-beacons.js
+++ b/scripts/util/deploy-protocol-client-beacons.js
@@ -1,7 +1,7 @@
 const hre = require("hardhat");
 const ethers = hre.ethers;
 const environments = require("../../environments");
-const confirmations = hre.network.name == "hardhat" ? 1 : environments.confirmations;
+const confirmations = hre.network.name === "hardhat" ? 1 : environments.confirmations;
 const { getFees } = require("./utils");
 
 /**
@@ -37,15 +37,6 @@ async function deployProtocolClientBeacons(protocolClients, protocolClientArgs, 
   await clientBeacon.deployTransaction.wait(confirmations);
 
   return [clientBeacon];
-}
-
-if (require.main === module) {
-  deployProtocolClientBeacons()
-    .then(() => process.exit(0))
-    .catch((error) => {
-      console.error(error);
-      process.exit(1);
-    });
 }
 
 exports.deployProtocolClientBeacons = deployProtocolClientBeacons;

--- a/scripts/util/deploy-protocol-client-impls.js
+++ b/scripts/util/deploy-protocol-client-impls.js
@@ -1,7 +1,7 @@
 const hre = require("hardhat");
 const ethers = hre.ethers;
 const environments = require("../../environments");
-const confirmations = hre.network.name == "hardhat" ? 1 : environments.confirmations;
+const confirmations = hre.network.name === "hardhat" ? 1 : environments.confirmations;
 const { getFees } = require("./utils");
 
 /**
@@ -25,15 +25,6 @@ async function deployProtocolClientImpls(maxPriorityFeePerGas) {
   await bosonVoucher.deployTransaction.wait(confirmations);
 
   return [bosonVoucher];
-}
-
-if (require.main === module) {
-  deployProtocolClientImpls()
-    .then(() => process.exit(0))
-    .catch((error) => {
-      console.error(error);
-      process.exit(1);
-    });
 }
 
 exports.deployProtocolClientImpls = deployProtocolClientImpls;

--- a/scripts/util/deploy-protocol-client-proxies.js
+++ b/scripts/util/deploy-protocol-client-proxies.js
@@ -1,7 +1,7 @@
 const hre = require("hardhat");
 const ethers = hre.ethers;
 const environments = require("../../environments");
-const confirmations = hre.network.name == "hardhat" ? 1 : environments.confirmations;
+const confirmations = hre.network.name === "hardhat" ? 1 : environments.confirmations;
 const { getFees } = require("./utils");
 
 /**
@@ -19,7 +19,6 @@ const { getFees } = require("./utils");
  * and deploys a ProtocolClientProxy for each one.
  *
  * @param protocolClients
- * @param protocolClientArgs
  * @param maxPriorityFeePerGas - maxPriorityFeePerGas for transactions
  * @returns {Promise<(*|*|*)[]>}
  */
@@ -42,15 +41,6 @@ async function deployProtocolClientProxies(protocolClients, maxPriorityFeePerGas
   await transactionResponse.wait(confirmations);
 
   return [clientProxy];
-}
-
-if (require.main === module) {
-  deployProtocolClientProxies()
-    .then(() => process.exit(0))
-    .catch((error) => {
-      console.error(error);
-      process.exit(1);
-    });
 }
 
 exports.deployProtocolClientProxies = deployProtocolClientProxies;

--- a/scripts/util/deploy-protocol-clients.js
+++ b/scripts/util/deploy-protocol-clients.js
@@ -38,13 +38,4 @@ async function deployProtocolClients(protocolClientArgs, maxPriorityFeePerGas) {
   return [protocolClientImpls, protocolClientBeacons, protocolClientProxies, protocolClients];
 }
 
-if (require.main === module) {
-  deployProtocolClients()
-    .then(() => process.exit(0))
-    .catch((error) => {
-      console.error(error);
-      process.exit(1);
-    });
-}
-
 exports.deployProtocolClients = deployProtocolClients;

--- a/scripts/util/deploy-protocol-config-facet.js
+++ b/scripts/util/deploy-protocol-config-facet.js
@@ -23,13 +23,4 @@ async function deployProtocolConfigFacet(diamond, config, maxPriorityFeePerGas) 
   return { facets: [deployedFacet[0].contract], cutTransaction: deployedFacet[0].cutTransaction };
 }
 
-if (require.main === module) {
-  deployProtocolConfigFacet()
-    .then(() => process.exit(0))
-    .catch((error) => {
-      console.error(error);
-      process.exit(1);
-    });
-}
-
 exports.deployProtocolConfigFacet = deployProtocolConfigFacet;

--- a/scripts/util/deploy-protocol-diamond.js
+++ b/scripts/util/deploy-protocol-diamond.js
@@ -3,7 +3,7 @@ const { getInterfaceIds } = require("../config/supported-interfaces.js");
 const hre = require("hardhat");
 const ethers = hre.ethers;
 const environments = require("../../environments");
-const confirmations = hre.network.name == "hardhat" ? 1 : environments.confirmations;
+const confirmations = hre.network.name === "hardhat" ? 1 : environments.confirmations;
 const { getFees } = require("./utils");
 
 /**
@@ -59,15 +59,6 @@ async function deployProtocolDiamond(maxPriorityFeePerGas) {
   await protocolDiamond.deployTransaction.wait(confirmations);
 
   return [protocolDiamond, dlf, dcf, erc165f, accessController, diamondArgs];
-}
-
-if (require.main === module) {
-  deployProtocolDiamond()
-    .then(() => process.exit(0))
-    .catch((error) => {
-      console.error(error);
-      process.exit(1);
-    });
 }
 
 exports.deployProtocolDiamond = deployProtocolDiamond;

--- a/scripts/util/deploy-protocol-handler-facets.js
+++ b/scripts/util/deploy-protocol-handler-facets.js
@@ -2,7 +2,7 @@ const { getFacetAddCut } = require("./diamond-utils.js");
 const hre = require("hardhat");
 const ethers = hre.ethers;
 const environments = require("../../environments");
-const confirmations = hre.network.name == "hardhat" ? 1 : environments.confirmations;
+const confirmations = hre.network.name === "hardhat" ? 1 : environments.confirmations;
 const { getFees } = require("./utils");
 
 /**
@@ -76,15 +76,6 @@ async function deployProtocolHandlerFacetsWithArgs(diamond, facetData, maxPriori
 
   // Return an array of objects with facet name and contract properties
   return deployedFacets;
-}
-
-if (require.main === module) {
-  deployProtocolHandlerFacets()
-    .then(() => process.exit(0))
-    .catch((error) => {
-      console.error(error);
-      process.exit(1);
-    });
 }
 
 exports.deployProtocolHandlerFacets = deployProtocolHandlerFacets;


### PR DESCRIPTION
Because copypasta, we have several unusable CLI support methods in utilities that take args, don't have a hardhat task to enable CLI args, and are only called by other scripts. These unusable methods take the form of:

```
if (require.main === module) {
  functionThatNeedsArguments()
    .then(() => process.exit(0))
    .catch((error) => {
      console.error(error);
      process.exit(1);
    });
}
```

Additionally,
  - fixed some warnings about unexpected type coercion when checking `hre.network.name === "hardhat"`
  - removed an unused @param from JSDoc