### PR TITLE
Detect changed contracts

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -197,7 +197,7 @@ npx hardhat create-dispute-resolver --path "path/to/dispute_resolver.json" --net
 Script that helps you find out, which contracts were changed between two commits. This is extremely useful before doing the upgrade to make sure all facets that were changed actually get upgraded.
 
 Run script with  
-```npx hardhat detect-contract-changes referenceCommit [targetCommit]```
+```npx hardhat detect-changed-contracts referenceCommit [targetCommit]```
 
 Parameters: 
 - referenceCommit [required] - commit/tag/branch to compare to
@@ -208,7 +208,7 @@ Script prints out the list of contracts that were created, deleted or changed be
 Examples: 
 
 ```
-npx hardhat detect-contract-changes v2.1.0 v2.2.0    // get changes between two tags
-npx hardhat detect-contract-changes b4d4277          // get changes between a commit and current branch (HEAD)
-npx hardhat detect-contract-changes v2.1.0 branch-1  // get changes a tag and another branch
+npx hardhat detect-changed-contracts v2.1.0 v2.2.0    // get changes between two tags
+npx hardhat detect-changed-contracts b4d4277          // get changes between a commit and current branch (HEAD)
+npx hardhat detect-changed-contracts v2.1.0 branch-1  // get changes a tag and another branch
 ```

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -204,3 +204,11 @@ Parameters:
 - targetCommit [optional] - commit/tag/branch to compare. If not provided, it will compare to current branch.
 
 Script prints out the list of contracts that were created, deleted or changed between specified commits.
+
+Examples: 
+
+```
+npx hardhat detect-contract-changes v2.1.0 v2.2.0    // get changes between two tags
+npx hardhat detect-contract-changes b4d4277          // get changes between a commit and current branch (HEAD)
+npx hardhat detect-contract-changes v2.1.0 branch-1  // get changes a tag and another branch
+```

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -73,7 +73,8 @@ For upgrade to succeed you need an account with UPGRADER role. Refer to [Manage 
 ### Upgrade clients
 Upgrade existing clients (currently only BosonVoucher). Script deploys new implementation and updates address on beacon.  
 We provide different npm scripts for different use cases. A script for Hardhat network does not exist. Since contracts are discarded after the deployment, they cannot be upgraded.  
-For upgrade to succeed you need an account with UPGRADER role. Refer to [Manage roles](#manage-roles) to see how to grant it.
+For upgrade to succeed you need an account with UPGRADER role. Refer to [Manage roles](#manage-roles) to see how to grant it.  
+If you are not sure which contracts were changed since last deployment/upgrade, refer to [Detect changed contract](#detect-changed-contract) to see how to get the list of changed contracts.
 
 - **local network**. This upgrades the clients on a independent instance of local network (e.g. `npx hardhat node`). Upgrade process is described [here](local-development.md#upgrade-clients).  
 ```npm run upgrade-clients:local```
@@ -192,6 +193,14 @@ Example:
 npx hardhat create-dispute-resolver --path "path/to/dispute_resolver.json" --network localhost
 ```
 
+### Detect changed contract
+Script that helps you find out, which contracts were changed between two commits. This is extremely useful before doing the upgrade to make sure all facets that were changed actually get upgraded.
 
+Run script with  
+```npx hardhat detect-contract-changes referenceCommit [targetCommit]```
 
+Parameters: 
+- referenceCommit [required] - commit/tag/branch to compare to
+- targetCommit [optional] - commit/tag/branch to compare. If not provided, it will compare to current branch.
 
+Script prints out the list of contracts that were created, deleted or changed between specified commits.

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -77,6 +77,18 @@ task("manage-roles", "Grant or revoke access control roles")
     await manageRoles(env);
   });
 
+task("detect-contract-changes", "Detects which contracts have changed between two versions")
+  .addPositionalParam("referenceCommit", "Commit/tag/branch to compare to")
+  .addOptionalPositionalParam(
+    "targetCommit",
+    "Commit/tag/branch to compare. If not provided, it will compare to current branch."
+  )
+  .setAction(async ({ referenceCommit, targetCommit }) => {
+    const { detectChangedContract } = await lazyImport("./scripts/util/detect-changed-contracts.js");
+
+    await detectChangedContract(referenceCommit, targetCommit);
+  });
+
 module.exports = {
   defaultNetwork: "hardhat",
   networks: {

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -77,7 +77,7 @@ task("manage-roles", "Grant or revoke access control roles")
     await manageRoles(env);
   });
 
-task("detect-contract-changes", "Detects which contracts have changed between two versions")
+task("detect-changed-contracts", "Detects which contracts have changed between two versions")
   .addPositionalParam("referenceCommit", "Commit/tag/branch to compare to")
   .addOptionalPositionalParam(
     "targetCommit",

--- a/scripts/util/detect-changed-contracts.js
+++ b/scripts/util/detect-changed-contracts.js
@@ -16,7 +16,7 @@ Detects is contract changed between two versions
 5. Compares bytecodes. If bytecode is different, or it does not exists in either branch, it is considered changed
 
 @param {string} referenceCommit - commit/tag/branch to compare to
-@param {string} targetCommit - commit/tag/branch to compare. If not provided, it will compare to current branch
+@param {string} targetCommit - commit/tag/branch to compare. If not provided, it will compare to current branch.
 */
 async function detectChangedContract(referenceCommit, targetCommit) {
   // By default compiler adds metadata ipfs hash to the end of bytecode.
@@ -121,4 +121,4 @@ async function getBytecodes() {
   return byteCodes;
 }
 
-detectChangedContract("v2.1.0");
+exports.detectChangedContract = detectChangedContract;

--- a/scripts/util/detect-changed-contracts.js
+++ b/scripts/util/detect-changed-contracts.js
@@ -1,5 +1,6 @@
 const hre = require("hardhat");
 const shell = require("shelljs");
+const { getInterfaceIds, interfaceImplementers } = require("../config/supported-interfaces.js");
 
 const prefix = "contracts/";
 
@@ -44,6 +45,7 @@ async function detectChangedContract(referenceCommit, targetCommit) {
 
   // Get reference bytecodes
   const referenceBytecodes = await getBytecodes();
+  const referenceInterfaceIds = await getInterfaceIds();
 
   // Checkout new version
   targetCommit = targetCommit || "HEAD";
@@ -56,6 +58,7 @@ async function detectChangedContract(referenceCommit, targetCommit) {
 
   // get target bytecodes
   const targetBytecodes = await getBytecodes();
+  const targetInterfaceIds = await getInterfaceIds();
 
   // Compare bytecodes
   const referenceContractList = Object.keys(referenceBytecodes);
@@ -70,7 +73,9 @@ async function detectChangedContract(referenceCommit, targetCommit) {
   let changedContracts = [];
   for (const contract of overlappingContracts) {
     if (referenceBytecodes[contract] != targetBytecodes[contract]) {
-      changedContracts.push(contract);
+      const interfaceImplementer = interfaceImplementers[contract];
+      const interfaceChange = referenceInterfaceIds[interfaceImplementer] != targetInterfaceIds[interfaceImplementer];
+      changedContracts.push({ name: contract, interfaceChange });
     }
   }
 

--- a/scripts/util/detect-changed-contracts.js
+++ b/scripts/util/detect-changed-contracts.js
@@ -1,0 +1,124 @@
+const hre = require("hardhat");
+const shell = require("shelljs");
+
+const prefix = "contracts/";
+
+// folders to check. Folder names are relative to "contracts"
+const sources = ["diamond", "protocol/facets", "protocol/clients"];
+
+/**
+Detects is contract changed between two versions
+
+1. Checkouts the branch you want to compare to
+2  Compiles the contracts, stores bytecodes
+3. Checkouts the branch you want to compare 
+4. Compiles the contracts, stores bytecodes
+5. Compares bytecodes. If bytecode is different, or it does not exists in either branch, it is considered changed
+
+@param {string} referenceCommit - commit/tag/branch to compare to
+@param {string} targetCommit - commit/tag/branch to compare. If not provided, it will compare to current branch
+*/
+async function detectChangedContract(referenceCommit, targetCommit) {
+  // By default compiler adds metadata ipfs hash to the end of bytecode.
+  // Even if contract is not changed, the metadata hash can be different, which makes the bytecode different and hard to detect if change has happened.
+  // To make comparison clean, we remove the metadata hash from the bytecode.
+  for (const compiler of hre.config.solidity.compilers) {
+    // This setting is solidity v0.8.9 style
+    // versions >= 0.8.18 use compiler.settings["metadata"] = {appendCBOR: false}
+    compiler.settings["metadata"] = { bytecodeHash: "none" };
+  }
+
+  // Check if reference commit is provided
+  if (!referenceCommit) {
+    console.log("Please provide a reference commit");
+    process.exit(1);
+  }
+
+  // Checkout old version
+  console.log(`Checking out version ${referenceCommit}`);
+  shell.exec(`git checkout ${referenceCommit} contracts`);
+
+  // Compile old version
+  await hre.run("clean");
+  await hre.run("compile");
+
+  // Get reference bytecodes
+  const referenceBytecodes = await getBytecodes();
+
+  // Checkout new version
+  targetCommit = targetCommit || "HEAD";
+  console.log(`Checking out version ${targetCommit}`);
+  shell.exec(`git checkout ${targetCommit} contracts`);
+
+  // Compile new version
+  await hre.run("clean");
+  await hre.run("compile");
+
+  // get target bytecodes
+  const targetBytecodes = await getBytecodes();
+
+  // Compare bytecodes
+  const referenceContractList = Object.keys(referenceBytecodes);
+  const targetContractList = Object.keys(targetBytecodes);
+
+  const overlappingContracts = referenceContractList.filter((contract) => targetContractList.includes(contract));
+  const removedContracts = referenceContractList.filter((contract) => !overlappingContracts.includes(contract));
+  const newContracts = targetContractList.filter((contract) => !overlappingContracts.includes(contract));
+
+  // Removed and new contracts are considered changed by default
+  // Overlapping contracts are only considered changed if the bytecode is different
+  let changedContracts = [];
+  for (const contract of overlappingContracts) {
+    if (referenceBytecodes[contract] != targetBytecodes[contract]) {
+      changedContracts.push(contract);
+    }
+  }
+
+  // Print results
+  if (removedContracts.length > 0) {
+    console.log("REMOVED CONTRACTS");
+    console.table(removedContracts);
+  }
+
+  if (newContracts.length > 0) {
+    console.log("NEW CONTRACTS");
+    console.table(newContracts);
+  }
+
+  if (changedContracts.length > 0) {
+    console.log("CHANGED CONTRACTS");
+    console.table(changedContracts);
+  }
+
+  console.log(`Total removed contracts: ${removedContracts.length}`);
+  console.log(`Total new contracts: ${newContracts.length}`);
+  console.log(`Total changed contracts: ${changedContracts.length}`);
+
+  // Checkout back to original branch
+  shell.exec(`git checkout HEAD contracts`);
+}
+
+async function getBytecodes() {
+  // Get build info
+  const contractNames = await hre.artifacts.getAllFullyQualifiedNames();
+
+  let byteCodes = {};
+  for (let contractName of contractNames) {
+    const [source, name] = contractName.split(":");
+
+    // Skip contracts that are not in the source folders
+    if (!sources.some((s) => source.startsWith(`${prefix}${s}`))) continue;
+
+    // Abstract contracts do not have bytecode, and factory creation fails. Skip them.
+    try {
+      const contract = await hre.ethers.getContractFactory(name);
+
+      // Store the bytecode
+      byteCodes[name] = contract.bytecode;
+    } catch {}
+  }
+
+  return byteCodes;
+}
+
+detectChangedContract("v2.1.0");


### PR DESCRIPTION
Utility script that prints out which contracts changed between two commits.
Especially useful for upgrade preparation.

Allows comparison of tags/commits/branches (any combination).