### PR TITLE
Verify succesful upgrade - refactor

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -45,18 +45,20 @@ task(
   "Deploy suite deploys protocol diamond, all facets, client and beacon, and initializes protcol diamond"
 )
   .addOptionalParam("env", "The deployment environment")
-  .setAction(async ({ env }) => {
+  .addOptionalParam("facetConfig", "JSON list of facets to deploy")
+  .setAction(async ({ env, facetConfig }) => {
     const { deploySuite } = await lazyImport("./scripts/deploy-suite.js");
 
-    await deploySuite(env);
+    await deploySuite(env, facetConfig);
   });
 
 task("upgrade-facets", "Upgrade existing facets, add new facets or remove existing facets")
   .addOptionalParam("env", "The deployment environment")
-  .setAction(async ({ env }) => {
+  .addOptionalParam("facetConfig", "JSON list of facets to upgrade")
+  .setAction(async ({ env, facetConfig }) => {
     const { upgradeFacets } = await lazyImport("./scripts/upgrade-facets.js");
 
-    await upgradeFacets(env);
+    await upgradeFacets(env, facetConfig);
   });
 
 task("manage-roles", "Grant or revoke access control roles")

--- a/scripts/deploy-suite.js
+++ b/scripts/deploy-suite.js
@@ -73,7 +73,7 @@ async function getArgFacetNames() {
   return (await getFacets()).argFacets;
 }
 
-async function main(env) {
+async function main(env, facetConfig) {
   // Compile everything (in case run by node)
   await hre.run("compile");
 
@@ -148,11 +148,19 @@ async function main(env) {
   console.log(`\n💎 Deploying and initializing protocol handler facets...`);
 
   // Deploy and cut facets
-  const deployedFacets = await deployProtocolHandlerFacets(
-    protocolDiamond,
-    await getNoArgFacetNames(),
-    maxPriorityFeePerGas
-  );
+  let noArgFacetNames, argFacetNames;
+  if (facetConfig) {
+    // facetConfig was passed in as a JSON object
+    const facetConfigObject = JSON.parse(facetConfig);
+    noArgFacetNames = facetConfigObject.noArgFacets;
+    argFacetNames = facetConfigObject.argFacets;
+  } else {
+    // Get values from default config file
+    noArgFacetNames = await getNoArgFacetNames();
+    argFacetNames = await getArgFacetNames();
+  }
+
+  const deployedFacets = await deployProtocolHandlerFacets(protocolDiamond, noArgFacetNames, maxPriorityFeePerGas);
   for (const deployedFacet of deployedFacets) {
     deploymentComplete(
       deployedFacet.name,
@@ -165,7 +173,7 @@ async function main(env) {
 
   const deployedFacetsWithArgs = await deployProtocolHandlerFacetsWithArgs(
     protocolDiamond,
-    await getArgFacetNames(),
+    argFacetNames,
     maxPriorityFeePerGas
   );
   for (const deployedFacet of deployedFacetsWithArgs) {

--- a/scripts/upgrade-facets.js
+++ b/scripts/upgrade-facets.js
@@ -33,7 +33,7 @@ const rl = readline.createInterface({
  *  2. Run the appropriate npm script in package.json to upgrade facets for a given network
  *  3. Save changes to the repo as a record of what was upgraded
  */
-async function main(env) {
+async function main(env, facetConfig) {
   // Bail now if hardhat network, unless the upgrade is tested
   if (network === "hardhat" && env !== "upgrade-test") process.exit();
 
@@ -113,7 +113,14 @@ async function main(env) {
   }
 
   // Get facets to upgrade
-  const facets = await getFacets();
+  let facets;
+  if (facetConfig) {
+    // facetConfig was passed in as a JSON object
+    facets = JSON.parse(facetConfig);
+  } else {
+    // Get values from default config file
+    facets = await getFacets();
+  }
 
   // Deploy new facets
   const deployedFacets = await deployProtocolHandlerFacets(

--- a/test/upgrade/00_config.js
+++ b/test/upgrade/00_config.js
@@ -1,0 +1,44 @@
+/*
+Immutable facet configs for deployment and upgrade, used in upgrade test.
+
+This file contains deployment and upgrade configs for each tag. Format of config must adhere to format specified in
+- scripts/config/facet-deploy.js
+- scripts/config/facet-upgrade.js
+
+*/
+
+const facets = {
+  deploy: {
+    "v2.0.0": {
+      noArgFacets: [
+        "AccountHandlerFacet",
+        "SellerHandlerFacet",
+        "BuyerHandlerFacet",
+        "DisputeResolverHandlerFacet",
+        "AgentHandlerFacet",
+        "BundleHandlerFacet",
+        "DisputeHandlerFacet",
+        "ExchangeHandlerFacet",
+        "FundsHandlerFacet",
+        "GroupHandlerFacet",
+        "OfferHandlerFacet",
+        "OrchestrationHandlerFacet",
+        "TwinHandlerFacet",
+        "PauseHandlerFacet",
+        "MetaTransactionsHandlerFacet",
+      ],
+      argFacets: {},
+    },
+  },
+  upgrade: {
+    "v2.1.0": {
+      addOrUpgrade: ["ERC165Facet", "AccountHandlerFacet", "SellerHandlerFacet", "DisputeResolverHandlerFacet"],
+      remove: [],
+      skipSelectors: {},
+      initArgs: {},
+      skipInit: ["ERC165Facet"],
+    },
+  },
+};
+
+exports.facets = facets;

--- a/test/upgrade/01_generic.js
+++ b/test/upgrade/01_generic.js
@@ -1,0 +1,293 @@
+const hre = require("hardhat");
+const ethers = hre.ethers;
+const { assert, expect } = require("chai");
+const { mockOffer, mockVoucher, mockExchange } = require("../util/mock");
+const { getEvent, calculateVoucherExpiry } = require("../util/utils.js");
+const Exchange = require("../../scripts/domain/Exchange");
+const Voucher = require("../../scripts/domain/Voucher");
+const { populateProtocolContract, getProtocolContractState } = require("../util/upgrade");
+
+// returns function with test that can be reused in every upgrade
+function getGenericContext(
+  deployer,
+  protocolDiamondAddress,
+  protocolContracts,
+  mockContracts,
+  protocolContractState,
+  preUpgradeEntities,
+  snapshot
+) {
+  let postUpgradeEntities;
+  let exchangeHandler, offerHandler, fundsHandler;
+  let mockToken;
+
+  ({ exchangeHandler, offerHandler, fundsHandler } = protocolContracts);
+  ({ mockToken } = mockContracts);
+
+  const genericContextFunction = async function () {
+    afterEach(async function () {
+      // revert to state right after the upgrade
+      // this is used so the lengthly setup (deploy+upgrade) is done only once
+      await ethers.provider.send("evm_revert", [snapshot]);
+      snapshot = await ethers.provider.send("evm_snapshot", []);
+    });
+
+    // Exchange methods
+    context("📋 Right After upgrade", async function () {
+      it("State is not affected directly after the update", async function () {
+        // Get protocol state after the upgrade
+        const protocolContractStateAfterUpgrade = await getProtocolContractState(
+          protocolDiamondAddress,
+          protocolContracts,
+          mockContracts,
+          preUpgradeEntities
+        );
+
+        // State before and after should be equal
+        assert.deepEqual(protocolContractState, protocolContractStateAfterUpgrade, "state mismatch after upgrade");
+      });
+    });
+
+    // Create new protocol entities. Existing data should not be affected
+    context("📋 New data after the upgrade do not corrupt the data from before the upgrade", async function () {
+      it("State is not affected", async function () {
+        postUpgradeEntities = await populateProtocolContract(
+          deployer,
+          protocolDiamondAddress,
+          protocolContracts,
+          mockContracts
+        );
+
+        // Get protocol state after the upgrade
+        // First get the data tha should be in location of old data
+        const protocolContractStateAfterUpgradeAndActions = await getProtocolContractState(
+          protocolDiamondAddress,
+          protocolContracts,
+          mockContracts,
+          preUpgradeEntities
+        );
+
+        // Counters are the only values that should be changed
+        // We check that the number increased for expected amount
+        // This also confirms that entities were actually created
+        const accountCount =
+          postUpgradeEntities.sellers.length +
+          postUpgradeEntities.DRs.length +
+          postUpgradeEntities.agents.length +
+          postUpgradeEntities.buyers.length;
+        assert.equal(
+          protocolContractStateAfterUpgradeAndActions.accountContractState.nextAccountId.toNumber(),
+          protocolContractState.accountContractState.nextAccountId.add(accountCount).toNumber(),
+          "nextAccountId mismatch"
+        );
+        assert.equal(
+          protocolContractStateAfterUpgradeAndActions.exchangeContractState.nextExchangeId.toNumber(),
+          protocolContractState.exchangeContractState.nextExchangeId
+            .add(postUpgradeEntities.exchanges.length)
+            .toNumber(),
+          "nextExchangeId mismatch"
+        );
+        assert.equal(
+          protocolContractStateAfterUpgradeAndActions.groupContractState.nextGroupId.toNumber(),
+          protocolContractState.groupContractState.nextGroupId.add(postUpgradeEntities.groups.length).toNumber(),
+          "nextGroupId mismatch"
+        );
+        assert.equal(
+          protocolContractStateAfterUpgradeAndActions.offerContractState.nextOfferId.toNumber(),
+          protocolContractState.offerContractState.nextOfferId.add(postUpgradeEntities.offers.length).toNumber(),
+          "nextOfferId mismatch"
+        );
+        assert.equal(
+          protocolContractStateAfterUpgradeAndActions.twinContractState.nextTwinId.toNumber(),
+          protocolContractState.twinContractState.nextTwinId.add(postUpgradeEntities.twins.length).toNumber(),
+          "nextTwinId mismatch"
+        );
+        assert.equal(
+          protocolContractStateAfterUpgradeAndActions.bundleContractState.nextBundleId.toNumber(),
+          protocolContractState.bundleContractState.nextBundleId.add(postUpgradeEntities.bundles.length).toNumber()
+        );
+
+        // State before and after should be equal
+        // remove nextXXid before comparing. Their correct value is verified already
+        delete protocolContractStateAfterUpgradeAndActions.accountContractState.nextAccountId;
+        delete protocolContractStateAfterUpgradeAndActions.exchangeContractState.nextExchangeId;
+        delete protocolContractStateAfterUpgradeAndActions.groupContractState.nextGroupId;
+        delete protocolContractStateAfterUpgradeAndActions.offerContractState.nextOfferId;
+        delete protocolContractStateAfterUpgradeAndActions.twinContractState.nextTwinId;
+        delete protocolContractStateAfterUpgradeAndActions.bundleContractState.nextBundleId;
+        delete protocolContractState.accountContractState.nextAccountId;
+        delete protocolContractState.exchangeContractState.nextExchangeId;
+        delete protocolContractState.groupContractState.nextGroupId;
+        delete protocolContractState.offerContractState.nextOfferId;
+        delete protocolContractState.twinContractState.nextTwinId;
+        delete protocolContractState.bundleContractState.nextBundleId;
+        assert.deepEqual(
+          protocolContractState,
+          protocolContractStateAfterUpgradeAndActions,
+          "state mismatch after upgrade"
+        );
+      });
+    });
+
+    // Test that offers and exchanges from before the upgrade can normally be used
+    // Check that correct events are emitted. State is not checked since units and integration test should make sure that event and state are consistent
+    context("📋 Interactions after the upgrade still work", async function () {
+      it("Commit to old offers", async function () {
+        const { offer, offerDates, offerDurations } = preUpgradeEntities.offers[1]; // pick some random offer
+        const offerPrice = offer.price;
+        const buyer = preUpgradeEntities.buyers[1];
+        let msgValue;
+        if (offer.exchangeToken == ethers.constants.AddressZero) {
+          msgValue = offerPrice;
+        } else {
+          // approve token transfer
+          msgValue = 0;
+          await mockToken.connect(buyer.wallet).approve(protocolDiamondAddress, offerPrice);
+          await mockToken.mint(buyer.wallet.address, offerPrice);
+        }
+
+        // Commit to offer
+        const exchangeId = await exchangeHandler.getNextExchangeId();
+        const tx = await exchangeHandler
+          .connect(buyer.wallet)
+          .commitToOffer(buyer.wallet.address, offer.id, { value: msgValue });
+        const txReceipt = await tx.wait();
+        const event = getEvent(txReceipt, exchangeHandler, "BuyerCommitted");
+
+        // Get the block timestamp of the confirmed tx
+        const blockNumber = tx.blockNumber;
+        const block = await ethers.provider.getBlock(blockNumber);
+
+        // Set expected voucher values
+        const voucher = mockVoucher({
+          committedDate: block.timestamp.toString(),
+          validUntilDate: calculateVoucherExpiry(block, offerDates.voucherRedeemableFrom, offerDurations.voucherValid),
+          redeemedDate: "0",
+        });
+
+        // Set expected exchange values
+        const exchange = mockExchange({
+          id: exchangeId.toString(),
+          offerId: offer.id,
+          buyerId: buyer.buyer.id,
+          finalizedDate: "0",
+        });
+
+        // Examine event
+        assert.equal(event.exchangeId.toString(), exchange.id, "Exchange id is incorrect");
+        assert.equal(event.offerId.toString(), offer.id, "Offer id is incorrect");
+        assert.equal(event.buyerId.toString(), buyer.buyer.id, "Buyer id is incorrect");
+
+        // Examine the exchange struct
+        assert.equal(
+          Exchange.fromStruct(event.exchange).toString(),
+          exchange.toString(),
+          "Exchange struct is incorrect"
+        );
+
+        // Examine the voucher struct
+        assert.equal(Voucher.fromStruct(event.voucher).toString(), voucher.toString(), "Voucher struct is incorrect");
+      });
+
+      it("Redeem old voucher", async function () {
+        const exchange = preUpgradeEntities.exchanges[0]; // some exchange that wasn't redeemed/revoked/canceled yet
+        const buyerWallet = preUpgradeEntities.buyers[exchange.buyerIndex].wallet;
+        await expect(exchangeHandler.connect(buyerWallet).redeemVoucher(exchange.exchangeId))
+          .to.emit(exchangeHandler, "VoucherRedeemed")
+          .withArgs(exchange.offerId, exchange.exchangeId, buyerWallet.address);
+      });
+
+      it("Revoke old voucher", async function () {
+        const exchange = preUpgradeEntities.exchanges[0]; // some exchange that wasn't redeemed/revoked/canceled yet
+        const buyerWallet = preUpgradeEntities.buyers[exchange.buyerIndex].wallet;
+        await expect(exchangeHandler.connect(buyerWallet).cancelVoucher(exchange.exchangeId))
+          .to.emit(exchangeHandler, "VoucherCanceled")
+          .withArgs(exchange.offerId, exchange.exchangeId, buyerWallet.address);
+      });
+
+      it("Cancel old voucher", async function () {
+        const exchange = preUpgradeEntities.exchanges[0]; // some exchange that wasn't redeemed/revoked/canceled yet
+        const offer = preUpgradeEntities.offers.find((o) => o.offer.id == exchange.offerId);
+        const seller = preUpgradeEntities.sellers.find((s) => s.seller.id == offer.offer.sellerId);
+        await expect(exchangeHandler.connect(seller.wallet).revokeVoucher(exchange.exchangeId))
+          .to.emit(exchangeHandler, "VoucherRevoked")
+          .withArgs(exchange.offerId, exchange.exchangeId, seller.wallet.address);
+      });
+
+      it("Old buyer commits to new offer", async function () {
+        const buyer = preUpgradeEntities.buyers[2];
+        const offerId = await offerHandler.getNextOfferId();
+        const exchangeId = await exchangeHandler.getNextExchangeId();
+
+        // create some new offer
+        const { offer, offerDates, offerDurations } = await mockOffer();
+        offer.id = offerId.toString();
+        const disputeResolverId = preUpgradeEntities.DRs[0].disputeResolver.id;
+        const agentId = preUpgradeEntities.agents[0].agent.id;
+        const seller = preUpgradeEntities.sellers[2];
+        await offerHandler
+          .connect(seller.wallet)
+          .createOffer(offer, offerDates, offerDurations, disputeResolverId, agentId);
+        await fundsHandler
+          .connect(seller.wallet)
+          .depositFunds(seller.seller.id, offer.exchangeToken, offer.sellerDeposit, {
+            value: offer.sellerDeposit,
+          });
+
+        // Commit to offer
+        const offerPrice = offer.price;
+        const tx = await exchangeHandler
+          .connect(buyer.wallet)
+          .commitToOffer(buyer.wallet.address, offer.id, { value: offerPrice });
+        const txReceipt = await tx.wait();
+        const event = getEvent(txReceipt, exchangeHandler, "BuyerCommitted");
+
+        // Get the block timestamp of the confirmed tx
+        const blockNumber = tx.blockNumber;
+        const block = await ethers.provider.getBlock(blockNumber);
+
+        // Set expected voucher values
+        const voucher = mockVoucher({
+          committedDate: block.timestamp.toString(),
+          validUntilDate: calculateVoucherExpiry(block, offerDates.voucherRedeemableFrom, offerDurations.voucherValid),
+          redeemedDate: "0",
+        });
+
+        // Set expected exchange values
+        const exchange = mockExchange({
+          id: exchangeId.toString(),
+          offerId: offer.id,
+          buyerId: buyer.buyer.id,
+          finalizedDate: "0",
+        });
+
+        // Examine event
+        assert.equal(event.exchangeId.toString(), exchange.id, "Exchange id is incorrect");
+        assert.equal(event.offerId.toString(), offer.id, "Offer id is incorrect");
+        assert.equal(event.buyerId.toString(), buyer.buyer.id, "Buyer id is incorrect");
+
+        // Examine the exchange struct
+        assert.equal(
+          Exchange.fromStruct(event.exchange).toString(),
+          exchange.toString(),
+          "Exchange struct is incorrect"
+        );
+
+        // Examine the voucher struct
+        assert.equal(Voucher.fromStruct(event.voucher).toString(), voucher.toString(), "Voucher struct is incorrect");
+      });
+
+      it("Void old offer", async function () {
+        const seller = preUpgradeEntities.sellers[0];
+        const offerId = seller.offerIds[0];
+
+        await expect(offerHandler.connect(seller.wallet).voidOffer(offerId))
+          .to.emit(offerHandler, "OfferVoided")
+          .withArgs(offerId, seller.seller.id, seller.wallet.address);
+      });
+    });
+  };
+  return genericContextFunction;
+}
+
+exports.getGenericContext = getGenericContext;

--- a/test/upgrade/01_generic.js
+++ b/test/upgrade/01_generic.js
@@ -7,7 +7,7 @@ const Exchange = require("../../scripts/domain/Exchange");
 const Voucher = require("../../scripts/domain/Voucher");
 const { populateProtocolContract, getProtocolContractState } = require("../util/upgrade");
 
-// returns function with test that can be reused in every upgrade
+// Returns function with test that can be reused in every upgrade
 function getGenericContext(
   deployer,
   protocolDiamondAddress,
@@ -26,8 +26,8 @@ function getGenericContext(
 
   const genericContextFunction = async function () {
     afterEach(async function () {
-      // revert to state right after the upgrade
-      // this is used so the lengthly setup (deploy+upgrade) is done only once
+      // Revert to state right after the upgrade.
+      // This is used so the lengthly setup (deploy+upgrade) is done only once.
       await ethers.provider.send("evm_revert", [snapshot]);
       snapshot = await ethers.provider.send("evm_snapshot", []);
     });
@@ -108,7 +108,7 @@ function getGenericContext(
         );
 
         // State before and after should be equal
-        // remove nextXXid before comparing. Their correct value is verified already
+        // Remove nextXXid before comparing. Their correct value is verified already
         delete protocolContractStateAfterUpgradeAndActions.accountContractState.nextAccountId;
         delete protocolContractStateAfterUpgradeAndActions.exchangeContractState.nextExchangeId;
         delete protocolContractStateAfterUpgradeAndActions.groupContractState.nextGroupId;
@@ -228,7 +228,7 @@ function getGenericContext(
         const offerId = await offerHandler.getNextOfferId();
         const exchangeId = await exchangeHandler.getNextExchangeId();
 
-        // create some new offer
+        // Create some new offer
         const { offer, offerDates, offerDurations } = await mockOffer();
         offer.id = offerId.toString();
         const disputeResolverId = preUpgradeEntities.DRs[0].disputeResolver.id;

--- a/test/upgrade/2.0.0-2.1.0.js
+++ b/test/upgrade/2.0.0-2.1.0.js
@@ -84,14 +84,14 @@ describe("[@skip-on-coverage] After facet upgrade, everything is still operation
   });
 
   afterEach(async function () {
-    // revert to state right after the upgrade
-    // this is used so the lengthly setup (deploy+upgrade) is done only once
+    // Revert to state right after the upgrade.
+    // This is used so the lengthly setup (deploy+upgrade) is done only once.
     await ethers.provider.send("evm_revert", [snapshot]);
     snapshot = await ethers.provider.send("evm_snapshot", []);
   });
 
   after(async function () {
-    // revert to latest state of contracts
+    // Revert to latest state of contracts
     shell.exec(`git checkout HEAD contracts`);
   });
 
@@ -99,7 +99,7 @@ describe("[@skip-on-coverage] After facet upgrade, everything is still operation
   // Test methods that were added to see that upgrade was succesful
   context("📋 Breaking changes and new methods", async function () {
     context("Breaking changes", async function () {
-      it("Seller addresses are not updated in one step, expect for the treasury", async function () {
+      it("Seller addresses are not updated in one step, except for the treasury", async function () {
         const oldSeller = preUpgradeEntities.sellers[3];
 
         const seller = oldSeller.seller.clone();
@@ -144,7 +144,7 @@ describe("[@skip-on-coverage] After facet upgrade, everything is still operation
 
         const disputeResolver = oldDisputeResolver.disputeResolver.clone();
 
-        // new dispute resolver values
+        // New dispute resolver values
         disputeResolver.escalationResponsePeriod = Number(
           Number(disputeResolver.escalationResponsePeriod) - 100
         ).toString();

--- a/test/upgrade/2.0.0-2.1.0.js
+++ b/test/upgrade/2.0.0-2.1.0.js
@@ -1,46 +1,22 @@
 const shell = require("shelljs");
-const { getStorageAt } = require("@nomicfoundation/hardhat-network-helpers");
 const hre = require("hardhat");
 const ethers = hre.ethers;
-const { keccak256 } = ethers.utils;
 const { assert, expect } = require("chai");
 const Seller = require("../../scripts/domain/Seller");
 const AuthToken = require("../../scripts/domain/AuthToken");
 const AuthTokenType = require("../../scripts/domain/AuthTokenType");
-const Bundle = require("../../scripts/domain/Bundle");
 const Role = require("../../scripts/domain/Role");
-const Group = require("../../scripts/domain/Group");
-const VoucherInitValues = require("../../scripts/domain/VoucherInitValues");
-const TokenType = require("../../scripts/domain/TokenType.js");
 const SellerUpdateFields = require("../../scripts/domain/SellerUpdateFields");
 const DisputeResolverUpdateFields = require("../../scripts/domain/DisputeResolverUpdateFields");
 const DisputeResolver = require("../../scripts/domain/DisputeResolver");
-const { DisputeResolverFee, DisputeResolverFeeList } = require("../../scripts/domain/DisputeResolverFee");
+const { DisputeResolverFeeList } = require("../../scripts/domain/DisputeResolverFee");
 const { deployMockTokens } = require("../../scripts/util/deploy-mock-tokens");
-const {
-  mockOffer,
-  mockDisputeResolver,
-  mockAuthToken,
-  mockSeller,
-  mockAgent,
-  mockBuyer,
-  mockCondition,
-  mockTwin,
-  mockVoucher,
-  mockExchange,
-} = require("../util/mock");
-const {
-  getEvent,
-  calculateVoucherExpiry,
-  setNextBlockTimestamp,
-  paddingType,
-  getMappingStoragePosition,
-} = require("../util/utils.js");
-const { oneMonth, oneDay } = require("../util/constants");
+const { mockOffer, mockAuthToken, mockVoucher, mockExchange } = require("../util/mock");
+const { getEvent, calculateVoucherExpiry } = require("../util/utils.js");
 const { readContracts } = require("../../scripts/util/utils");
-const { getInterfaceIds } = require("../../scripts/config/supported-interfaces.js");
 const Exchange = require("../../scripts/domain/Exchange");
 const Voucher = require("../../scripts/domain/Voucher");
+const { populateProtocolContract, getProtocolContractState } = require("./utils");
 
 const oldVersion = "v2.0.0";
 const newVersion = "v2.1.0";
@@ -68,18 +44,9 @@ describe("[@skip-on-coverage] After facet upgrade, everything is still operation
   let protocolDiamondAddress;
   let mockAuthERC721Contract;
 
-  // variable to store entities during each "populateProtocolContract"
-  // index 0 contains data before the upgrade, index 1 data after upgrade
-  let DRs = [[], []];
-  let sellers = [[], []];
-  let buyers = [[], []];
-  let agents = [[], []];
-  let offers = [[], []];
-  let groups = [[], []];
-  let twins = [[], []];
-  let exchanges = [[], []];
-  let bundles = [[], []];
+  // reference protocol state
   let protocolContractState;
+  let preUpgradeEntities, postUpgradeEntities;
 
   before(async function () {
     // Make accounts available
@@ -141,11 +108,40 @@ describe("[@skip-on-coverage] After facet upgrade, everything is still operation
     mockTwinTokens = [mockTwin721_1, mockTwin721_2];
 
     // Populate protocol with data
-    await populateProtocolContract();
+    preUpgradeEntities = await populateProtocolContract(
+      deployer,
+      protocolDiamondAddress,
+      {
+        accountHandler,
+        exchangeHandler,
+        offerHandler,
+        fundsHandler,
+        disputeHandler,
+        bundleHandler,
+        groupHandler,
+        twinHandler,
+      },
+      { mockToken, mockConditionalToken, mockAuthERC721Contract, mockTwinTokens, mockTwin20, mockTwin1155 }
+    );
 
     // Get current protocol state, which serves as the reference
     // We assume that this state is a true one, relying on our unit and integration tests
-    protocolContractState = await getProtocolContractState(0);
+    protocolContractState = await getProtocolContractState(
+      protocolDiamondAddress,
+      {
+        accountHandler,
+        exchangeHandler,
+        offerHandler,
+        fundsHandler,
+        disputeHandler,
+        bundleHandler,
+        groupHandler,
+        twinHandler,
+        configHandler,
+      },
+      { mockToken, mockTwinTokens },
+      preUpgradeEntities
+    );
 
     // Upgrade protocol
     if (newVersion) {
@@ -186,7 +182,22 @@ describe("[@skip-on-coverage] After facet upgrade, everything is still operation
   context("📋 Right After upgrade", async function () {
     it("State is not affected directly after the update", async function () {
       // Get protocol state after the upgrade
-      const protocolContractStateAfterUpgrade = await getProtocolContractState(0);
+      const protocolContractStateAfterUpgrade = await getProtocolContractState(
+        protocolDiamondAddress,
+        {
+          accountHandler,
+          exchangeHandler,
+          offerHandler,
+          fundsHandler,
+          disputeHandler,
+          bundleHandler,
+          groupHandler,
+          twinHandler,
+          configHandler,
+        },
+        { mockToken, mockTwinTokens },
+        preUpgradeEntities
+      );
 
       // State before and after should be equal
       assert.deepEqual(protocolContractState, protocolContractStateAfterUpgrade, "state mismatch after upgrade");
@@ -196,16 +207,49 @@ describe("[@skip-on-coverage] After facet upgrade, everything is still operation
   // Create new protocol entities. Existing data should not be affected
   context("📋 New data after the upgrade do not corrupt the data from before the upgrade", async function () {
     it("State is not affected", async function () {
-      await populateProtocolContract(true);
+      postUpgradeEntities = await populateProtocolContract(
+        deployer,
+        protocolDiamondAddress,
+        {
+          accountHandler,
+          exchangeHandler,
+          offerHandler,
+          fundsHandler,
+          disputeHandler,
+          bundleHandler,
+          groupHandler,
+          twinHandler,
+        },
+        { mockToken, mockConditionalToken, mockAuthERC721Contract, mockTwinTokens, mockTwin20, mockTwin1155 }
+      );
 
       // Get protocol state after the upgrade
-      // First get the data that should be in location of old data
-      const protocolContractStateAfterUpgradeAndActions = await getProtocolContractState(0);
+      // First get the data tha should be in location of old data
+      const protocolContractStateAfterUpgradeAndActions = await getProtocolContractState(
+        protocolDiamondAddress,
+        {
+          accountHandler,
+          exchangeHandler,
+          offerHandler,
+          fundsHandler,
+          disputeHandler,
+          bundleHandler,
+          groupHandler,
+          twinHandler,
+          configHandler,
+        },
+        { mockToken, mockTwinTokens },
+        preUpgradeEntities
+      );
 
       // Counters are the only values that should be changed
       // We check that the number increased for expected amount
       // This also confirms that entities were actually created
-      const accountCount = sellers[1].length + DRs[1].length + agents[1].length + buyers[1].length;
+      const accountCount =
+        postUpgradeEntities.sellers.length +
+        postUpgradeEntities.DRs.length +
+        postUpgradeEntities.agents.length +
+        postUpgradeEntities.buyers.length;
       assert.equal(
         protocolContractStateAfterUpgradeAndActions.accountContractState.nextAccountId.toNumber(),
         protocolContractState.accountContractState.nextAccountId.add(accountCount).toNumber(),
@@ -213,27 +257,27 @@ describe("[@skip-on-coverage] After facet upgrade, everything is still operation
       );
       assert.equal(
         protocolContractStateAfterUpgradeAndActions.exchangeContractState.nextExchangeId.toNumber(),
-        protocolContractState.exchangeContractState.nextExchangeId.add(exchanges[1].length).toNumber(),
+        protocolContractState.exchangeContractState.nextExchangeId.add(postUpgradeEntities.exchanges.length).toNumber(),
         "nextExchangeId mismatch"
       );
       assert.equal(
         protocolContractStateAfterUpgradeAndActions.groupContractState.nextGroupId.toNumber(),
-        protocolContractState.groupContractState.nextGroupId.add(groups[1].length).toNumber(),
+        protocolContractState.groupContractState.nextGroupId.add(postUpgradeEntities.groups.length).toNumber(),
         "nextGroupId mismatch"
       );
       assert.equal(
         protocolContractStateAfterUpgradeAndActions.offerContractState.nextOfferId.toNumber(),
-        protocolContractState.offerContractState.nextOfferId.add(offers[1].length).toNumber(),
+        protocolContractState.offerContractState.nextOfferId.add(postUpgradeEntities.offers.length).toNumber(),
         "nextOfferId mismatch"
       );
       assert.equal(
         protocolContractStateAfterUpgradeAndActions.twinContractState.nextTwinId.toNumber(),
-        protocolContractState.twinContractState.nextTwinId.add(twins[1].length).toNumber(),
+        protocolContractState.twinContractState.nextTwinId.add(postUpgradeEntities.twins.length).toNumber(),
         "nextTwinId mismatch"
       );
       assert.equal(
         protocolContractStateAfterUpgradeAndActions.bundleContractState.nextBundleId.toNumber(),
-        protocolContractState.bundleContractState.nextBundleId.add(bundles[1].length).toNumber()
+        protocolContractState.bundleContractState.nextBundleId.add(postUpgradeEntities.bundles.length).toNumber()
       );
 
       // State before and after should be equal
@@ -262,11 +306,9 @@ describe("[@skip-on-coverage] After facet upgrade, everything is still operation
   // Check that correct events are emitted. State is not checked since units and integration test should make sure that event and state are consistent
   context("📋 Interactions after the upgrade still work", async function () {
     it("Commit to old offers", async function () {
-      const offer = offers[0][1].offer; // pick some random offer
-      const offerDates = offers[0][1].offerDates; // pick some random offer
-      const offerDurations = offers[0][1].offerDurations; // pick some random offer
+      const { offer, offerDates, offerDurations } = preUpgradeEntities.offers[1]; // pick some random offer
       const offerPrice = offer.price;
-      const buyer = buyers[0][1];
+      const buyer = preUpgradeEntities.buyers[1];
       let msgValue;
       if (offer.exchangeToken == ethers.constants.AddressZero) {
         msgValue = offerPrice;
@@ -317,32 +359,32 @@ describe("[@skip-on-coverage] After facet upgrade, everything is still operation
     });
 
     it("Redeem old voucher", async function () {
-      const exchange = exchanges[0][0]; // some exchange that wasn't redeemed/revoked/canceled yet
-      const buyerWallet = buyers[0][exchange.buyerIndex].wallet;
+      const exchange = preUpgradeEntities.exchanges[0]; // some exchange that wasn't redeemed/revoked/canceled yet
+      const buyerWallet = preUpgradeEntities.buyers[exchange.buyerIndex].wallet;
       await expect(exchangeHandler.connect(buyerWallet).redeemVoucher(exchange.exchangeId))
         .to.emit(exchangeHandler, "VoucherRedeemed")
         .withArgs(exchange.offerId, exchange.exchangeId, buyerWallet.address);
     });
 
     it("Cancel old voucher", async function () {
-      const exchange = exchanges[0][0]; // some exchange that wasn't redeemed/revoked/canceled yet
-      const buyerWallet = buyers[0][exchange.buyerIndex].wallet;
+      const exchange = preUpgradeEntities.exchanges[0]; // some exchange that wasn't redeemed/revoked/canceled yet
+      const buyerWallet = preUpgradeEntities.buyers[exchange.buyerIndex].wallet;
       await expect(exchangeHandler.connect(buyerWallet).cancelVoucher(exchange.exchangeId))
         .to.emit(exchangeHandler, "VoucherCanceled")
         .withArgs(exchange.offerId, exchange.exchangeId, buyerWallet.address);
     });
 
     it("Revoke old voucher", async function () {
-      const exchange = exchanges[0][0]; // some exchange that wasn't redeemed/revoked/canceled yet
-      const offer = offers[0].find((o) => o.offer.id == exchange.offerId);
-      const seller = sellers[0].find((s) => s.seller.id == offer.offer.sellerId);
+      const exchange = preUpgradeEntities.exchanges[0]; // some exchange that wasn't redeemed/revoked/canceled yet
+      const offer = preUpgradeEntities.offers.find((o) => o.offer.id == exchange.offerId);
+      const seller = preUpgradeEntities.sellers.find((s) => s.seller.id == offer.offer.sellerId);
       await expect(exchangeHandler.connect(seller.wallet).revokeVoucher(exchange.exchangeId))
         .to.emit(exchangeHandler, "VoucherRevoked")
         .withArgs(exchange.offerId, exchange.exchangeId, seller.wallet.address);
     });
 
     it("Escalate old dispute", async function () {
-      const exchange = exchanges[0][5]; // exchange for which dispute was raised
+      const exchange = preUpgradeEntities.exchanges[5]; // exchange for which dispute was raised
       const buyerWallet = buyers[0][exchange.buyerIndex].wallet;
       const offer = offers[0].find((o) => o.offer.id == exchange.offerId);
       await expect(disputeHandler.connect(buyerWallet).escalateDispute(exchange.exchangeId))
@@ -351,21 +393,22 @@ describe("[@skip-on-coverage] After facet upgrade, everything is still operation
     });
 
     it("Old buyer commits to new offer", async function () {
-      const buyer = buyers[0][2];
+      const buyer = preUpgradeEntities.buyers[2];
       const offerId = await offerHandler.getNextOfferId();
       const exchangeId = await exchangeHandler.getNextExchangeId();
 
       // create some new offer
       const { offer, offerDates, offerDurations } = await mockOffer();
       offer.id = offerId.toString();
-      const disputeResolverId = DRs[0][0].disputeResolver.id;
-      const agentId = agents[0][0].agent.id;
+      const disputeResolverId = preUpgradeEntities.DRs[0].disputeResolver.id;
+      const agentId = preUpgradeEntities.agents[0].agent.id;
+      const seller = preUpgradeEntities.sellers[2];
       await offerHandler
-        .connect(sellers[0][2].wallet)
+        .connect(seller.wallet)
         .createOffer(offer, offerDates, offerDurations, disputeResolverId, agentId);
       await fundsHandler
-        .connect(sellers[0][2].wallet)
-        .depositFunds(sellers[0][2].seller.id, offer.exchangeToken, offer.sellerDeposit, {
+        .connect(seller.wallet)
+        .depositFunds(seller.seller.id, offer.exchangeToken, offer.sellerDeposit, {
           value: offer.sellerDeposit,
         });
 
@@ -409,7 +452,7 @@ describe("[@skip-on-coverage] After facet upgrade, everything is still operation
     });
 
     it("Void old offer", async function () {
-      const seller = sellers[0][0];
+      const seller = preUpgradeEntities.sellers[0];
       const offerId = seller.offerIds[0];
 
       await expect(offerHandler.connect(seller.wallet).voidOffer(offerId))
@@ -423,7 +466,7 @@ describe("[@skip-on-coverage] After facet upgrade, everything is still operation
   context("📋 Breaking changes and new methods", async function () {
     context("Breaking changes", async function () {
       it("Seller addresses are not updated in one step, expect for the treasury", async function () {
-        const oldSeller = sellers[0][3];
+        const oldSeller = preUpgradeEntities.sellers[3];
 
         const seller = oldSeller.seller.clone();
 
@@ -463,7 +506,7 @@ describe("[@skip-on-coverage] After facet upgrade, everything is still operation
       });
 
       it("Dispute resolver is not updated in one step", async function () {
-        const oldDisputeResolver = DRs[0][2];
+        const oldDisputeResolver = preUpgradeEntities.DRs[2];
 
         const disputeResolver = oldDisputeResolver.disputeResolver.clone();
 
@@ -549,7 +592,7 @@ describe("[@skip-on-coverage] After facet upgrade, everything is still operation
       });
 
       it("Seller can be updated in two steps", async function () {
-        const oldSeller = sellers[0][3];
+        const oldSeller = preUpgradeEntities.sellers[3];
 
         const seller = oldSeller.seller.clone();
         seller.treasury = treasury.address;
@@ -647,7 +690,7 @@ describe("[@skip-on-coverage] After facet upgrade, everything is still operation
       });
 
       it("Dispute resolver can be updated in two steps", async function () {
-        const oldDisputeResolver = DRs[0][1];
+        const oldDisputeResolver = preUpgradeEntities.DRs[1];
 
         const disputeResolver = oldDisputeResolver.disputeResolver.clone();
 
@@ -731,1087 +774,4 @@ describe("[@skip-on-coverage] After facet upgrade, everything is still operation
       });
     });
   });
-
-  // utility functions
-  async function populateProtocolContract(afterUpgrade = false) {
-    // populateProtocolContract can be called before and after update
-    // using the same ids would results in clashes in come cases, so use offset to prevent that
-    const versionIndex = afterUpgrade ? 1 : 0;
-    let accountOffset, offerOffset, groupOffset, exchangeOffset, twinOffset, bundleOffset;
-    accountOffset = offerOffset = groupOffset = exchangeOffset = twinOffset = bundleOffset = 0;
-    if (afterUpgrade) {
-      accountOffset = sellers[0].length + DRs[0].length + agents[0].length + buyers[0].length;
-      offerOffset = offers[0].length;
-      groupOffset = groups[0].length;
-      exchangeOffset = exchanges[0].length;
-      twinOffset = twins[0].length;
-      bundleOffset = bundles[0].length;
-    }
-
-    const entity = {
-      SELLER: 0,
-      DR: 1,
-      AGENT: 2,
-      BUYER: 3,
-    };
-
-    const DRcount = 3;
-    const agentCount = 2;
-    const sellerCount = 5;
-    const buyerCount = 5;
-    const totalCount = DRcount + agentCount + sellerCount + buyerCount;
-    const creationOrder = [
-      entity.DR,
-      entity.AGENT,
-      entity.SELLER,
-      entity.SELLER,
-      entity.DR,
-      entity.SELLER,
-      entity.DR,
-      entity.SELLER,
-      entity.AGENT,
-      entity.SELLER,
-      entity.BUYER,
-      entity.BUYER,
-      entity.BUYER,
-      entity.BUYER,
-      entity.BUYER,
-    ]; // maybe programatically set the random order, except for the buyers
-
-    for (let i = 0; i < totalCount; i++) {
-      const wallet = ethers.Wallet.createRandom();
-      const connectedWallet = wallet.connect(ethers.provider);
-      //Fund the new wallet
-      let tx = {
-        to: connectedWallet.address,
-        // Convert currency unit from ether to wei
-        value: ethers.utils.parseEther("10"),
-      };
-      await deployer.sendTransaction(tx);
-
-      // create entities
-      switch (creationOrder[i]) {
-        case entity.DR: {
-          const disputeResolver = mockDisputeResolver(wallet.address, wallet.address, wallet.address, wallet.address);
-          const disputeResolverFees = [
-            new DisputeResolverFee(ethers.constants.AddressZero, "Native", "0"),
-            new DisputeResolverFee(mockToken.address, "MockToken", "0"),
-          ];
-          const sellerAllowList = [];
-          await accountHandler
-            .connect(connectedWallet)
-            .createDisputeResolver(disputeResolver, disputeResolverFees, sellerAllowList);
-          DRs[versionIndex].push({ wallet: connectedWallet, disputeResolver, disputeResolverFees, sellerAllowList });
-
-          //ADMIN role activates Dispute Resolver
-          await accountHandler.connect(deployer).activateDisputeResolver(disputeResolver.id);
-          break;
-        }
-        case entity.SELLER: {
-          const seller = mockSeller(wallet.address, wallet.address, wallet.address, wallet.address);
-          const id = i + accountOffset;
-          let authToken;
-          // randomly decide if auth token is used or not
-          if (Math.random() > 0.5) {
-            // no auth token
-            authToken = mockAuthToken();
-          } else {
-            // use auth token
-            seller.admin = ethers.constants.AddressZero;
-            await mockAuthERC721Contract.connect(connectedWallet).mint(101 * id, 1);
-            authToken = new AuthToken(`${101 * id}`, AuthTokenType.Lens);
-          }
-          // set unique new voucherInitValues
-          const voucherInitValues = new VoucherInitValues(`http://seller${id}.com/uri`, id * 10);
-          await accountHandler.connect(connectedWallet).createSeller(seller, authToken, voucherInitValues);
-          sellers[versionIndex].push({ wallet: connectedWallet, seller, authToken, voucherInitValues, offerIds: [] });
-
-          // mint mock token to sellers just in case they need them
-          await mockToken.mint(connectedWallet.address, "10000000000");
-          await mockToken.connect(connectedWallet).approve(protocolDiamondAddress, "10000000000");
-          break;
-        }
-        case entity.AGENT: {
-          const agent = mockAgent(wallet.address);
-          await accountHandler.connect(connectedWallet).createAgent(agent);
-          agents[versionIndex].push({ wallet: connectedWallet, agent });
-          break;
-        }
-        case entity.BUYER: {
-          // no need to explicitly create buyer, since it's done automatically during commitToOffer
-          const buyer = mockBuyer(wallet.address);
-          buyers[versionIndex].push({ wallet: connectedWallet, buyer });
-
-          // mint them conditional token in case they need it
-          await mockConditionalToken.mint(wallet.address, "10");
-          break;
-        }
-      }
-    }
-
-    // Make explicit allowed sellers list for some DRs
-    const sellerIds = sellers[versionIndex].map((s) => s.seller.id);
-    for (let i = 0; i < DRs[versionIndex].length; i = i + 2) {
-      const DR = DRs[versionIndex][i];
-      DR.sellerAllowList = sellerIds;
-      await accountHandler.connect(DR.wallet).addSellersToAllowList(DR.disputeResolver.id, sellerIds);
-    }
-
-    // create offers - first seller has 5 offers, second 4, third 3 etc
-    let offerId = offerOffset;
-    for (let i = 0; i < sellers[versionIndex].length; i++) {
-      for (let j = i; j >= 0; j--) {
-        // Mock offer, offerDates and offerDurations
-        const { offer, offerDates, offerDurations } = await mockOffer();
-
-        // Set unique offer properties based on offer id
-        offer.id = `${++offerId}`;
-        offer.sellerId = sellers[versionIndex][j].seller.id;
-        offer.price = `${offerId * 1000}`;
-        offer.sellerDeposit = `${offerId * 100}`;
-        offer.buyerCancelPenalty = `${offerId * 50}`;
-        offer.quantityAvailable = `${(offerId + 1) * 15}`;
-
-        // Default offer is in native token. Change every other to mock token
-        if (offerId % 2 == 0) {
-          offer.exchangeToken = mockToken.address;
-        }
-
-        // Set unique offer dates based on offer id
-        const now = offerDates.validFrom;
-        offerDates.validFrom = ethers.BigNumber.from(now)
-          .add(oneMonth + offerId * 1000)
-          .toString();
-        offerDates.validUntil = ethers.BigNumber.from(now)
-          .add(oneMonth * 6 * (offerId + 1))
-          .toString();
-
-        // Set unique offerDurations based on offer id
-        offerDurations.disputePeriod = `${(offerId + 1) * oneMonth}`;
-        offerDurations.voucherValid = `${(offerId + 1) * oneMonth}`;
-        offerDurations.resolutionPeriod = `${(offerId + 1) * oneDay}`;
-
-        // choose one DR and agent
-        const disputeResolverId = DRs[versionIndex][offerId % 3].disputeResolver.id;
-        const agentId = agents[versionIndex][offerId % 2].agent.id;
-
-        // create an offer
-        await offerHandler
-          .connect(sellers[versionIndex][j].wallet)
-          .createOffer(offer, offerDates, offerDurations, disputeResolverId, agentId);
-
-        offers[versionIndex].push({ offer, offerDates, offerDurations, disputeResolverId, agentId });
-        sellers[versionIndex][j].offerIds.push(offerId);
-
-        // Deposit seller funds so the commit will succeed
-        const sellerPool = ethers.BigNumber.from(offer.quantityAvailable).mul(offer.price).toString();
-        const msgValue = offer.exchangeToken == ethers.constants.AddressZero ? sellerPool : "0";
-        await fundsHandler
-          .connect(sellers[versionIndex][j].wallet)
-          .depositFunds(sellers[versionIndex][j].seller.id, offer.exchangeToken, sellerPool, { value: msgValue });
-      }
-    }
-
-    // group some offers
-    let groupId = groupOffset;
-    for (let i = 0; i < sellers[versionIndex].length; i = i + 2) {
-      const seller = sellers[versionIndex][i];
-      const group = new Group(++groupId, seller.seller.id, seller.offerIds); // group all seller's offers
-      const condition = mockCondition({
-        tokenAddress: mockConditionalToken.address,
-        maxCommits: "10",
-      });
-      await groupHandler.connect(seller.wallet).createGroup(group, condition);
-
-      groups[versionIndex].push(group);
-    }
-
-    // create some twins and bundles
-    let twinId = twinOffset;
-    let bundleId = bundleOffset;
-    for (let i = 1; i < sellers[versionIndex].length; i = i + 2) {
-      const seller = sellers[versionIndex][i];
-      let twinIds = []; // used for bundle
-
-      // non fungible token
-      await mockTwinTokens[0].connect(seller.wallet).setApprovalForAll(protocolDiamondAddress, true);
-      await mockTwinTokens[1].connect(seller.wallet).setApprovalForAll(protocolDiamondAddress, true);
-      // create multiple ranges
-      const twin721 = mockTwin(rando.address, TokenType.NonFungibleToken);
-      twin721.amount = "0";
-      for (let j = 0; j < 7; j++) {
-        twin721.tokenId = `${j * 1000000 + (i + accountOffset) * 100}`;
-        twin721.supplyAvailable = `${10000 * (i + accountOffset + 1)}`;
-        twin721.tokenAddress = mockTwinTokens[j % 2].address; // oscilate between twins
-        twin721.id = ++twinId;
-        await twinHandler.connect(seller.wallet).createTwin(twin721);
-
-        twins[versionIndex].push(twin721);
-        twinIds.push(twinId);
-      }
-
-      // fungible
-      const twin20 = mockTwin(mockTwin20.address, TokenType.FungibleToken);
-      await mockTwin20.connect(seller.wallet).approve(protocolDiamondAddress, 1);
-      twin20.id = ++twinId;
-      twin20.amount = i + accountOffset;
-      twin20.supplyAvailable = twin20.amount * 100000000;
-      await twinHandler.connect(seller.wallet).createTwin(twin20);
-      twins[versionIndex].push(twin20);
-      twinIds.push(twinId);
-
-      // multitoken twin
-      const twin1155 = mockTwin(mockTwin1155.address, TokenType.MultiToken);
-      await mockTwin1155.connect(seller.wallet).setApprovalForAll(protocolDiamondAddress, true);
-      for (let j = 0; j < 3; j++) {
-        twin1155.tokenId = `${j * 30000 + (i + accountOffset) * 300}`;
-        twin1155.amount = i + accountOffset + j;
-        twin1155.supplyAvailable = `${300000 * (i + accountOffset + 1)}`;
-        twin1155.id = ++twinId;
-        await twinHandler.connect(seller.wallet).createTwin(twin1155);
-        twins[versionIndex].push(twin1155);
-        twinIds.push(twinId);
-      }
-
-      // create bundle with all seller's twins and offers
-      const bundle = new Bundle(++bundleId, seller.seller.id, seller.offerIds, twinIds);
-      await bundleHandler.connect(seller.wallet).createBundle(bundle);
-      bundles[versionIndex].push(bundle);
-    }
-
-    // commit to some offers: first buyer commit to 1 offer, second to 2, third to 3 etc
-    await setNextBlockTimestamp(Number(offers[versionIndex][offers[versionIndex].length - 1].offerDates.validFrom)); // When latest offer is valid, also other offers are valid
-    let exchangeId = exchangeOffset;
-    for (let i = 0; i < buyers[versionIndex].length; i++) {
-      for (let j = i; j < buyers[versionIndex].length; j++) {
-        const offer = offers[versionIndex][i + j].offer; // some offers will be picked multiple times, some never.
-        const offerPrice = offer.price;
-        const buyerWallet = buyers[versionIndex][j].wallet;
-        let msgValue;
-        if (offer.exchangeToken == ethers.constants.AddressZero) {
-          msgValue = offerPrice;
-        } else {
-          // approve token transfer
-          msgValue = 0;
-          await mockToken.connect(buyerWallet).approve(protocolDiamondAddress, offerPrice);
-          await mockToken.mint(buyerWallet.address, offerPrice);
-        }
-        await exchangeHandler.connect(buyerWallet).commitToOffer(buyerWallet.address, offer.id, { value: msgValue });
-        exchanges[versionIndex].push({ exchangeId: ++exchangeId, offerId: offer.id, buyerIndex: j });
-      }
-    }
-
-    // redeem some vouchers #4
-    for (const id of [2, 5, 11, 8]) {
-      const exchange = exchanges[versionIndex][id];
-      await exchangeHandler
-        .connect(buyers[versionIndex][exchange.buyerIndex].wallet)
-        .redeemVoucher(exchange.exchangeId);
-    }
-
-    // cancel some vouchers #3
-    for (const id of [10, 3, 13]) {
-      const exchange = exchanges[versionIndex][id];
-      await exchangeHandler
-        .connect(buyers[versionIndex][exchange.buyerIndex].wallet)
-        .cancelVoucher(exchange.exchangeId);
-    }
-
-    // revoke some vouchers #2
-    for (const id of [4, 6]) {
-      const exchange = exchanges[versionIndex][id];
-      const offer = offers[versionIndex].find((o) => o.offer.id == exchange.offerId);
-      const seller = sellers[versionIndex].find((s) => s.seller.id == offer.offer.sellerId);
-      await exchangeHandler.connect(seller.wallet).revokeVoucher(exchange.exchangeId);
-    }
-
-    // raise dispute on some exchanges #1
-    const id = 5; // must be one of redeemed ones
-    const exchange = exchanges[versionIndex][id];
-    await disputeHandler.connect(buyers[versionIndex][exchange.buyerIndex].wallet).raiseDispute(exchange.exchangeId);
-  }
-
-  async function getProtocolContractState(versionIndex = 0) {
-    const [
-      accountContractState,
-      offerContractState,
-      exchangeContractState,
-      bundleContractState,
-      configContractState,
-      disputeContractState,
-      fundsContractState,
-      groupContractState,
-      twinContractState,
-      metaTxContractState,
-      metaTxPrivateContractState,
-      protocolStatusPrivateContractState,
-      protocolLookupsPrivateContractState,
-    ] = await Promise.all([
-      getAccountContractState(versionIndex),
-      getOfferContractState(versionIndex),
-      getExchangeContractState(versionIndex),
-      getBundleContractState(versionIndex),
-      getConfigContractState(),
-      getDisputeContractState(versionIndex),
-      getFundsContractState(versionIndex),
-      getGroupContractState(versionIndex),
-      getTwinContractState(versionIndex),
-      getMetaTxContractState(versionIndex),
-      getMetaTxPrivateContractState(),
-      getProtocolStatusPrivateContractState(),
-      getProtocolLookupsPrivateContractState(versionIndex),
-    ]);
-
-    return {
-      accountContractState,
-      offerContractState,
-      exchangeContractState,
-      bundleContractState,
-      configContractState,
-      disputeContractState,
-      fundsContractState,
-      groupContractState,
-      twinContractState,
-      metaTxContractState,
-      metaTxPrivateContractState,
-      protocolStatusPrivateContractState,
-      protocolLookupsPrivateContractState,
-    };
-  }
-
-  async function getAccountContractState(versionIndex) {
-    const accountHandlerRando = accountHandler.connect(rando);
-    // all id count
-    const totalCount =
-      DRs[versionIndex].length +
-      sellers[versionIndex].length +
-      buyers[versionIndex].length +
-      agents[versionIndex].length;
-    const offset = versionIndex == 1 ? DRs[0].length + sellers[0].length + buyers[0].length + agents[0].length : 0;
-    let DRsState = [];
-    let sellerState = [];
-    let buyersState = [];
-    let agentsState = [];
-    let allowedSellersState = [];
-    let sellerByAddressState = [];
-    let sellerByAuthTokenState = [];
-    let DRbyAddressState = [];
-    let nextAccountId;
-
-    // Query even the ids where it's not expected to get the entity
-    for (let id = 1 + offset; id <= totalCount + offset; id++) {
-      const [singleSellerState, singleDRsState, singleBuyersState, singleAgentsState] = await Promise.all([
-        accountHandlerRando.getSeller(id),
-        accountHandlerRando.getDisputeResolver(id),
-        accountHandlerRando.getBuyer(id),
-        accountHandlerRando.getAgent(id),
-      ]);
-      sellerState.push(singleSellerState);
-      DRsState.push(singleDRsState);
-      buyersState.push(singleBuyersState);
-      agentsState.push(singleAgentsState);
-      for (let id2 = 1 + offset; id2 <= totalCount + offset; id2++) {
-        allowedSellersState.push(await accountHandlerRando.areSellersAllowed(id2, [id]));
-      }
-    }
-
-    for (const seller of sellers[versionIndex]) {
-      const sellerAddress = seller.wallet.address;
-      const sellerAuthToken = seller.authToken;
-
-      const [singleSellerByAddressState, singleSellerByAuthTokenState, singleDRbyAddressState] = await Promise.all([
-        accountHandlerRando.getSellerByAddress(sellerAddress),
-        accountHandlerRando.getSellerByAuthToken(sellerAuthToken),
-        accountHandlerRando.getDisputeResolverByAddress(sellerAddress),
-      ]);
-      sellerByAddressState.push(singleSellerByAddressState);
-      sellerByAuthTokenState.push(singleSellerByAuthTokenState);
-      DRbyAddressState.push(singleDRbyAddressState);
-    }
-
-    const otherAccounts = [...DRs[versionIndex], ...agents[versionIndex], ...buyers[versionIndex]];
-
-    for (const account of otherAccounts) {
-      const accountAddress = account.wallet.address;
-
-      const [singleSellerByAddressState, singleDRbyAddressState] = await Promise.all([
-        accountHandlerRando.getSellerByAddress(accountAddress),
-        accountHandlerRando.getDisputeResolverByAddress(accountAddress),
-      ]);
-      sellerByAddressState.push(singleSellerByAddressState);
-      DRbyAddressState.push(singleDRbyAddressState);
-    }
-
-    nextAccountId = await accountHandlerRando.getNextAccountId();
-
-    return {
-      DRsState,
-      sellerState,
-      buyersState,
-      sellerByAddressState,
-      sellerByAuthTokenState,
-      DRbyAddressState,
-      nextAccountId,
-    };
-  }
-
-  async function getOfferContractState(versionIndex) {
-    const offerHandlerRando = offerHandler.connect(rando);
-    // get offers
-    let offersState = [];
-    let isOfferVoidedState = [];
-    let agentIdByOfferState = [];
-    for (const offer of offers[versionIndex]) {
-      const id = offer.offer.id;
-      const [singleOffersState, singleIsOfferVoidedState, singleAgentIdByOfferState] = await Promise.all([
-        offerHandlerRando.getOffer(id),
-        offerHandlerRando.isOfferVoided(id),
-        offerHandlerRando.getAgentIdByOffer(id),
-      ]);
-      offersState.push(singleOffersState);
-      isOfferVoidedState.push(singleIsOfferVoidedState);
-      agentIdByOfferState.push(singleAgentIdByOfferState);
-    }
-
-    let nextOfferId = await offerHandlerRando.getNextOfferId();
-
-    return { offersState, isOfferVoidedState, agentIdByOfferState, nextOfferId };
-  }
-
-  async function getExchangeContractState(versionIndex) {
-    const exchangeHandlerRando = exchangeHandler.connect(rando);
-    // get exchanges
-    let exchangesState = [];
-    let exchangeStateState = [];
-    let isExchangeFinalizedState = [];
-    let receiptsState = [];
-
-    for (const exchange of exchanges[versionIndex]) {
-      const id = exchange.exchangeId;
-      const [singleExchangesState, singleExchangeStateState, singleIsExchangeFinalizedState] = await Promise.all([
-        exchangeHandlerRando.getExchange(id),
-        exchangeHandlerRando.getExchangeState(id),
-        exchangeHandlerRando.isExchangeFinalized(id),
-      ]);
-      exchangesState.push(singleExchangesState);
-      exchangeStateState.push(singleExchangeStateState);
-      isExchangeFinalizedState.push(singleIsExchangeFinalizedState);
-      try {
-        receiptsState.push(await exchangeHandlerRando.getReceipt(id));
-      } catch {
-        receiptsState.push(["NOT_FINALIZED"]);
-      }
-    }
-
-    let nextExchangeId = await exchangeHandlerRando.getNextExchangeId();
-    return { exchangesState, exchangeStateState, isExchangeFinalizedState, receiptsState, nextExchangeId };
-  }
-
-  async function getBundleContractState(versionIndex) {
-    // get bundles
-    const bundleHandlerRando = bundleHandler.connect(rando);
-    let bundlesState = [];
-    let bundleIdByOfferState = [];
-    let bundleIdByTwinState = [];
-    for (const bundle of bundles[versionIndex]) {
-      const id = bundle.id;
-      const [singleBundlesState, singleBundleIdByOfferState, singleBundleIdByTwinState] = await Promise.all([
-        bundleHandlerRando.getBundle(id),
-        bundleHandlerRando.getBundleIdByOffer(id),
-        bundleHandlerRando.getBundleIdByTwin(id),
-      ]);
-      bundlesState.push(singleBundlesState);
-      bundleIdByOfferState.push(singleBundleIdByOfferState);
-      bundleIdByTwinState.push(singleBundleIdByTwinState);
-    }
-
-    let nextBundleId = await bundleHandlerRando.getNextBundleId();
-    return { bundlesState, bundleIdByOfferState, bundleIdByTwinState, nextBundleId };
-  }
-
-  async function getConfigContractState() {
-    const configHandlerRando = configHandler.connect(rando);
-    const [
-      tokenAddress,
-      treasuryAddress,
-      voucherBeaconAddress,
-      beaconProxyAddress,
-      protocolFeePercentage,
-      protocolFeeFlatBoson,
-      maxOffersPerBatch,
-      maxOffersPerGroup,
-      maxTwinsPerBundle,
-      maxOffersPerBundle,
-      maxTokensPerWithdrawal,
-      maxFeesPerDisputeResolver,
-      maxEscalationResponsePeriod,
-      maxDisputesPerBatch,
-      maxTotalOfferFeePercentage,
-      maxAllowedSellers,
-      buyerEscalationDepositPercentage,
-      authTokenContractNone,
-      authTokenContractCustom,
-      authTokenContractLens,
-      authTokenContractENS,
-      maxExchangesPerBatch,
-      maxRoyaltyPecentage,
-      maxResolutionPeriod,
-      minDisputePeriod,
-      accessControllerAddress,
-    ] = await Promise.all([
-      configHandlerRando.getTokenAddress(),
-      configHandlerRando.getTreasuryAddress(),
-      configHandlerRando.getVoucherBeaconAddress(),
-      configHandlerRando.getBeaconProxyAddress(),
-      configHandlerRando.getProtocolFeePercentage(),
-      configHandlerRando.getProtocolFeeFlatBoson(),
-      configHandlerRando.getMaxOffersPerBatch(),
-      configHandlerRando.getMaxOffersPerGroup(),
-      configHandlerRando.getMaxTwinsPerBundle(),
-      configHandlerRando.getMaxOffersPerBundle(),
-      configHandlerRando.getMaxTokensPerWithdrawal(),
-      configHandlerRando.getMaxFeesPerDisputeResolver(),
-      configHandlerRando.getMaxEscalationResponsePeriod(),
-      configHandlerRando.getMaxDisputesPerBatch(),
-      configHandlerRando.getMaxTotalOfferFeePercentage(),
-      configHandlerRando.getMaxAllowedSellers(),
-      configHandlerRando.getBuyerEscalationDepositPercentage(),
-      configHandlerRando.getAuthTokenContract(AuthTokenType.None),
-      configHandlerRando.getAuthTokenContract(AuthTokenType.Custom),
-      configHandlerRando.getAuthTokenContract(AuthTokenType.Lens),
-      configHandlerRando.getAuthTokenContract(AuthTokenType.ENS),
-      configHandlerRando.getMaxExchangesPerBatch(),
-      configHandlerRando.getMaxRoyaltyPecentage(),
-      configHandlerRando.getMaxResolutionPeriod(),
-      configHandlerRando.getMinDisputePeriod(),
-      configHandlerRando.getAccessControllerAddress(),
-    ]);
-
-    return {
-      tokenAddress,
-      treasuryAddress,
-      voucherBeaconAddress,
-      beaconProxyAddress,
-      protocolFeePercentage,
-      protocolFeeFlatBoson,
-      maxOffersPerBatch,
-      maxOffersPerGroup,
-      maxTwinsPerBundle,
-      maxOffersPerBundle,
-      maxTokensPerWithdrawal,
-      maxFeesPerDisputeResolver,
-      maxEscalationResponsePeriod,
-      maxDisputesPerBatch,
-      maxTotalOfferFeePercentage,
-      maxAllowedSellers,
-      buyerEscalationDepositPercentage,
-      authTokenContractNone,
-      authTokenContractCustom,
-      authTokenContractLens,
-      authTokenContractENS,
-      maxExchangesPerBatch,
-      maxRoyaltyPecentage,
-      maxResolutionPeriod,
-      minDisputePeriod,
-      accessControllerAddress,
-    };
-  }
-
-  async function getDisputeContractState(versionIndex) {
-    const disputeHandlerRando = disputeHandler.connect(rando);
-    let disputesState = [];
-    let disputesStatesState = [];
-    let disputeTimeoutState = [];
-    let isDisputeFinalizedState = [];
-
-    for (const exchange of exchanges[versionIndex]) {
-      const id = exchange.exchangeId;
-      const [singleDisputesState, singleDisputesStatesState, singleDisputeTimeoutState, singleIsDisputeFinalizedState] =
-        await Promise.all([
-          disputeHandlerRando.getDispute(id),
-          disputeHandlerRando.getDisputeState(id),
-          disputeHandlerRando.getDisputeTimeout(id),
-          disputeHandlerRando.isDisputeFinalized(id),
-        ]);
-      disputesState.push(singleDisputesState);
-      disputesStatesState.push(singleDisputesStatesState);
-      disputeTimeoutState.push(singleDisputeTimeoutState);
-      isDisputeFinalizedState.push(singleIsDisputeFinalizedState);
-    }
-
-    return { disputesState, disputesStatesState, disputeTimeoutState, isDisputeFinalizedState };
-  }
-
-  async function getFundsContractState(versionIndex) {
-    const fundsHandlerRando = fundsHandler.connect(rando);
-    // all id count
-    const totalCount =
-      DRs[versionIndex].length +
-      sellers[versionIndex].length +
-      buyers[versionIndex].length +
-      agents[versionIndex].length;
-
-    const offset = versionIndex == 1 ? DRs[0].length + sellers[0].length + buyers[0].length + agents[0].length : 0;
-
-    // Query even the ids where it's not expected to get the entity
-    const accountIds = [...Array(totalCount + offset + 1).keys()].slice(1);
-    const groupsState = await Promise.all(accountIds.map((id) => fundsHandlerRando.getAvailableFunds(id)));
-
-    return { groupsState };
-  }
-
-  async function getGroupContractState(versionIndex) {
-    const groupHandlerRando = groupHandler.connect(rando);
-    const offset = versionIndex == 1 ? groups[0].length : 0;
-    const groupIds = [...Array(groups[versionIndex].length + offset + 1).keys()].slice(1);
-    const groupsState = await Promise.all(groupIds.map((id) => groupHandlerRando.getGroup(id)));
-
-    const nextGroupId = await groupHandlerRando.getNextGroupId();
-    return { groupsState, nextGroupId };
-  }
-
-  async function getTwinContractState(versionIndex) {
-    const twinHandlerRando = twinHandler.connect(rando);
-    const offset = versionIndex == 1 ? twins[0].length : 0;
-    const twinIds = [...Array(twins[versionIndex].length + offset + 1).keys()].slice(1);
-    const twinsState = await Promise.all(twinIds.map((id) => twinHandlerRando.getTwin(id)));
-
-    const nextTwinId = await twinHandlerRando.getNextTwinId();
-    return { twinsState, nextTwinId };
-  }
-
-  async function getMetaTxContractState() {
-    return {};
-  }
-
-  async function getMetaTxPrivateContractState() {
-    /*
-    ProtocolMetaTxInfo storage layout
-
-    #0 [ currentSenderAddress + isMetaTransaction ]
-    #1 [ domain separator ]
-    #2 [ ] // placeholder for usedNonce
-    #3 [ cachedChainId ]
-    #4 [ ] // placeholder for inputType
-    #5 [ ] // placeholder for hashInfo
-    */
-
-    // starting slot
-    const metaTxStorageSlot = keccak256(ethers.utils.toUtf8Bytes("boson.protocol.metaTransactions"));
-    const metaTxStorageSlotNumber = ethers.BigNumber.from(metaTxStorageSlot);
-
-    // current sender address + isMetaTransaction (they are packed since they are shorter than one slot)
-    // should be always be 0x
-    const inTransactionInfo = await getStorageAt(protocolDiamondAddress, metaTxStorageSlotNumber.add("0"));
-
-    // domain separator
-    const domainSeparator = await getStorageAt(protocolDiamondAddress, metaTxStorageSlotNumber.add("1"));
-
-    // cached chain id
-    const cachedChainId = await getStorageAt(protocolDiamondAddress, metaTxStorageSlotNumber.add("3"));
-
-    // input type
-    const inputTypeKeys = [
-      "commitToOffer(address,uint256)",
-      "cancelVoucher(uint256)",
-      "redeemVoucher(uint256)",
-      "completeExchange(uint256)",
-      "withdrawFunds(uint256,address[],uint256[])",
-      "retractDispute(uint256)",
-      "raiseDispute(uint256)",
-      "escalateDispute(uint256)",
-      "resolveDispute(uint256,uint256,bytes32,bytes32,uint8)",
-    ];
-
-    const inputTypesState = [];
-    for (const inputTypeKey of inputTypeKeys) {
-      const storageSlot = getMappingStoragePosition(metaTxStorageSlotNumber.add("4"), inputTypeKey, paddingType.NONE);
-      inputTypesState.push(await getStorageAt(protocolDiamondAddress, storageSlot));
-    }
-
-    // hashInfo
-    const hashInfoTypes = {
-      Generic: 0,
-      CommitToOffer: 1,
-      Exchange: 2,
-      Funds: 3,
-      RaiseDispute: 4,
-      ResolveDispute: 5,
-    };
-
-    const hashInfoState = [];
-    for (const hashInfoType of Object.values(hashInfoTypes)) {
-      const storageSlot = getMappingStoragePosition(metaTxStorageSlotNumber.add("5"), hashInfoType, paddingType.START);
-      // get also hashFunction
-      hashInfoState.push({
-        typeHash: await getStorageAt(protocolDiamondAddress, storageSlot),
-        functionPointer: await getStorageAt(protocolDiamondAddress, ethers.BigNumber.from(storageSlot).add(1)),
-      });
-    }
-
-    return { inTransactionInfo, domainSeparator, cachedChainId, inputTypesState, hashInfoState };
-  }
-
-  async function getProtocolStatusPrivateContractState() {
-    /*
-    ProtocolStatus storage layout
-
-    #0 [ pauseScenario ]
-    #1 [ reentrancyStatus ]
-    #2 [ ] // placeholder for initializedInterfaces
-    */
-
-    // starting slot
-    const protocolStatusStorageSlot = keccak256(ethers.utils.toUtf8Bytes("boson.protocol.initializers"));
-    const protocolStatusStorageSlotNumber = ethers.BigNumber.from(protocolStatusStorageSlot);
-
-    // pause scenario
-    const pauseScenario = await getStorageAt(protocolDiamondAddress, protocolStatusStorageSlotNumber.add("0"));
-
-    // reentrancy status
-    // defualt: NOT_ENTERED = 1
-    const reentrancyStatus = await getStorageAt(protocolDiamondAddress, protocolStatusStorageSlotNumber.add("1"));
-
-    // initializedInterfaces
-    const interfaceIds = await getInterfaceIds();
-
-    const initializedInterfacesState = [];
-    for (const interfaceId of Object.values(interfaceIds)) {
-      const storageSlot = getMappingStoragePosition(
-        protocolStatusStorageSlotNumber.add("2"),
-        interfaceId,
-        paddingType.END
-      );
-      initializedInterfacesState.push(await getStorageAt(protocolDiamondAddress, storageSlot));
-    }
-
-    return { pauseScenario, reentrancyStatus, initializedInterfacesState };
-  }
-
-  async function getProtocolLookupsPrivateContractState(versionIndex) {
-    /*
-    ProtocolLookups storage layout
-
-    Variables marked with X have an external getter and are not handled here
-    #0  [ ] // placeholder for exchangeIdsByOffer
-    #1  [X] // placeholder for bundleIdByOffer
-    #2  [X] // placeholder for bundleIdByTwin
-    #3  [ ] // placeholder for groupIdByOffer
-    #4  [X] // placeholder for agentIdByOffer
-    #5  [X] // placeholder for sellerIdByOperator
-    #6  [X] // placeholder for sellerIdByAdmin
-    #7  [X] // placeholder for sellerIdByClerk
-    #8  [ ] // placeholder for buyerIdByWallet
-    #9  [X] // placeholder for disputeResolverIdByOperator
-    #10 [X] // placeholder for disputeResolverIdByAdmin
-    #11 [X] // placeholder for disputeResolverIdByClerk
-    #12 [ ] // placeholder for disputeResolverFeeTokenIndex
-    #13 [ ] // placeholder for agentIdByWallet
-    #14 [X] // placeholder for availableFunds
-    #15 [X] // placeholder for tokenList
-    #16 [ ] // placeholder for tokenIndexByAccount
-    #17 [ ] // placeholder for cloneAddress
-    #18 [ ] // placeholder for voucherCount
-    #19 [ ] // placeholder for conditionalCommitsByAddress
-    #20 [X] // placeholder for authTokenContracts
-    #21 [X] // placeholder for sellerIdByAuthToken
-    #22 [ ] // placeholder for twinRangesBySeller
-    #23 [ ] // placeholder for twinIdsByTokenAddressAndBySeller
-    #24 [X] // placeholder for twinReceiptsByExchange
-    #25 [X] // placeholder for allowedSellers
-    #26 [ ] // placeholder for allowedSellerIndex
-    #27 [X] // placeholder for exchangeCondition
-    #28 [ ] // placeholder for offerIdIndexByGroup
-    #29 [ ] // placeholder for pendingAddressUpdatesBySeller
-    #30 [ ] // placeholder for pendingAuthTokenUpdatesBySeller
-    #31 [ ] // placeholder for pendingAddressUpdatesByDisputeResolver
-    */
-
-    // starting slot
-    const protocolLookupsSlot = keccak256(ethers.utils.toUtf8Bytes("boson.protocol.lookups"));
-    const protocolLookupsSlotNumber = ethers.BigNumber.from(protocolLookupsSlot);
-
-    // exchangeIdsByOffer and groupIdByOffer
-    let exchangeIdsByOfferState = [];
-    let groupIdByOfferState = [];
-    for (const offer of offers[versionIndex]) {
-      const id = Number(offer.offer.id);
-      // exchangeIdsByOffer
-      let exchangeIdsByOffer = [];
-      const arraySlot = ethers.BigNumber.from(
-        getMappingStoragePosition(protocolLookupsSlotNumber.add("0"), id, paddingType.START)
-      );
-      const arrayLength = ethers.BigNumber.from(await getStorageAt(protocolDiamondAddress, arraySlot)).toNumber();
-      const arrayStart = ethers.BigNumber.from(keccak256(arraySlot));
-      for (let i = 0; i < arrayLength; i++) {
-        exchangeIdsByOffer.push(await getStorageAt(protocolDiamondAddress, arrayStart.add(i)));
-      }
-      exchangeIdsByOfferState.push(exchangeIdsByOffer);
-
-      // groupIdByOffer
-      groupIdByOfferState.push(
-        await getStorageAt(
-          protocolDiamondAddress,
-          getMappingStoragePosition(protocolLookupsSlotNumber.add("3"), id, paddingType.START)
-        )
-      );
-    }
-
-    // buyerIdByWallet, agentIdByWallet, conditionalCommitsByAddress
-    let buyerIdByWallet = [];
-    let agentIdByWallet = [];
-    let conditionalCommitsByAddress = [];
-
-    const accounts = [...sellers[versionIndex], ...DRs[versionIndex], ...agents[versionIndex], ...buyers[versionIndex]];
-
-    for (const account of accounts) {
-      const accountAddress = account.wallet.address;
-
-      // buyerIdByWallet
-      buyerIdByWallet.push(
-        await getStorageAt(
-          protocolDiamondAddress,
-          getMappingStoragePosition(protocolLookupsSlotNumber.add("8"), accountAddress, paddingType.START)
-        )
-      );
-
-      // agentIdByWallet
-      agentIdByWallet.push(
-        await getStorageAt(
-          protocolDiamondAddress,
-          getMappingStoragePosition(protocolLookupsSlotNumber.add("13"), accountAddress, paddingType.START)
-        )
-      );
-
-      // conditionalCommitsByAddress
-      const firstMappingStorageSlot = ethers.BigNumber.from(
-        getMappingStoragePosition(protocolLookupsSlotNumber.add("19"), accountAddress, paddingType.START)
-      );
-      let commitsPerGroup = [];
-      for (const group of groups[versionIndex]) {
-        const id = group.id;
-        commitsPerGroup.push(
-          await getStorageAt(
-            protocolDiamondAddress,
-            getMappingStoragePosition(firstMappingStorageSlot, id, paddingType.START)
-          )
-        );
-      }
-      conditionalCommitsByAddress.push(commitsPerGroup);
-    }
-
-    // disputeResolverFeeTokenIndex, tokenIndexByAccount, cloneAddress, voucherCount
-    let disputeResolverFeeTokenIndex = [];
-    let tokenIndexByAccount = [];
-    let cloneAddress = [];
-    let voucherCount = [];
-
-    // all id count
-    const totalCount =
-      DRs[versionIndex].length +
-      sellers[versionIndex].length +
-      buyers[versionIndex].length +
-      agents[versionIndex].length;
-    const offset = versionIndex == 1 ? DRs[0].length + sellers[0].length + buyers[0].length + agents[0].length : 0;
-    const startId = 1 + offset;
-    const endId = totalCount + offset;
-
-    // loop over all ids even where no data is expected
-    for (let id = startId; id <= endId; id++) {
-      // disputeResolverFeeTokenIndex
-      let firstMappingStorageSlot = ethers.BigNumber.from(
-        getMappingStoragePosition(protocolLookupsSlotNumber.add("12"), id, paddingType.START)
-      );
-      disputeResolverFeeTokenIndex.push({
-        native: await getStorageAt(
-          protocolDiamondAddress,
-          getMappingStoragePosition(firstMappingStorageSlot, ethers.constants.AddressZero, paddingType.START)
-        ),
-        mockToken: await getStorageAt(
-          protocolDiamondAddress,
-          getMappingStoragePosition(firstMappingStorageSlot, mockToken.address, paddingType.START)
-        ),
-      });
-
-      // tokenIndexByAccount
-      firstMappingStorageSlot = ethers.BigNumber.from(
-        getMappingStoragePosition(protocolLookupsSlotNumber.add("16"), id, paddingType.START)
-      );
-      tokenIndexByAccount.push({
-        native: await getStorageAt(
-          protocolDiamondAddress,
-          getMappingStoragePosition(firstMappingStorageSlot, ethers.constants.AddressZero, paddingType.START)
-        ),
-        mockToken: await getStorageAt(
-          protocolDiamondAddress,
-          getMappingStoragePosition(firstMappingStorageSlot, mockToken.address, paddingType.START)
-        ),
-      });
-
-      // cloneAddress
-      cloneAddress.push(
-        await getStorageAt(
-          protocolDiamondAddress,
-          getMappingStoragePosition(protocolLookupsSlotNumber.add("17"), id, paddingType.START)
-        )
-      );
-
-      // voucherCount
-      voucherCount.push(
-        await getStorageAt(
-          protocolDiamondAddress,
-          getMappingStoragePosition(protocolLookupsSlotNumber.add("18"), id, paddingType.START)
-        )
-      );
-    }
-
-    // twinRangesBySeller
-    let twinRangesBySeller = [];
-    for (let id = startId; id <= endId; id++) {
-      const firstMappingStorageSlot = ethers.BigNumber.from(
-        getMappingStoragePosition(protocolLookupsSlotNumber.add("22"), id, paddingType.START)
-      );
-      let ranges = {};
-      for (let mockTwin of mockTwinTokens) {
-        ranges[mockTwin.address] = [];
-        const arraySlot = getMappingStoragePosition(firstMappingStorageSlot, mockTwin.address, paddingType.START);
-        const arrayLength = ethers.BigNumber.from(await getStorageAt(protocolDiamondAddress, arraySlot)).toNumber();
-        const arrayStart = ethers.BigNumber.from(keccak256(arraySlot));
-        for (let i = 0; i < arrayLength * 2; i = i + 2) {
-          // each BosonTypes.TokenRange has length 2
-          ranges[mockTwin.address].push({
-            start: await getStorageAt(protocolDiamondAddress, arrayStart.add(i)),
-            end: await getStorageAt(protocolDiamondAddress, arrayStart.add(i + 1)),
-          });
-        }
-      }
-      twinRangesBySeller.push(ranges);
-    }
-
-    // twinIdsByTokenAddressAndBySeller
-    let twinIdsByTokenAddressAndBySeller = [];
-    for (let id = startId; id <= endId; id++) {
-      const firstMappingStorageSlot = ethers.BigNumber.from(
-        getMappingStoragePosition(protocolLookupsSlotNumber.add("23"), id, paddingType.START)
-      );
-      let twinIds = {};
-      for (let mockTwin of mockTwinTokens) {
-        twinIds[mockTwin.address] = [];
-        const arraySlot = getMappingStoragePosition(firstMappingStorageSlot, mockTwin.address, paddingType.START);
-        const arrayLength = ethers.BigNumber.from(await getStorageAt(protocolDiamondAddress, arraySlot)).toNumber();
-        const arrayStart = ethers.BigNumber.from(keccak256(arraySlot));
-        for (let i = 0; i < arrayLength; i++) {
-          twinIds[mockTwin.address].push(await getStorageAt(protocolDiamondAddress, arrayStart.add(i)));
-        }
-      }
-      twinIdsByTokenAddressAndBySeller.push(twinIds);
-    }
-
-    // allowedSellerIndex
-    let allowedSellerIndex = [];
-    for (const DR of DRs[versionIndex]) {
-      const firstMappingStorageSlot = ethers.BigNumber.from(
-        getMappingStoragePosition(
-          protocolLookupsSlotNumber.add("26"),
-          ethers.BigNumber.from(DR.disputeResolver.id).toHexString(),
-          paddingType.START
-        )
-      );
-      let sellerStatus = [];
-      for (const seller of sellers[versionIndex]) {
-        sellerStatus.push(
-          await getStorageAt(
-            protocolDiamondAddress,
-            getMappingStoragePosition(
-              firstMappingStorageSlot,
-              ethers.BigNumber.from(seller.seller.id).toHexString(),
-              paddingType.START
-            )
-          )
-        );
-      }
-      allowedSellerIndex.push(sellerStatus);
-    }
-
-    // offerIdIndexByGroup
-    let offerIdIndexByGroup = [];
-    for (const group of groups[versionIndex]) {
-      const id = group.id;
-      const firstMappingStorageSlot = ethers.BigNumber.from(
-        getMappingStoragePosition(protocolLookupsSlotNumber.add("28"), id, paddingType.START)
-      );
-      let offerInidices = [];
-      for (const offer of offers[versionIndex]) {
-        const id2 = Number(offer.offer.id);
-        offerInidices.push(
-          await getStorageAt(
-            protocolDiamondAddress,
-            getMappingStoragePosition(firstMappingStorageSlot, id2, paddingType.START)
-          )
-        );
-      }
-      offerIdIndexByGroup.push(offerInidices);
-    }
-
-    // pendingAddressUpdatesBySeller, pendingAuthTokenUpdatesBySeller, pendingAddressUpdatesByDisputeResolver
-    let pendingAddressUpdatesBySeller = [];
-    let pendingAuthTokenUpdatesBySeller = [];
-    let pendingAddressUpdatesByDisputeResolver = [];
-
-    // Although pending address/auth token update is not yet defined in 2.0.0, we can check that storage slots are empty
-    for (let id = startId; id <= endId; id++) {
-      // pendingAddressUpdatesBySeller
-      let structStorageSlot = ethers.BigNumber.from(
-        getMappingStoragePosition(protocolLookupsSlotNumber.add("29"), id, paddingType.START)
-      );
-      let structFields = [];
-      for (let i = 0; i < 5; i++) {
-        // BosonTypes.Seller has 6 fields, but last bool is packed in one slot with previous field
-        structFields.push(await getStorageAt(protocolDiamondAddress, structStorageSlot.add(i)));
-      }
-      pendingAddressUpdatesBySeller.push(structFields);
-
-      // pendingAuthTokenUpdatesBySeller
-      structStorageSlot = ethers.BigNumber.from(
-        getMappingStoragePosition(protocolLookupsSlotNumber.add("30"), id, paddingType.START)
-      );
-      structFields = [];
-      for (let i = 0; i < 2; i++) {
-        // BosonTypes.AuthToken has 2 fields
-        structFields.push(await getStorageAt(protocolDiamondAddress, structStorageSlot.add(i)));
-      }
-      pendingAuthTokenUpdatesBySeller.push(structFields);
-
-      // pendingAddressUpdatesByDisputeResolver
-      structStorageSlot = ethers.BigNumber.from(
-        getMappingStoragePosition(protocolLookupsSlotNumber.add("31"), id, paddingType.START)
-      );
-      structFields = [];
-      for (let i = 0; i < 8; i++) {
-        // BosonTypes.DisputeResolver has 8 fields
-        structFields.push(await getStorageAt(protocolDiamondAddress, structStorageSlot.add(i)));
-      }
-      structFields[6] = await getStorageAt(protocolDiamondAddress, keccak256(structStorageSlot.add(6))); // represents field string metadataUri. Technically this value represents the length of the string, but since it should be 0, we don't do further decoding
-      pendingAddressUpdatesByDisputeResolver.push(structFields);
-    }
-
-    return {
-      exchangeIdsByOfferState,
-      groupIdByOfferState,
-      buyerIdByWallet,
-      disputeResolverFeeTokenIndex,
-      agentIdByWallet,
-      tokenIndexByAccount,
-      cloneAddress,
-      voucherCount,
-      conditionalCommitsByAddress,
-      twinRangesBySeller,
-      twinIdsByTokenAddressAndBySeller,
-      allowedSellerIndex,
-      offerIdIndexByGroup,
-      pendingAddressUpdatesBySeller,
-      pendingAuthTokenUpdatesBySeller,
-      pendingAddressUpdatesByDisputeResolver,
-    };
-  }
 });

--- a/test/upgrade/utils.js
+++ b/test/upgrade/utils.js
@@ -1,0 +1,1149 @@
+const { getStorageAt } = require("@nomicfoundation/hardhat-network-helpers");
+const hre = require("hardhat");
+const ethers = hre.ethers;
+const { keccak256 } = ethers.utils;
+const AuthToken = require("../../scripts/domain/AuthToken");
+const AuthTokenType = require("../../scripts/domain/AuthTokenType");
+const Bundle = require("../../scripts/domain/Bundle");
+const Group = require("../../scripts/domain/Group");
+const VoucherInitValues = require("../../scripts/domain/VoucherInitValues");
+const TokenType = require("../../scripts/domain/TokenType.js");
+const { DisputeResolverFee } = require("../../scripts/domain/DisputeResolverFee");
+const {
+  mockOffer,
+  mockDisputeResolver,
+  mockAuthToken,
+  mockSeller,
+  mockAgent,
+  mockBuyer,
+  mockCondition,
+  mockTwin,
+} = require("../util/mock");
+const { setNextBlockTimestamp, paddingType, getMappingStoragePosition } = require("../util/utils.js");
+const { oneMonth, oneDay } = require("../util/constants");
+const { getInterfaceIds } = require("../../scripts/config/supported-interfaces.js");
+
+// Common vars
+let rando;
+
+// populates protocol with some entities
+// returns
+/*   DRs
+      sellers
+      buyers
+      agents
+      offers
+      exchanges
+      bundles
+      groups
+      twins*/
+async function populateProtocolContract(
+  deployer,
+  protocolDiamondAddress,
+  {
+    accountHandler,
+    exchangeHandler,
+    offerHandler,
+    fundsHandler,
+    disputeHandler,
+    bundleHandler,
+    groupHandler,
+    twinHandler,
+  },
+  { mockToken, mockConditionalToken, mockAuthERC721Contract, mockTwinTokens, mockTwin20, mockTwin1155 }
+) {
+  let DRs = [];
+  let sellers = [];
+  let buyers = [];
+  let agents = [];
+  let offers = [];
+  let groups = [];
+  let twins = [];
+  let exchanges = [];
+  let bundles = [];
+
+  const entityType = {
+    SELLER: 0,
+    DR: 1,
+    AGENT: 2,
+    BUYER: 3,
+  };
+
+  const entities = [
+    entityType.DR,
+    entityType.AGENT,
+    entityType.SELLER,
+    entityType.SELLER,
+    entityType.DR,
+    entityType.SELLER,
+    entityType.DR,
+    entityType.SELLER,
+    entityType.AGENT,
+    entityType.SELLER,
+    entityType.BUYER,
+    entityType.BUYER,
+    entityType.BUYER,
+    entityType.BUYER,
+    entityType.BUYER,
+  ];
+
+  for (const entity of entities) {
+    const wallet = ethers.Wallet.createRandom();
+    const connectedWallet = wallet.connect(ethers.provider);
+    //Fund the new wallet
+    let tx = {
+      to: connectedWallet.address,
+      // Convert currency unit from ether to wei
+      value: ethers.utils.parseEther("10"),
+    };
+    await deployer.sendTransaction(tx);
+
+    // create entities
+    switch (entity) {
+      case entityType.DR: {
+        const disputeResolver = mockDisputeResolver(wallet.address, wallet.address, wallet.address, wallet.address);
+        const disputeResolverFees = [
+          new DisputeResolverFee(ethers.constants.AddressZero, "Native", "0"),
+          new DisputeResolverFee(mockToken.address, "MockToken", "0"),
+        ];
+        const sellerAllowList = [];
+        await accountHandler
+          .connect(connectedWallet)
+          .createDisputeResolver(disputeResolver, disputeResolverFees, sellerAllowList);
+        DRs.push({
+          wallet: connectedWallet,
+          id: disputeResolver.id,
+          disputeResolver,
+          disputeResolverFees,
+          sellerAllowList,
+        });
+
+        //ADMIN role activates Dispute Resolver
+        await accountHandler.connect(deployer).activateDisputeResolver(disputeResolver.id);
+        break;
+      }
+      case entityType.SELLER: {
+        const seller = mockSeller(wallet.address, wallet.address, wallet.address, wallet.address);
+        const id = seller.id;
+        let authToken;
+        // randomly decide if auth token is used or not
+        if (Math.random() > 0.5) {
+          // no auth token
+          authToken = mockAuthToken();
+        } else {
+          // use auth token
+          seller.admin = ethers.constants.AddressZero;
+          await mockAuthERC721Contract.connect(connectedWallet).mint(101 * id, 1);
+          authToken = new AuthToken(`${101 * id}`, AuthTokenType.Lens);
+        }
+        // set unique new voucherInitValues
+        const voucherInitValues = new VoucherInitValues(`http://seller${id}.com/uri`, id * 10);
+        await accountHandler.connect(connectedWallet).createSeller(seller, authToken, voucherInitValues);
+        sellers.push({ wallet: connectedWallet, id, seller, authToken, voucherInitValues, offerIds: [] });
+
+        // mint mock token to sellers just in case they need them
+        await mockToken.mint(connectedWallet.address, "10000000000");
+        await mockToken.connect(connectedWallet).approve(protocolDiamondAddress, "10000000000");
+        break;
+      }
+      case entityType.AGENT: {
+        const agent = mockAgent(wallet.address);
+        await accountHandler.connect(connectedWallet).createAgent(agent);
+        agents.push({ wallet: connectedWallet, id: agent.id, agent });
+        break;
+      }
+      case entityType.BUYER: {
+        // no need to explicitly create buyer, since it's done automatically during commitToOffer
+        const buyer = mockBuyer(wallet.address);
+        buyers.push({ wallet: connectedWallet, id: buyer.id, buyer });
+
+        // mint them conditional token in case they need it
+        await mockConditionalToken.mint(wallet.address, "10");
+        break;
+      }
+    }
+  }
+
+  // Make explicit allowed sellers list for some DRs
+  const sellerIds = sellers.map((s) => s.seller.id);
+  for (let i = 0; i < DRs.length; i = i + 2) {
+    const DR = DRs[i];
+    DR.sellerAllowList = sellerIds;
+    await accountHandler.connect(DR.wallet).addSellersToAllowList(DR.disputeResolver.id, sellerIds);
+  }
+
+  // create offers - first seller has 5 offers, second 4, third 3 etc
+  let offerId = (await offerHandler.getNextOfferId()).toNumber();
+  for (let i = 0; i < sellers.length; i++) {
+    for (let j = i; j >= 0; j--) {
+      // Mock offer, offerDates and offerDurations
+      const { offer, offerDates, offerDurations } = await mockOffer();
+
+      // Set unique offer properties based on offer id
+      offer.id = `${offerId}`;
+      offer.sellerId = sellers[j].seller.id;
+      offer.price = `${offerId * 1000}`;
+      offer.sellerDeposit = `${offerId * 100}`;
+      offer.buyerCancelPenalty = `${offerId * 50}`;
+      offer.quantityAvailable = `${(offerId + 1) * 15}`;
+
+      // Default offer is in native token. Change every other to mock token
+      if (offerId % 2 == 0) {
+        offer.exchangeToken = mockToken.address;
+      }
+
+      // Set unique offer dates based on offer id
+      const now = offerDates.validFrom;
+      offerDates.validFrom = ethers.BigNumber.from(now)
+        .add(oneMonth + offerId * 1000)
+        .toString();
+      offerDates.validUntil = ethers.BigNumber.from(now)
+        .add(oneMonth * 6 * (offerId + 1))
+        .toString();
+
+      // Set unique offerDurations based on offer id
+      offerDurations.disputePeriod = `${(offerId + 1) * oneMonth}`;
+      offerDurations.voucherValid = `${(offerId + 1) * oneMonth}`;
+      offerDurations.resolutionPeriod = `${(offerId + 1) * oneDay}`;
+
+      // choose one DR and agent
+      const disputeResolverId = DRs[offerId % 3].disputeResolver.id;
+      const agentId = agents[offerId % 2].agent.id;
+
+      // create an offer
+      await offerHandler
+        .connect(sellers[j].wallet)
+        .createOffer(offer, offerDates, offerDurations, disputeResolverId, agentId);
+
+      offers.push({ offer, offerDates, offerDurations, disputeResolverId, agentId });
+      sellers[j].offerIds.push(offerId);
+
+      // Deposit seller funds so the commit will succeed
+      const sellerPool = ethers.BigNumber.from(offer.quantityAvailable).mul(offer.price).toString();
+      const msgValue = offer.exchangeToken == ethers.constants.AddressZero ? sellerPool : "0";
+      await fundsHandler
+        .connect(sellers[j].wallet)
+        .depositFunds(sellers[j].seller.id, offer.exchangeToken, sellerPool, { value: msgValue });
+
+      offerId++;
+    }
+  }
+
+  // group some offers
+  let groupId = (await groupHandler.getNextGroupId()).toNumber();
+  for (let i = 0; i < sellers.length; i = i + 2) {
+    const seller = sellers[i];
+    const group = new Group(groupId, seller.seller.id, seller.offerIds); // group all seller's offers
+    const condition = mockCondition({
+      tokenAddress: mockConditionalToken.address,
+      maxCommits: "10",
+    });
+    await groupHandler.connect(seller.wallet).createGroup(group, condition);
+
+    groups.push(group);
+
+    groupId++;
+  }
+
+  // create some twins and bundles
+  let twinId = (await twinHandler.getNextTwinId()).toNumber();
+  let bundleId = (await bundleHandler.getNextBundleId()).toNumber();
+  for (let i = 1; i < sellers.length; i = i + 2) {
+    const seller = sellers[i];
+    const sellerId = seller.id;
+    let twinIds = []; // used for bundle
+
+    // non fungible token
+    await mockTwinTokens[0].connect(seller.wallet).setApprovalForAll(protocolDiamondAddress, true);
+    await mockTwinTokens[1].connect(seller.wallet).setApprovalForAll(protocolDiamondAddress, true);
+    // create multiple ranges
+    const twin721 = mockTwin(ethers.constants.AddressZero, TokenType.NonFungibleToken);
+    twin721.amount = "0";
+    for (let j = 0; j < 7; j++) {
+      twin721.tokenId = `${sellerId * 1000000 + j * 100000}`;
+      twin721.supplyAvailable = `${100 * (sellerId + 1)}`;
+      twin721.tokenAddress = mockTwinTokens[j % 2].address; // oscilate between twins
+      twin721.id = twinId;
+      await twinHandler.connect(seller.wallet).createTwin(twin721);
+
+      twins.push(twin721);
+      twinIds.push(twinId);
+
+      twinId++;
+    }
+
+    // fungible
+    const twin20 = mockTwin(mockTwin20.address, TokenType.FungibleToken);
+    await mockTwin20.connect(seller.wallet).approve(protocolDiamondAddress, 1);
+    twin20.id = twinId;
+    twin20.amount = sellerId;
+    twin20.supplyAvailable = twin20.amount * 100000000;
+    await twinHandler.connect(seller.wallet).createTwin(twin20);
+    twins.push(twin20);
+    twinIds.push(twinId);
+    twinId++;
+
+    // multitoken twin
+    const twin1155 = mockTwin(mockTwin1155.address, TokenType.MultiToken);
+    await mockTwin1155.connect(seller.wallet).setApprovalForAll(protocolDiamondAddress, true);
+    for (let j = 0; j < 3; j++) {
+      twin1155.tokenId = `${j * 30000 + sellerId * 300}`;
+      twin1155.amount = sellerId + j;
+      twin1155.supplyAvailable = `${300000 * (sellerId + 1)}`;
+      twin1155.id = twinId;
+      await twinHandler.connect(seller.wallet).createTwin(twin1155);
+      twins.push(twin1155);
+      twinIds.push(twinId);
+      twinId++;
+    }
+
+    // create bundle with all seller's twins and offers
+    const bundle = new Bundle(bundleId, seller.seller.id, seller.offerIds, twinIds);
+    await bundleHandler.connect(seller.wallet).createBundle(bundle);
+    bundles.push(bundle);
+    bundleId++;
+  }
+
+  // commit to some offers: first buyer commit to 1 offer, second to 2, third to 3 etc
+  await setNextBlockTimestamp(Number(offers[offers.length - 1].offerDates.validFrom)); // When latest offer is valid, also other offers are valid
+  let exchangeId = (await exchangeHandler.getNextExchangeId()).toNumber();
+  for (let i = 0; i < buyers.length; i++) {
+    for (let j = i; j < buyers.length; j++) {
+      const offer = offers[i + j].offer; // some offers will be picked multiple times, some never.
+      const offerPrice = offer.price;
+      const buyerWallet = buyers[j].wallet;
+      let msgValue;
+      if (offer.exchangeToken == ethers.constants.AddressZero) {
+        msgValue = offerPrice;
+      } else {
+        // approve token transfer
+        msgValue = 0;
+        await mockToken.connect(buyerWallet).approve(protocolDiamondAddress, offerPrice);
+        await mockToken.mint(buyerWallet.address, offerPrice);
+      }
+      await exchangeHandler.connect(buyerWallet).commitToOffer(buyerWallet.address, offer.id, { value: msgValue });
+      exchanges.push({ exchangeId: exchangeId, offerId: offer.id, buyerIndex: j });
+      exchangeId++;
+    }
+  }
+
+  // redeem some vouchers #4
+  for (const id of [2, 5, 11, 8]) {
+    const exchange = exchanges[id];
+    await exchangeHandler.connect(buyers[exchange.buyerIndex].wallet).redeemVoucher(exchange.exchangeId);
+  }
+
+  // cancel some vouchers #3
+  for (const id of [10, 3, 13]) {
+    const exchange = exchanges[id];
+    await exchangeHandler.connect(buyers[exchange.buyerIndex].wallet).cancelVoucher(exchange.exchangeId);
+  }
+
+  // revoke some vouchers #2
+  for (const id of [4, 6]) {
+    const exchange = exchanges[id];
+    const offer = offers.find((o) => o.offer.id == exchange.offerId);
+    const seller = sellers.find((s) => s.seller.id == offer.offer.sellerId);
+    await exchangeHandler.connect(seller.wallet).revokeVoucher(exchange.exchangeId);
+  }
+
+  // raise dispute on some exchanges #1
+  const id = 5; // must be one of redeemed ones
+  const exchange = exchanges[id];
+  await disputeHandler.connect(buyers[exchange.buyerIndex].wallet).raiseDispute(exchange.exchangeId);
+
+  return { DRs, sellers, buyers, agents, offers, exchanges, bundles, groups, twins };
+}
+
+// Retruns protocol state for provided entities
+async function getProtocolContractState(
+  protocolDiamondAddress,
+  {
+    accountHandler,
+    exchangeHandler,
+    offerHandler,
+    fundsHandler,
+    disputeHandler,
+    bundleHandler,
+    groupHandler,
+    twinHandler,
+    configHandler,
+  },
+  { mockToken, mockTwinTokens },
+  { DRs, sellers, buyers, agents, offers, exchanges, bundles, groups, twins }
+) {
+  rando = (await ethers.getSigners())[10]; // random account making the calls
+
+  const [
+    accountContractState,
+    offerContractState,
+    exchangeContractState,
+    bundleContractState,
+    configContractState,
+    disputeContractState,
+    fundsContractState,
+    groupContractState,
+    twinContractState,
+    metaTxContractState,
+    metaTxPrivateContractState,
+    protocolStatusPrivateContractState,
+    protocolLookupsPrivateContractState,
+  ] = await Promise.all([
+    getAccountContractState(accountHandler, { DRs, sellers, buyers, agents }),
+    getOfferContractState(offerHandler, offers),
+    getExchangeContractState(exchangeHandler, exchanges),
+    getBundleContractState(bundleHandler, bundles),
+    getConfigContractState(configHandler),
+    getDisputeContractState(disputeHandler, exchanges),
+    getFundsContractState(fundsHandler, { DRs, sellers, buyers, agents }),
+    getGroupContractState(groupHandler, groups),
+    getTwinContractState(twinHandler, twins),
+    getMetaTxContractState(),
+    getMetaTxPrivateContractState(protocolDiamondAddress),
+    getProtocolStatusPrivateContractState(protocolDiamondAddress),
+    getProtocolLookupsPrivateContractState(
+      protocolDiamondAddress,
+      { mockToken, mockTwinTokens },
+      { sellers, DRs, agents, buyers, offers, groups }
+    ),
+  ]);
+
+  return {
+    accountContractState,
+    offerContractState,
+    exchangeContractState,
+    bundleContractState,
+    configContractState,
+    disputeContractState,
+    fundsContractState,
+    groupContractState,
+    twinContractState,
+    metaTxContractState,
+    metaTxPrivateContractState,
+    protocolStatusPrivateContractState,
+    protocolLookupsPrivateContractState,
+  };
+}
+
+async function getAccountContractState(accountHandler, { DRs, sellers, buyers, agents }) {
+  const accountHandlerRando = accountHandler.connect(rando);
+  // all accounts
+  const accounts = [...sellers, ...DRs, ...buyers, ...agents];
+  let DRsState = [];
+  let sellerState = [];
+  let buyersState = [];
+  let agentsState = [];
+  let allowedSellersState = [];
+  let sellerByAddressState = [];
+  let sellerByAuthTokenState = [];
+  let DRbyAddressState = [];
+  let nextAccountId;
+
+  // Query even the ids where it's not expected to get the entity
+  for (const account of accounts) {
+    const id = account.id;
+    const [singleSellerState, singleDRsState, singleBuyersState, singleAgentsState] = await Promise.all([
+      accountHandlerRando.getSeller(id),
+      accountHandlerRando.getDisputeResolver(id),
+      accountHandlerRando.getBuyer(id),
+      accountHandlerRando.getAgent(id),
+    ]);
+    sellerState.push(singleSellerState);
+    DRsState.push(singleDRsState);
+    buyersState.push(singleBuyersState);
+    agentsState.push(singleAgentsState);
+    for (const account2 of accounts) {
+      const id2 = account2.id;
+      allowedSellersState.push(await accountHandlerRando.areSellersAllowed(id2, [id]));
+    }
+  }
+
+  for (const seller of sellers) {
+    const sellerAddress = seller.wallet.address;
+    const sellerAuthToken = seller.authToken;
+
+    const [singleSellerByAddressState, singleSellerByAuthTokenState, singleDRbyAddressState] = await Promise.all([
+      accountHandlerRando.getSellerByAddress(sellerAddress),
+      accountHandlerRando.getSellerByAuthToken(sellerAuthToken),
+      accountHandlerRando.getDisputeResolverByAddress(sellerAddress),
+    ]);
+    sellerByAddressState.push(singleSellerByAddressState);
+    sellerByAuthTokenState.push(singleSellerByAuthTokenState);
+    DRbyAddressState.push(singleDRbyAddressState);
+  }
+
+  const otherAccounts = [...DRs, ...agents, ...buyers];
+
+  for (const account of otherAccounts) {
+    const accountAddress = account.wallet.address;
+
+    const [singleSellerByAddressState, singleDRbyAddressState] = await Promise.all([
+      accountHandlerRando.getSellerByAddress(accountAddress),
+      accountHandlerRando.getDisputeResolverByAddress(accountAddress),
+    ]);
+    sellerByAddressState.push(singleSellerByAddressState);
+    DRbyAddressState.push(singleDRbyAddressState);
+  }
+
+  nextAccountId = await accountHandlerRando.getNextAccountId();
+
+  return {
+    DRsState,
+    sellerState,
+    buyersState,
+    sellerByAddressState,
+    sellerByAuthTokenState,
+    DRbyAddressState,
+    nextAccountId,
+  };
+}
+
+async function getOfferContractState(offerHandler, offers) {
+  const offerHandlerRando = offerHandler.connect(rando);
+  // get offers
+  let offersState = [];
+  let isOfferVoidedState = [];
+  let agentIdByOfferState = [];
+  for (const offer of offers) {
+    const id = offer.offer.id;
+    const [singleOffersState, singleIsOfferVoidedState, singleAgentIdByOfferState] = await Promise.all([
+      offerHandlerRando.getOffer(id),
+      offerHandlerRando.isOfferVoided(id),
+      offerHandlerRando.getAgentIdByOffer(id),
+    ]);
+    offersState.push(singleOffersState);
+    isOfferVoidedState.push(singleIsOfferVoidedState);
+    agentIdByOfferState.push(singleAgentIdByOfferState);
+  }
+
+  let nextOfferId = await offerHandlerRando.getNextOfferId();
+
+  return { offersState, isOfferVoidedState, agentIdByOfferState, nextOfferId };
+}
+
+async function getExchangeContractState(exchangeHandler, exchanges) {
+  const exchangeHandlerRando = exchangeHandler.connect(rando);
+  // get exchanges
+  let exchangesState = [];
+  let exchangeStateState = [];
+  let isExchangeFinalizedState = [];
+  let receiptsState = [];
+
+  for (const exchange of exchanges) {
+    const id = exchange.exchangeId;
+    const [singleExchangesState, singleExchangeStateState, singleIsExchangeFinalizedState] = await Promise.all([
+      exchangeHandlerRando.getExchange(id),
+      exchangeHandlerRando.getExchangeState(id),
+      exchangeHandlerRando.isExchangeFinalized(id),
+    ]);
+    exchangesState.push(singleExchangesState);
+    exchangeStateState.push(singleExchangeStateState);
+    isExchangeFinalizedState.push(singleIsExchangeFinalizedState);
+    try {
+      receiptsState.push(await exchangeHandlerRando.getReceipt(id));
+    } catch {
+      receiptsState.push(["NOT_FINALIZED"]);
+    }
+  }
+
+  let nextExchangeId = await exchangeHandlerRando.getNextExchangeId();
+  return { exchangesState, exchangeStateState, isExchangeFinalizedState, receiptsState, nextExchangeId };
+}
+
+async function getBundleContractState(bundleHandler, bundles) {
+  // get bundles
+  const bundleHandlerRando = bundleHandler.connect(rando);
+  let bundlesState = [];
+  let bundleIdByOfferState = [];
+  let bundleIdByTwinState = [];
+  for (const bundle of bundles) {
+    const id = bundle.id;
+    const [singleBundlesState, singleBundleIdByOfferState, singleBundleIdByTwinState] = await Promise.all([
+      bundleHandlerRando.getBundle(id),
+      bundleHandlerRando.getBundleIdByOffer(id),
+      bundleHandlerRando.getBundleIdByTwin(id),
+    ]);
+    bundlesState.push(singleBundlesState);
+    bundleIdByOfferState.push(singleBundleIdByOfferState);
+    bundleIdByTwinState.push(singleBundleIdByTwinState);
+  }
+
+  let nextBundleId = await bundleHandlerRando.getNextBundleId();
+  return { bundlesState, bundleIdByOfferState, bundleIdByTwinState, nextBundleId };
+}
+
+async function getConfigContractState(configHandler) {
+  const configHandlerRando = configHandler.connect(rando);
+  const [
+    tokenAddress,
+    treasuryAddress,
+    voucherBeaconAddress,
+    beaconProxyAddress,
+    protocolFeePercentage,
+    protocolFeeFlatBoson,
+    maxOffersPerBatch,
+    maxOffersPerGroup,
+    maxTwinsPerBundle,
+    maxOffersPerBundle,
+    maxTokensPerWithdrawal,
+    maxFeesPerDisputeResolver,
+    maxEscalationResponsePeriod,
+    maxDisputesPerBatch,
+    maxTotalOfferFeePercentage,
+    maxAllowedSellers,
+    buyerEscalationDepositPercentage,
+    authTokenContractNone,
+    authTokenContractCustom,
+    authTokenContractLens,
+    authTokenContractENS,
+    maxExchangesPerBatch,
+    maxRoyaltyPecentage,
+    maxResolutionPeriod,
+    minDisputePeriod,
+    accessControllerAddress,
+  ] = await Promise.all([
+    configHandlerRando.getTokenAddress(),
+    configHandlerRando.getTreasuryAddress(),
+    configHandlerRando.getVoucherBeaconAddress(),
+    configHandlerRando.getBeaconProxyAddress(),
+    configHandlerRando.getProtocolFeePercentage(),
+    configHandlerRando.getProtocolFeeFlatBoson(),
+    configHandlerRando.getMaxOffersPerBatch(),
+    configHandlerRando.getMaxOffersPerGroup(),
+    configHandlerRando.getMaxTwinsPerBundle(),
+    configHandlerRando.getMaxOffersPerBundle(),
+    configHandlerRando.getMaxTokensPerWithdrawal(),
+    configHandlerRando.getMaxFeesPerDisputeResolver(),
+    configHandlerRando.getMaxEscalationResponsePeriod(),
+    configHandlerRando.getMaxDisputesPerBatch(),
+    configHandlerRando.getMaxTotalOfferFeePercentage(),
+    configHandlerRando.getMaxAllowedSellers(),
+    configHandlerRando.getBuyerEscalationDepositPercentage(),
+    configHandlerRando.getAuthTokenContract(AuthTokenType.None),
+    configHandlerRando.getAuthTokenContract(AuthTokenType.Custom),
+    configHandlerRando.getAuthTokenContract(AuthTokenType.Lens),
+    configHandlerRando.getAuthTokenContract(AuthTokenType.ENS),
+    configHandlerRando.getMaxExchangesPerBatch(),
+    configHandlerRando.getMaxRoyaltyPecentage(),
+    configHandlerRando.getMaxResolutionPeriod(),
+    configHandlerRando.getMinDisputePeriod(),
+    configHandlerRando.getAccessControllerAddress(),
+  ]);
+
+  return {
+    tokenAddress,
+    treasuryAddress,
+    voucherBeaconAddress,
+    beaconProxyAddress,
+    protocolFeePercentage,
+    protocolFeeFlatBoson,
+    maxOffersPerBatch,
+    maxOffersPerGroup,
+    maxTwinsPerBundle,
+    maxOffersPerBundle,
+    maxTokensPerWithdrawal,
+    maxFeesPerDisputeResolver,
+    maxEscalationResponsePeriod,
+    maxDisputesPerBatch,
+    maxTotalOfferFeePercentage,
+    maxAllowedSellers,
+    buyerEscalationDepositPercentage,
+    authTokenContractNone,
+    authTokenContractCustom,
+    authTokenContractLens,
+    authTokenContractENS,
+    maxExchangesPerBatch,
+    maxRoyaltyPecentage,
+    maxResolutionPeriod,
+    minDisputePeriod,
+    accessControllerAddress,
+  };
+}
+
+async function getDisputeContractState(disputeHandler, exchanges) {
+  const disputeHandlerRando = disputeHandler.connect(rando);
+  let disputesState = [];
+  let disputesStatesState = [];
+  let disputeTimeoutState = [];
+  let isDisputeFinalizedState = [];
+
+  for (const exchange of exchanges) {
+    const id = exchange.exchangeId;
+    const [singleDisputesState, singleDisputesStatesState, singleDisputeTimeoutState, singleIsDisputeFinalizedState] =
+      await Promise.all([
+        disputeHandlerRando.getDispute(id),
+        disputeHandlerRando.getDisputeState(id),
+        disputeHandlerRando.getDisputeTimeout(id),
+        disputeHandlerRando.isDisputeFinalized(id),
+      ]);
+    disputesState.push(singleDisputesState);
+    disputesStatesState.push(singleDisputesStatesState);
+    disputeTimeoutState.push(singleDisputeTimeoutState);
+    isDisputeFinalizedState.push(singleIsDisputeFinalizedState);
+  }
+
+  return { disputesState, disputesStatesState, disputeTimeoutState, isDisputeFinalizedState };
+}
+
+async function getFundsContractState(fundsHandler, { DRs, sellers, buyers, agents }) {
+  const fundsHandlerRando = fundsHandler.connect(rando);
+
+  // Query even the ids where it's not expected to get the entity
+  const accountIds = [...DRs, ...sellers, ...buyers, ...agents].map((account) => account.id);
+  const groupsState = await Promise.all(accountIds.map((id) => fundsHandlerRando.getAvailableFunds(id)));
+
+  return { groupsState };
+}
+
+async function getGroupContractState(groupHandler, groups) {
+  const groupHandlerRando = groupHandler.connect(rando);
+  const groupIds = [...Array(groups.length + 1).keys()].slice(1);
+  const groupsState = await Promise.all(groupIds.map((id) => groupHandlerRando.getGroup(id)));
+
+  const nextGroupId = await groupHandlerRando.getNextGroupId();
+  return { groupsState, nextGroupId };
+}
+
+async function getTwinContractState(twinHandler, twins) {
+  const twinHandlerRando = twinHandler.connect(rando);
+  const twinIds = [...Array(twins.length + 1).keys()].slice(1);
+  const twinsState = await Promise.all(twinIds.map((id) => twinHandlerRando.getTwin(id)));
+
+  const nextTwinId = await twinHandlerRando.getNextTwinId();
+  return { twinsState, nextTwinId };
+}
+
+async function getMetaTxContractState() {
+  return {};
+}
+
+async function getMetaTxPrivateContractState(protocolDiamondAddress) {
+  /*
+    ProtocolMetaTxInfo storage layout
+
+    #0 [ currentSenderAddress + isMetaTransaction ]
+    #1 [ domain separator ]
+    #2 [ ] // placeholder for usedNonce
+    #3 [ cachedChainId ]
+    #4 [ ] // placeholder for inputType
+    #5 [ ] // placeholder for hashInfo
+    */
+
+  // starting slot
+  const metaTxStorageSlot = keccak256(ethers.utils.toUtf8Bytes("boson.protocol.metaTransactions"));
+  const metaTxStorageSlotNumber = ethers.BigNumber.from(metaTxStorageSlot);
+
+  // current sender address + isMetaTransaction (they are packed since they are shorter than one slot)
+  // should be always be 0x
+  const inTransactionInfo = await getStorageAt(protocolDiamondAddress, metaTxStorageSlotNumber.add("0"));
+
+  // domain separator
+  const domainSeparator = await getStorageAt(protocolDiamondAddress, metaTxStorageSlotNumber.add("1"));
+
+  // cached chain id
+  const cachedChainId = await getStorageAt(protocolDiamondAddress, metaTxStorageSlotNumber.add("3"));
+
+  // input type
+  const inputTypeKeys = [
+    "commitToOffer(address,uint256)",
+    "cancelVoucher(uint256)",
+    "redeemVoucher(uint256)",
+    "completeExchange(uint256)",
+    "withdrawFunds(uint256,address[],uint256[])",
+    "retractDispute(uint256)",
+    "raiseDispute(uint256)",
+    "escalateDispute(uint256)",
+    "resolveDispute(uint256,uint256,bytes32,bytes32,uint8)",
+  ];
+
+  const inputTypesState = [];
+  for (const inputTypeKey of inputTypeKeys) {
+    const storageSlot = getMappingStoragePosition(metaTxStorageSlotNumber.add("4"), inputTypeKey, paddingType.NONE);
+    inputTypesState.push(await getStorageAt(protocolDiamondAddress, storageSlot));
+  }
+
+  // hashInfo
+  const hashInfoTypes = {
+    Generic: 0,
+    CommitToOffer: 1,
+    Exchange: 2,
+    Funds: 3,
+    RaiseDispute: 4,
+    ResolveDispute: 5,
+  };
+
+  const hashInfoState = [];
+  for (const hashInfoType of Object.values(hashInfoTypes)) {
+    const storageSlot = getMappingStoragePosition(metaTxStorageSlotNumber.add("5"), hashInfoType, paddingType.START);
+    // get also hashFunction
+    hashInfoState.push({
+      typeHash: await getStorageAt(protocolDiamondAddress, storageSlot),
+      functionPointer: await getStorageAt(protocolDiamondAddress, ethers.BigNumber.from(storageSlot).add(1)),
+    });
+  }
+
+  return { inTransactionInfo, domainSeparator, cachedChainId, inputTypesState, hashInfoState };
+}
+
+async function getProtocolStatusPrivateContractState(protocolDiamondAddress) {
+  /*
+    ProtocolStatus storage layout
+
+    #0 [ pauseScenario ]
+    #1 [ reentrancyStatus ]
+    #2 [ ] // placeholder for initializedInterfaces
+    */
+
+  // starting slot
+  const protocolStatusStorageSlot = keccak256(ethers.utils.toUtf8Bytes("boson.protocol.initializers"));
+  const protocolStatusStorageSlotNumber = ethers.BigNumber.from(protocolStatusStorageSlot);
+
+  // pause scenario
+  const pauseScenario = await getStorageAt(protocolDiamondAddress, protocolStatusStorageSlotNumber.add("0"));
+
+  // reentrancy status
+  // defualt: NOT_ENTERED = 1
+  const reentrancyStatus = await getStorageAt(protocolDiamondAddress, protocolStatusStorageSlotNumber.add("1"));
+
+  // initializedInterfaces
+  const interfaceIds = await getInterfaceIds();
+
+  const initializedInterfacesState = [];
+  for (const interfaceId of Object.values(interfaceIds)) {
+    const storageSlot = getMappingStoragePosition(
+      protocolStatusStorageSlotNumber.add("2"),
+      interfaceId,
+      paddingType.END
+    );
+    initializedInterfacesState.push(await getStorageAt(protocolDiamondAddress, storageSlot));
+  }
+
+  return { pauseScenario, reentrancyStatus, initializedInterfacesState };
+}
+
+async function getProtocolLookupsPrivateContractState(
+  protocolDiamondAddress,
+  { mockToken, mockTwinTokens },
+  { sellers, DRs, agents, buyers, offers, groups }
+) {
+  /*
+    ProtocolLookups storage layout
+
+    Variables marked with X have an external getter and are not handled here
+    #0  [ ] // placeholder for exchangeIdsByOffer
+    #1  [X] // placeholder for bundleIdByOffer
+    #2  [X] // placeholder for bundleIdByTwin
+    #3  [ ] // placeholder for groupIdByOffer
+    #4  [X] // placeholder for agentIdByOffer
+    #5  [X] // placeholder for sellerIdByOperator
+    #6  [X] // placeholder for sellerIdByAdmin
+    #7  [X] // placeholder for sellerIdByClerk
+    #8  [ ] // placeholder for buyerIdByWallet
+    #9  [X] // placeholder for disputeResolverIdByOperator
+    #10 [X] // placeholder for disputeResolverIdByAdmin
+    #11 [X] // placeholder for disputeResolverIdByClerk
+    #12 [ ] // placeholder for disputeResolverFeeTokenIndex
+    #13 [ ] // placeholder for agentIdByWallet
+    #14 [X] // placeholder for availableFunds
+    #15 [X] // placeholder for tokenList
+    #16 [ ] // placeholder for tokenIndexByAccount
+    #17 [ ] // placeholder for cloneAddress
+    #18 [ ] // placeholder for voucherCount
+    #19 [ ] // placeholder for conditionalCommitsByAddress
+    #20 [X] // placeholder for authTokenContracts
+    #21 [X] // placeholder for sellerIdByAuthToken
+    #22 [ ] // placeholder for twinRangesBySeller
+    #23 [ ] // placeholder for twinIdsByTokenAddressAndBySeller
+    #24 [X] // placeholder for twinReceiptsByExchange
+    #25 [X] // placeholder for allowedSellers
+    #26 [ ] // placeholder for allowedSellerIndex
+    #27 [X] // placeholder for exchangeCondition
+    #28 [ ] // placeholder for offerIdIndexByGroup
+    #29 [ ] // placeholder for pendingAddressUpdatesBySeller
+    #30 [ ] // placeholder for pendingAuthTokenUpdatesBySeller
+    #31 [ ] // placeholder for pendingAddressUpdatesByDisputeResolver
+    */
+
+  // starting slot
+  const protocolLookupsSlot = keccak256(ethers.utils.toUtf8Bytes("boson.protocol.lookups"));
+  const protocolLookupsSlotNumber = ethers.BigNumber.from(protocolLookupsSlot);
+
+  // exchangeIdsByOffer and groupIdByOffer
+  let exchangeIdsByOfferState = [];
+  let groupIdByOfferState = [];
+  for (const offer of offers) {
+    const id = Number(offer.offer.id);
+    // exchangeIdsByOffer
+    let exchangeIdsByOffer = [];
+    const arraySlot = ethers.BigNumber.from(
+      getMappingStoragePosition(protocolLookupsSlotNumber.add("0"), id, paddingType.START)
+    );
+    const arrayLength = ethers.BigNumber.from(await getStorageAt(protocolDiamondAddress, arraySlot)).toNumber();
+    const arrayStart = ethers.BigNumber.from(keccak256(arraySlot));
+    for (let i = 0; i < arrayLength; i++) {
+      exchangeIdsByOffer.push(await getStorageAt(protocolDiamondAddress, arrayStart.add(i)));
+    }
+    exchangeIdsByOfferState.push(exchangeIdsByOffer);
+
+    // groupIdByOffer
+    groupIdByOfferState.push(
+      await getStorageAt(
+        protocolDiamondAddress,
+        getMappingStoragePosition(protocolLookupsSlotNumber.add("3"), id, paddingType.START)
+      )
+    );
+  }
+
+  // buyerIdByWallet, agentIdByWallet, conditionalCommitsByAddress
+  let buyerIdByWallet = [];
+  let agentIdByWallet = [];
+  let conditionalCommitsByAddress = [];
+
+  const accounts = [...sellers, ...DRs, ...agents, ...buyers];
+
+  for (const account of accounts) {
+    const accountAddress = account.wallet.address;
+
+    // buyerIdByWallet
+    buyerIdByWallet.push(
+      await getStorageAt(
+        protocolDiamondAddress,
+        getMappingStoragePosition(protocolLookupsSlotNumber.add("8"), accountAddress, paddingType.START)
+      )
+    );
+
+    // agentIdByWallet
+    agentIdByWallet.push(
+      await getStorageAt(
+        protocolDiamondAddress,
+        getMappingStoragePosition(protocolLookupsSlotNumber.add("13"), accountAddress, paddingType.START)
+      )
+    );
+
+    // conditionalCommitsByAddress
+    const firstMappingStorageSlot = ethers.BigNumber.from(
+      getMappingStoragePosition(protocolLookupsSlotNumber.add("19"), accountAddress, paddingType.START)
+    );
+    let commitsPerGroup = [];
+    for (const group of groups) {
+      const id = group.id;
+      commitsPerGroup.push(
+        await getStorageAt(
+          protocolDiamondAddress,
+          getMappingStoragePosition(firstMappingStorageSlot, id, paddingType.START)
+        )
+      );
+    }
+    conditionalCommitsByAddress.push(commitsPerGroup);
+  }
+
+  // disputeResolverFeeTokenIndex, tokenIndexByAccount, cloneAddress, voucherCount
+  let disputeResolverFeeTokenIndex = [];
+  let tokenIndexByAccount = [];
+  let cloneAddress = [];
+  let voucherCount = [];
+
+  // all account ids
+  const accountIds = accounts.map((account) => Number(account.id));
+
+  // loop over all ids even where no data is expected
+  for (const id of accountIds) {
+    // disputeResolverFeeTokenIndex
+    let firstMappingStorageSlot = ethers.BigNumber.from(
+      getMappingStoragePosition(protocolLookupsSlotNumber.add("12"), id, paddingType.START)
+    );
+    disputeResolverFeeTokenIndex.push({
+      native: await getStorageAt(
+        protocolDiamondAddress,
+        getMappingStoragePosition(firstMappingStorageSlot, ethers.constants.AddressZero, paddingType.START)
+      ),
+      mockToken: await getStorageAt(
+        protocolDiamondAddress,
+        getMappingStoragePosition(firstMappingStorageSlot, mockToken.address, paddingType.START)
+      ),
+    });
+
+    // tokenIndexByAccount
+    firstMappingStorageSlot = ethers.BigNumber.from(
+      getMappingStoragePosition(protocolLookupsSlotNumber.add("16"), id, paddingType.START)
+    );
+    tokenIndexByAccount.push({
+      native: await getStorageAt(
+        protocolDiamondAddress,
+        getMappingStoragePosition(firstMappingStorageSlot, ethers.constants.AddressZero, paddingType.START)
+      ),
+      mockToken: await getStorageAt(
+        protocolDiamondAddress,
+        getMappingStoragePosition(firstMappingStorageSlot, mockToken.address, paddingType.START)
+      ),
+    });
+
+    // cloneAddress
+    cloneAddress.push(
+      await getStorageAt(
+        protocolDiamondAddress,
+        getMappingStoragePosition(protocolLookupsSlotNumber.add("17"), id, paddingType.START)
+      )
+    );
+
+    // voucherCount
+    voucherCount.push(
+      await getStorageAt(
+        protocolDiamondAddress,
+        getMappingStoragePosition(protocolLookupsSlotNumber.add("18"), id, paddingType.START)
+      )
+    );
+  }
+
+  // twinRangesBySeller
+  let twinRangesBySeller = [];
+  for (const id of accountIds) {
+    const firstMappingStorageSlot = ethers.BigNumber.from(
+      getMappingStoragePosition(protocolLookupsSlotNumber.add("22"), id, paddingType.START)
+    );
+    let ranges = {};
+    for (let mockTwin of mockTwinTokens) {
+      ranges[mockTwin.address] = [];
+      const arraySlot = getMappingStoragePosition(firstMappingStorageSlot, mockTwin.address, paddingType.START);
+      const arrayLength = ethers.BigNumber.from(await getStorageAt(protocolDiamondAddress, arraySlot)).toNumber();
+      const arrayStart = ethers.BigNumber.from(keccak256(arraySlot));
+      for (let i = 0; i < arrayLength * 2; i = i + 2) {
+        // each BosonTypes.TokenRange has length 2
+        ranges[mockTwin.address].push({
+          start: await getStorageAt(protocolDiamondAddress, arrayStart.add(i)),
+          end: await getStorageAt(protocolDiamondAddress, arrayStart.add(i + 1)),
+        });
+      }
+    }
+    twinRangesBySeller.push(ranges);
+  }
+
+  // twinIdsByTokenAddressAndBySeller
+  let twinIdsByTokenAddressAndBySeller = [];
+  for (const id of accountIds) {
+    const firstMappingStorageSlot = ethers.BigNumber.from(
+      getMappingStoragePosition(protocolLookupsSlotNumber.add("23"), id, paddingType.START)
+    );
+    let twinIds = {};
+    for (let mockTwin of mockTwinTokens) {
+      twinIds[mockTwin.address] = [];
+      const arraySlot = getMappingStoragePosition(firstMappingStorageSlot, mockTwin.address, paddingType.START);
+      const arrayLength = ethers.BigNumber.from(await getStorageAt(protocolDiamondAddress, arraySlot)).toNumber();
+      const arrayStart = ethers.BigNumber.from(keccak256(arraySlot));
+      for (let i = 0; i < arrayLength; i++) {
+        twinIds[mockTwin.address].push(await getStorageAt(protocolDiamondAddress, arrayStart.add(i)));
+      }
+    }
+    twinIdsByTokenAddressAndBySeller.push(twinIds);
+  }
+
+  // allowedSellerIndex
+  let allowedSellerIndex = [];
+  for (const DR of DRs) {
+    const firstMappingStorageSlot = ethers.BigNumber.from(
+      getMappingStoragePosition(
+        protocolLookupsSlotNumber.add("26"),
+        ethers.BigNumber.from(DR.disputeResolver.id).toHexString(),
+        paddingType.START
+      )
+    );
+    let sellerStatus = [];
+    for (const seller of sellers) {
+      sellerStatus.push(
+        await getStorageAt(
+          protocolDiamondAddress,
+          getMappingStoragePosition(
+            firstMappingStorageSlot,
+            ethers.BigNumber.from(seller.seller.id).toHexString(),
+            paddingType.START
+          )
+        )
+      );
+    }
+    allowedSellerIndex.push(sellerStatus);
+  }
+
+  // offerIdIndexByGroup
+  let offerIdIndexByGroup = [];
+  for (const group of groups) {
+    const id = group.id;
+    const firstMappingStorageSlot = ethers.BigNumber.from(
+      getMappingStoragePosition(protocolLookupsSlotNumber.add("28"), id, paddingType.START)
+    );
+    let offerInidices = [];
+    for (const offer of offers) {
+      const id2 = Number(offer.offer.id);
+      offerInidices.push(
+        await getStorageAt(
+          protocolDiamondAddress,
+          getMappingStoragePosition(firstMappingStorageSlot, id2, paddingType.START)
+        )
+      );
+    }
+    offerIdIndexByGroup.push(offerInidices);
+  }
+
+  // pendingAddressUpdatesBySeller, pendingAuthTokenUpdatesBySeller, pendingAddressUpdatesByDisputeResolver
+  let pendingAddressUpdatesBySeller = [];
+  let pendingAuthTokenUpdatesBySeller = [];
+  let pendingAddressUpdatesByDisputeResolver = [];
+
+  // Although pending address/auth token update is not yet defined in 2.0.0, we can check that storage slots are empty
+  for (const id of accountIds) {
+    // pendingAddressUpdatesBySeller
+    let structStorageSlot = ethers.BigNumber.from(
+      getMappingStoragePosition(protocolLookupsSlotNumber.add("29"), id, paddingType.START)
+    );
+    let structFields = [];
+    for (let i = 0; i < 5; i++) {
+      // BosonTypes.Seller has 6 fields, but last bool is packed in one slot with previous field
+      structFields.push(await getStorageAt(protocolDiamondAddress, structStorageSlot.add(i)));
+    }
+    pendingAddressUpdatesBySeller.push(structFields);
+
+    // pendingAuthTokenUpdatesBySeller
+    structStorageSlot = ethers.BigNumber.from(
+      getMappingStoragePosition(protocolLookupsSlotNumber.add("30"), id, paddingType.START)
+    );
+    structFields = [];
+    for (let i = 0; i < 2; i++) {
+      // BosonTypes.AuthToken has 2 fields
+      structFields.push(await getStorageAt(protocolDiamondAddress, structStorageSlot.add(i)));
+    }
+    pendingAuthTokenUpdatesBySeller.push(structFields);
+
+    // pendingAddressUpdatesByDisputeResolver
+    structStorageSlot = ethers.BigNumber.from(
+      getMappingStoragePosition(protocolLookupsSlotNumber.add("31"), id, paddingType.START)
+    );
+    structFields = [];
+    for (let i = 0; i < 8; i++) {
+      // BosonTypes.DisputeResolver has 8 fields
+      structFields.push(await getStorageAt(protocolDiamondAddress, structStorageSlot.add(i)));
+    }
+    structFields[6] = await getStorageAt(protocolDiamondAddress, keccak256(structStorageSlot.add(6))); // represents field string metadataUri. Technically this value represents the length of the string, but since it should be 0, we don't do further decoding
+    pendingAddressUpdatesByDisputeResolver.push(structFields);
+  }
+
+  return {
+    exchangeIdsByOfferState,
+    groupIdByOfferState,
+    buyerIdByWallet,
+    disputeResolverFeeTokenIndex,
+    agentIdByWallet,
+    tokenIndexByAccount,
+    cloneAddress,
+    voucherCount,
+    conditionalCommitsByAddress,
+    twinRangesBySeller,
+    twinIdsByTokenAddressAndBySeller,
+    allowedSellerIndex,
+    offerIdIndexByGroup,
+    pendingAddressUpdatesBySeller,
+    pendingAuthTokenUpdatesBySeller,
+    pendingAddressUpdatesByDisputeResolver,
+  };
+}
+
+exports.populateProtocolContract = populateProtocolContract;
+exports.getProtocolContractState = getProtocolContractState;

--- a/test/util/upgrade.js
+++ b/test/util/upgrade.js
@@ -26,6 +26,7 @@ const { oneMonth, oneDay } = require("./constants");
 const { getInterfaceIds } = require("../../scripts/config/supported-interfaces.js");
 const { deployMockTokens } = require("../../scripts/util/deploy-mock-tokens");
 const { readContracts } = require("../../scripts/util/utils");
+const { facets } = require("../upgrade/00_config");
 
 // Common vars
 let rando;
@@ -37,7 +38,7 @@ async function deploySuite(deployer, tag) {
   shell.exec(`git checkout ${tag} contracts`);
 
   // run deploy suite, which automatically compiles the contracts
-  await hre.run("deploy-suite", { env: "upgrade-test" });
+  await hre.run("deploy-suite", { env: "upgrade-test", facetConfig: JSON.stringify(facets.deploy[tag]) });
 
   // Read contract info from file
   const chainId = (await hre.ethers.provider.getNetwork()).chainId;
@@ -123,7 +124,7 @@ async function upgradeSuite(tag, protocolDiamondAddress, upgradedInterfaces) {
 
   // compile new contracts
   await hre.run("compile");
-  await hre.run("upgrade-facets", { env: "upgrade-test" });
+  await hre.run("upgrade-facets", { env: "upgrade-test", facetConfig: JSON.stringify(facets.upgrade[tag]) });
 
   // Cast to updated interface
   let newHandlers = {};


### PR DESCRIPTION
Refactor of code in #468 

- utility functions to deploy, upgrade, populate contract, get contract data are moved to `test/util/upgrade.js`
- reorganization of test variable - script no longer relies on positional arguments to distinguish between pre- and post- upgrade state
- deploy and upgrade configs are now in `test/upgrade/00_config.js` and is no longer required to modify default configs
- generic tests were extracted out of  `test/upgrade/2.0.0-2.1.0.js` and moved into a separate file `test/upgrade/01_generic.js` (it's named that way so it will always stay on top).