### PR TITLE
Rename ProcolInitializationFacet to ProtocolInitializationHandlerFacet

### DIFF
--- a/contracts/mock/MockProtocolInitializationFacet.sol
+++ b/contracts/mock/MockProtocolInitializationFacet.sol
@@ -7,7 +7,7 @@ pragma solidity 0.8.9;
  * @notice Simulates state of the protocol in tests before v2.1.0.
  *
  */
-contract MockProtocolInitializationFacet {
+contract MockProtocolInitializationHandlerFacet {
     /**
      * @notice No-op function to simulate state of the protocol in tests before v 2.1.0., but still compatible with new deploy script.
      */

--- a/contracts/protocol/facets/ProtocolInitializationHandlerFacet.sol
+++ b/contracts/protocol/facets/ProtocolInitializationHandlerFacet.sol
@@ -13,7 +13,7 @@ import { DiamondLib } from "../../diamond/DiamondLib.sol";
  * @notice Handle initializion of new versions after 2.1.0.
  *
  */
-contract ProtocolInitializationFacet is IBosonProtocolInitializationHandler, ProtocolBase {
+contract ProtocolInitializationHandlerFacet is IBosonProtocolInitializationHandler, ProtocolBase {
     /**
      * @notice Modifier to protect initializer function from being invoked twice for a given version.
      */

--- a/scripts/config/facet-deploy.js
+++ b/scripts/config/facet-deploy.js
@@ -53,7 +53,7 @@ const noArgFacetNames = [
   "OrchestrationHandlerFacet2",
   "TwinHandlerFacet",
   "PauseHandlerFacet",
-  "ProtocolInitializationFacet", // args are generated on cutDiamond function
+  "ProtocolInitializationHandlerFacet", // args are generated on cutDiamond function
 ];
 
 async function getFacets(config) {

--- a/scripts/config/facet-upgrade.js
+++ b/scripts/config/facet-upgrade.js
@@ -6,10 +6,10 @@
  * - skipSelectors:  mapping "facetName":"listOfFunctionsToBeSkipped". With this you can specify functions that will be ignored during the update.
  *          You don't have to specify "initialize()" since it's ignored by default.
  *          Skip does not apply to facets that are completely removed.
- * - facetsToInit: list of facets that will be initialized on ProtocolInitializationFacet. 
+ * - facetsToInit: list of facets that will be initialized on ProtocolInitializationHandlerFacet. 
  *                 if facet initializer expects arguments, provide them here. For no-arg initializers pass an empty array.
- *                 You don't have to provide ProtocolInitializationFacet args here because they are generated on cut function.
- * - initializationData: ABI encoded data that is initialized directly on ProtocolInitializationFacet and not on any other facet, using versions specific init function.
+ *                 You don't have to provide ProtocolInitializationHandlerFacet args here because they are generated on cut function.
+ * - initializationData: ABI encoded data that is initialized directly on ProtocolInitializationHandlerFacet and not on any other facet, using versions specific init function.
  * 
  * Example:
     {

--- a/scripts/config/supported-interfaces.js
+++ b/scripts/config/supported-interfaces.js
@@ -46,7 +46,7 @@ const interfaceImplementers = {
   DiamondCutFacet: "IDiamondCut",
   ERC165Facet: "IERC165Extended",
   ConfigHandlerFacet: "IBosonConfigHandler",
-  ProtocolInitializationFacet: "IBosonProtocolInitializationHandler",
+  ProtocolInitializationHandlerFacet: "IBosonProtocolInitializationHandler",
 };
 
 // manually add the interfaces that currently cannot be calculated

--- a/scripts/upgrade-facets.js
+++ b/scripts/upgrade-facets.js
@@ -150,7 +150,7 @@ async function main(env, facetConfig) {
     const selectors = getSelectors(newFacet.contract, true);
     let newSelectors = selectors.selectors;
 
-    if (newFacet.name !== "ProtocolInitializationFacet") {
+    if (newFacet.name !== "ProtocolInitializationHandlerFacet") {
       // Initialization data for facets with no-arg initializers
       const noArgInitFunction = "initialize()";
       const noArgInitInterface = new ethers.utils.Interface([`function ${noArgInitFunction}`]);
@@ -285,7 +285,7 @@ async function main(env, facetConfig) {
     }
   }
 
-  // Get ProtocolInitializationFacet from deployedFacets when added/replaced in this upgrade or get it from contracts if already deployed
+  // Get ProtocolInitializationHandlerFacet from deployedFacets when added/replaced in this upgrade or get it from contracts if already deployed
   let protocolInitializationFacet = await getInitializationFacet(deployedFacets, contracts);
   const facetsToInit = deployedFacets.filter((facet) => facet.initialize) ?? [];
   const initializeCalldata = getInitializeCalldata(
@@ -328,8 +328,8 @@ async function main(env, facetConfig) {
 
   console.log(divider);
 
-  // Cast diamond to ProtocolInitializationFacet
-  protocolInitializationFacet = await ethers.getContractAt("ProtocolInitializationFacet", protocolAddress);
+  // Cast diamond to ProtocolInitializationHandlerFacet
+  protocolInitializationFacet = await ethers.getContractAt("ProtocolInitializationHandlerFacet", protocolAddress);
   const newVersion = await protocolInitializationFacet.getVersion();
   console.log(`\n📋 New version: ${newVersion}`);
 
@@ -358,7 +358,7 @@ async function getUserResponse(question, validResponses) {
 const getInitializationFacet = async (deployedFacets, contracts) => {
   let protocolInitializationFacet;
 
-  const protocolInitializationName = "ProtocolInitializationFacet";
+  const protocolInitializationName = "ProtocolInitializationHandlerFacet";
   const protocolInitializationDeployed = deployedFacets.find((f) => f.name == protocolInitializationName);
 
   if (protocolInitializationDeployed) {
@@ -371,7 +371,7 @@ const getInitializationFacet = async (deployedFacets, contracts) => {
   }
 
   if (!protocolInitializationFacet) {
-    console.error("Could not find ProtocolInitializationFacet");
+    console.error("Could not find ProtocolInitializationHandlerFacet");
     process.exit(1);
   }
 

--- a/scripts/util/deploy-protocol-handler-facets.js
+++ b/scripts/util/deploy-protocol-handler-facets.js
@@ -33,7 +33,7 @@ async function deployAndCutFacets(
   const facetsToInit = deployedFacets.filter((facet) => facet.initialize) ?? [];
 
   initializationFacet =
-    initializationFacet || deployedFacets.find((f) => f.name == "ProtocolInitializationFacet").contract;
+    initializationFacet || deployedFacets.find((f) => f.name == "ProtocolInitializationHandlerFacet").contract;
 
   const initializeCalldata = getInitializeCalldata(
     facetsToInit,
@@ -47,7 +47,7 @@ async function deployAndCutFacets(
 
   deployedFacets = deployedFacets.map((facet) => {
     const cut =
-      facet.name == "ProtocolInitializationFacet"
+      facet.name == "ProtocolInitializationHandlerFacet"
         ? getFacetAddCut(facet.contract, [initializeCalldata.slice(0, 10)])
         : getFacetAddCut(facet.contract, [facet.initialize && facet.initialize.slice(0, 10)] || []);
     facet.cut.push(cut);
@@ -91,7 +91,7 @@ async function deployProtocolFacets(facetNames, facetsToInit, maxPriorityFeePerG
       cut: [],
     };
 
-    if (facetsToInit[facetName] && facetName !== "ProtocolInitializationFacet") {
+    if (facetsToInit[facetName] && facetName !== "ProtocolInitializationHandlerFacet") {
       const calldata = facetContract.interface.encodeFunctionData(
         "initialize",
         facetsToInit[facetName].length && facetsToInit[facetName]

--- a/scripts/util/diamond-utils.js
+++ b/scripts/util/diamond-utils.js
@@ -136,7 +136,7 @@ async function getStateModifyingFunctionsHashes(facetNames, omitFunctions = []) 
   return smf.map((smf) => keccak256(toUtf8Bytes(smf)));
 }
 
-// Get ProtocolInitializationFacet initialize calldata to be called on diamondCut
+// Get ProtocolInitializationHandlerFacet initialize calldata to be called on diamondCut
 function getInitializeCalldata(
   facetsToInitialize,
   version,

--- a/scripts/util/estimate-limits.js
+++ b/scripts/util/estimate-limits.js
@@ -915,7 +915,7 @@ async function setupCommonEnvironment() {
     "OfferHandlerFacet",
     "SellerHandlerFacet",
     "TwinHandlerFacet",
-    "ProtocolInitializationFacet",
+    "ProtocolInitializationHandlerFacet",
     "ConfigHandlerFacet",
   ];
 

--- a/test/example/SnapshotGateTest.js
+++ b/test/example/SnapshotGateTest.js
@@ -151,7 +151,7 @@ describe("SnapshotGate", function () {
       "ExchangeHandlerFacet",
       "OfferHandlerFacet",
       "GroupHandlerFacet",
-      "ProtocolInitializationFacet",
+      "ProtocolInitializationHandlerFacet",
       "ConfigHandlerFacet",
     ];
 

--- a/test/integration/01-update-account-roles-addresses.js
+++ b/test/integration/01-update-account-roles-addresses.js
@@ -124,7 +124,7 @@ describe("[@skip-on-coverage] Update account roles addresses", function () {
       "ExchangeHandlerFacet",
       "FundsHandlerFacet",
       "DisputeHandlerFacet",
-      "ProtocolInitializationFacet",
+      "ProtocolInitializationHandlerFacet",
       "ConfigHandlerFacet",
     ];
 

--- a/test/integration/02-Upgraded-facet.js
+++ b/test/integration/02-Upgraded-facet.js
@@ -148,7 +148,7 @@ describe("[@skip-on-coverage] After facet upgrade, everything is still operation
       "OfferHandlerFacet",
       "FundsHandlerFacet",
       "DisputeHandlerFacet",
-      "ProtocolInitializationFacet",
+      "ProtocolInitializationHandlerFacet",
       "ConfigHandlerFacet",
     ];
 

--- a/test/integration/03-DR-removes-the-seller-from-allowed-list.js
+++ b/test/integration/03-DR-removes-the-seller-from-allowed-list.js
@@ -125,7 +125,7 @@ describe("[@skip-on-coverage] DR removes sellers from the approved seller list",
       "OfferHandlerFacet",
       "FundsHandlerFacet",
       "DisputeHandlerFacet",
-      "ProtocolInitializationFacet",
+      "ProtocolInitializationHandlerFacet",
       "ConfigHandlerFacet",
     ];
 

--- a/test/integration/04-DR-removes-fees.js
+++ b/test/integration/04-DR-removes-fees.js
@@ -123,7 +123,7 @@ describe("[@skip-on-coverage] DR removes fee", function () {
       "ExchangeHandlerFacet",
       "FundsHandlerFacet",
       "DisputeHandlerFacet",
-      "ProtocolInitializationFacet",
+      "ProtocolInitializationHandlerFacet",
       "ConfigHandlerFacet",
     ];
 

--- a/test/protocol/AccountHandlerTest.js
+++ b/test/protocol/AccountHandlerTest.js
@@ -115,7 +115,7 @@ describe("IBosonAccountHandler", function () {
       "BuyerHandlerFacet",
       "DisputeResolverHandlerFacet",
       "AgentHandlerFacet",
-      "ProtocolInitializationFacet",
+      "ProtocolInitializationHandlerFacet",
       "ConfigHandlerFacet",
     ];
 

--- a/test/protocol/AgentHandlerTest.js
+++ b/test/protocol/AgentHandlerTest.js
@@ -91,7 +91,7 @@ describe("AgentHandler", function () {
       "AccountHandlerFacet",
       "AgentHandlerFacet",
       "PauseHandlerFacet",
-      "ProtocolInitializationFacet",
+      "ProtocolInitializationHandlerFacet",
       "ConfigHandlerFacet",
     ];
 

--- a/test/protocol/BundleHandlerTest.js
+++ b/test/protocol/BundleHandlerTest.js
@@ -166,7 +166,7 @@ describe("IBosonBundleHandler", function () {
       "ExchangeHandlerFacet",
       "FundsHandlerFacet",
       "PauseHandlerFacet",
-      "ProtocolInitializationFacet",
+      "ProtocolInitializationHandlerFacet",
       "ConfigHandlerFacet",
     ];
 

--- a/test/protocol/BuyerHandlerTest.js
+++ b/test/protocol/BuyerHandlerTest.js
@@ -128,7 +128,7 @@ describe("BuyerHandler", function () {
       "OfferHandlerFacet",
       "FundsHandlerFacet",
       "PauseHandlerFacet",
-      "ProtocolInitializationFacet",
+      "ProtocolInitializationHandlerFacet",
       "ConfigHandlerFacet",
     ];
 

--- a/test/protocol/ConfigHandlerTest.js
+++ b/test/protocol/ConfigHandlerTest.js
@@ -123,7 +123,7 @@ describe("IBosonConfigHandler", function () {
           },
         ];
 
-        const facetNames = ["ProtocolInitializationFacet", "ConfigHandlerFacet"];
+        const facetNames = ["ProtocolInitializationHandlerFacet", "ConfigHandlerFacet"];
 
         const facetsToDeploy = await getFacetsWithArgs(facetNames, protocolConfig);
 
@@ -257,7 +257,7 @@ describe("IBosonConfigHandler", function () {
           buyerEscalationDepositPercentage,
         },
       ];
-      const facetNames = ["ProtocolInitializationFacet", "ConfigHandlerFacet"];
+      const facetNames = ["ProtocolInitializationHandlerFacet", "ConfigHandlerFacet"];
 
       const facetsToDeploy = await getFacetsWithArgs(facetNames, protocolConfig);
 

--- a/test/protocol/DisputeHandlerTest.js
+++ b/test/protocol/DisputeHandlerTest.js
@@ -173,7 +173,7 @@ describe("IBosonDisputeHandler", function () {
       "FundsHandlerFacet",
       "DisputeHandlerFacet",
       "PauseHandlerFacet",
-      "ProtocolInitializationFacet",
+      "ProtocolInitializationHandlerFacet",
       "ConfigHandlerFacet",
     ];
 

--- a/test/protocol/DisputeResolverHandlerTest.js
+++ b/test/protocol/DisputeResolverHandlerTest.js
@@ -194,7 +194,7 @@ describe("DisputeResolverHandler", function () {
       "SellerHandlerFacet",
       "DisputeResolverHandlerFacet",
       "PauseHandlerFacet",
-      "ProtocolInitializationFacet",
+      "ProtocolInitializationHandlerFacet",
       "ConfigHandlerFacet",
     ];
 

--- a/test/protocol/ExchangeHandlerTest.js
+++ b/test/protocol/ExchangeHandlerTest.js
@@ -214,7 +214,7 @@ describe("IBosonExchangeHandler", function () {
       "BundleHandlerFacet",
       "GroupHandlerFacet",
       "PauseHandlerFacet",
-      "ProtocolInitializationFacet",
+      "ProtocolInitializationHandlerFacet",
       "ConfigHandlerFacet",
     ];
 

--- a/test/protocol/FundsHandlerTest.js
+++ b/test/protocol/FundsHandlerTest.js
@@ -187,7 +187,7 @@ describe("IBosonFundsHandler", function () {
       "OfferHandlerFacet",
       "PauseHandlerFacet",
       "AccountHandlerFacet",
-      "ProtocolInitializationFacet",
+      "ProtocolInitializationHandlerFacet",
       "ConfigHandlerFacet",
     ];
 
@@ -195,7 +195,7 @@ describe("IBosonFundsHandler", function () {
 
     // Cut the protocol handler facets into the Diamond
     const { deployedFacets } = await deployAndCutFacets(protocolDiamond.address, facetsToDeploy, maxPriorityFeePerGas);
-    protocolInitializationFacet = deployedFacets.find((f) => f.name === "ProtocolInitializationFacet").contract;
+    protocolInitializationFacet = deployedFacets.find((f) => f.name === "ProtocolInitializationHandlerFacet").contract;
 
     // Cast Diamond to IERC165
     erc165 = await ethers.getContractAt("ERC165Facet", protocolDiamond.address);
@@ -870,7 +870,7 @@ describe("IBosonFundsHandler", function () {
           });
 
           it("Withdraw when dispute is retracted, it emits a FundsWithdrawn event", async function () {
-            // ProtocolInitializationFacet has to be passed to deploy function works
+            // ProtocolInitializationHandlerFacet has to be passed to deploy function works
             const facetsToDeploy = await getFacetsWithArgs(["DisputeHandlerFacet"]);
 
             await deployAndCutFacets(
@@ -2679,7 +2679,7 @@ describe("IBosonFundsHandler", function () {
 
       context("Final state DISPUTED", async function () {
         beforeEach(async function () {
-          // ProtocolInitializationFacet has to be passed to deploy function works
+          // ProtocolInitializationHandlerFacet has to be passed to deploy function works
           const facetsToDeploy = await getFacetsWithArgs(["DisputeHandlerFacet"]);
 
           await deployAndCutFacets(

--- a/test/protocol/GroupHandlerTest.js
+++ b/test/protocol/GroupHandlerTest.js
@@ -141,7 +141,7 @@ describe("IBosonGroupHandler", function () {
       "OfferHandlerFacet",
       "GroupHandlerFacet",
       "PauseHandlerFacet",
-      "ProtocolInitializationFacet",
+      "ProtocolInitializationHandlerFacet",
       "ConfigHandlerFacet",
     ];
 

--- a/test/protocol/MetaTransactionsHandlerTest.js
+++ b/test/protocol/MetaTransactionsHandlerTest.js
@@ -196,7 +196,7 @@ describe("IBosonMetaTransactionsHandler", function () {
       "PauseHandlerFacet",
       "BuyerHandlerFacet",
       "MetaTransactionsHandlerFacet",
-      "ProtocolInitializationFacet",
+      "ProtocolInitializationHandlerFacet",
       "ConfigHandlerFacet",
     ];
 

--- a/test/protocol/OfferHandlerTest.js
+++ b/test/protocol/OfferHandlerTest.js
@@ -183,7 +183,7 @@ describe("IBosonOfferHandler", function () {
       "DisputeResolverHandlerFacet",
       "OfferHandlerFacet",
       "PauseHandlerFacet",
-      "ProtocolInitializationFacet",
+      "ProtocolInitializationHandlerFacet",
       "ConfigHandlerFacet",
       "FundsHandlerFacet",
       "ExchangeHandlerFacet",

--- a/test/protocol/OrchestrationHandlerTest.js
+++ b/test/protocol/OrchestrationHandlerTest.js
@@ -219,7 +219,7 @@ describe("IBosonOrchestrationHandler", function () {
       "OrchestrationHandlerFacet2",
       "PauseHandlerFacet",
       "AccountHandlerFacet",
-      "ProtocolInitializationFacet",
+      "ProtocolInitializationHandlerFacet",
       "ConfigHandlerFacet",
     ];
 

--- a/test/protocol/PauseHandlerTest.js
+++ b/test/protocol/PauseHandlerTest.js
@@ -43,7 +43,7 @@ describe("IBosonPauseHandler", function () {
     // Temporarily grant PAUSER role to pauser account
     await accessController.grantRole(Role.PAUSER, pauser.address);
 
-    const facetNames = ["PauseHandlerFacet", "ProtocolInitializationFacet"];
+    const facetNames = ["PauseHandlerFacet", "ProtocolInitializationHandlerFacet"];
 
     const facetsToDeploy = await getFacetsWithArgs(facetNames);
 

--- a/test/protocol/ProtocolInitializationHandlerTest.js
+++ b/test/protocol/ProtocolInitializationHandlerTest.js
@@ -46,8 +46,11 @@ describe("ProtocolInitializationHandler", async function () {
     // Cast Diamond to DiamondCutFacet
     diamondCutFacet = await ethers.getContractAt("DiamondCutFacet", protocolDiamond.address);
 
-    // Cast Diamond to ProtocolInitializationFacet
-    protocolInitializationFacet = await ethers.getContractAt("ProtocolInitializationFacet", protocolDiamond.address);
+    // Cast Diamond to ProtocolInitializationHandlerFacet
+    protocolInitializationFacet = await ethers.getContractAt(
+      "ProtocolInitializationHandlerFacet",
+      protocolDiamond.address
+    );
 
     version = "2.2.0";
 
@@ -61,7 +64,7 @@ describe("ProtocolInitializationHandler", async function () {
       it("Should initialize version 2.2.0 and emit ProtocolInitialized", async function () {
         const { cutTransaction } = await deployAndCutFacets(
           protocolDiamond.address,
-          { ProtocolInitializationFacet: [] },
+          { ProtocolInitializationHandlerFacet: [] },
           maxPriorityFeePerGas
         );
 
@@ -72,7 +75,9 @@ describe("ProtocolInitializationHandler", async function () {
         let protocolInitializationFacetDeployed;
 
         beforeEach(async function () {
-          const ProtocolInitilizationContractFactory = await ethers.getContractFactory("ProtocolInitializationFacet");
+          const ProtocolInitilizationContractFactory = await ethers.getContractFactory(
+            "ProtocolInitializationHandlerFacet"
+          );
           protocolInitializationFacetDeployed = await ProtocolInitilizationContractFactory.deploy(
             await getFees(maxPriorityFeePerGas)
           );
@@ -182,21 +187,21 @@ describe("ProtocolInitializationHandler", async function () {
   });
 
   describe("After deploy tests", async function () {
-    let deployedProtocolInitializationFacet;
+    let deployedProtocolInitializationHandlerFacet;
     beforeEach(async function () {
       version = "2.2.0";
 
-      const interfaceId = InterfaceIds[interfaceImplementers["ProtocolInitializationFacet"]];
+      const interfaceId = InterfaceIds[interfaceImplementers["ProtocolInitializationHandlerFacet"]];
 
       const { deployedFacets } = await deployAndCutFacets(
         protocolDiamond.address,
-        { ProtocolInitializationFacet: [version, [], [], true] },
+        { ProtocolInitializationHandlerFacet: [version, [], [], true] },
         maxPriorityFeePerGas,
         version,
         undefined,
         [interfaceId]
       );
-      deployedProtocolInitializationFacet = deployedFacets[0];
+      deployedProtocolInitializationHandlerFacet = deployedFacets[0];
     });
 
     // Interface support (ERC-156 provided by ProtocolDiamond, others by deployed facets)
@@ -217,7 +222,7 @@ describe("ProtocolInitializationHandler", async function () {
 
         version = ethers.utils.formatBytes32String("2.3.0");
         const calldataProtocolInitialization =
-          deployedProtocolInitializationFacet.contract.interface.encodeFunctionData("initialize", [
+          deployedProtocolInitializationHandlerFacet.contract.interface.encodeFunctionData("initialize", [
             version,
             [],
             [],
@@ -229,7 +234,7 @@ describe("ProtocolInitializationHandler", async function () {
 
         await diamondCutFacet.diamondCut(
           [],
-          deployedProtocolInitializationFacet.contract.address,
+          deployedProtocolInitializationHandlerFacet.contract.address,
           calldataProtocolInitialization,
           await getFees(maxPriorityFeePerGas)
         );
@@ -258,16 +263,22 @@ describe("ProtocolInitializationHandler", async function () {
       const calldataTestFacet = testFacet.interface.encodeFunctionData("initialize", [rando.address]);
 
       version = ethers.utils.formatBytes32String("2.3.0");
-      const calldataProtocolInitialization = deployedProtocolInitializationFacet.contract.interface.encodeFunctionData(
-        "initialize",
-        [version, [testFacet.address], [calldataTestFacet], true, "0x", [], []]
-      );
+      const calldataProtocolInitialization =
+        deployedProtocolInitializationHandlerFacet.contract.interface.encodeFunctionData("initialize", [
+          version,
+          [testFacet.address],
+          [calldataTestFacet],
+          true,
+          "0x",
+          [],
+          [],
+        ]);
 
       const facetCuts = [getFacetAddCut(testFacet)];
 
       await diamondCutFacet.diamondCut(
         facetCuts,
-        deployedProtocolInitializationFacet.contract.address,
+        deployedProtocolInitializationHandlerFacet.contract.address,
         calldataProtocolInitialization,
         await getFees(maxPriorityFeePerGas)
       );
@@ -292,7 +303,7 @@ describe("ProtocolInitializationHandler", async function () {
         const calldataTestFacet = testFacet.interface.encodeFunctionData("initialize", [testFacet.address]);
 
         const calldataProtocolInitialization =
-          deployedProtocolInitializationFacet.contract.interface.encodeFunctionData("initialize", [
+          deployedProtocolInitializationHandlerFacet.contract.interface.encodeFunctionData("initialize", [
             version,
             [testFacet.address],
             [calldataTestFacet],
@@ -307,7 +318,7 @@ describe("ProtocolInitializationHandler", async function () {
         await expect(
           diamondCutFacet.diamondCut(
             facetCuts,
-            deployedProtocolInitializationFacet.contract.address,
+            deployedProtocolInitializationHandlerFacet.contract.address,
             calldataProtocolInitialization,
             await getFees(maxPriorityFeePerGas)
           )
@@ -320,7 +331,7 @@ describe("ProtocolInitializationHandler", async function () {
         const calldataTestFacet = testFacet.interface.encodeFunctionData("initialize", [deployer.address]);
 
         const calldataProtocolInitialization =
-          deployedProtocolInitializationFacet.contract.interface.encodeFunctionData("initialize", [
+          deployedProtocolInitializationHandlerFacet.contract.interface.encodeFunctionData("initialize", [
             version,
             [testFacet.address],
             [calldataTestFacet],
@@ -335,7 +346,7 @@ describe("ProtocolInitializationHandler", async function () {
         await expect(
           diamondCutFacet.diamondCut(
             facetCuts,
-            deployedProtocolInitializationFacet.contract.address,
+            deployedProtocolInitializationHandlerFacet.contract.address,
             calldataProtocolInitialization,
             await getFees(maxPriorityFeePerGas)
           )
@@ -345,7 +356,7 @@ describe("ProtocolInitializationHandler", async function () {
   });
 
   describe("initV2_2_0", async function () {
-    let deployedProtocolInitializationFacet;
+    let deployedProtocolInitializationHandlerFacet;
     let configHandler;
     let facetCut;
 
@@ -353,7 +364,9 @@ describe("ProtocolInitializationHandler", async function () {
       version = "2.1.0";
 
       // Deploy mock protocol initialization facet which simulates state before v2.2.0
-      const ProtocolInitilizationContractFactory = await ethers.getContractFactory("MockProtocolInitializationFacet");
+      const ProtocolInitilizationContractFactory = await ethers.getContractFactory(
+        "MockProtocolInitializationHandlerFacet"
+      );
       const mockInitializationFacetDeployed = await ProtocolInitilizationContractFactory.deploy(
         await getFees(maxPriorityFeePerGas)
       );
@@ -383,11 +396,12 @@ describe("ProtocolInitializationHandler", async function () {
       );
 
       // Deploy v2.2.0 facets
-      [{ contract: deployedProtocolInitializationFacet }, { contract: configHandler }] = await deployProtocolFacets(
-        ["ProtocolInitializationFacet", "ConfigHandlerFacet"],
-        {},
-        await getFees(maxPriorityFeePerGas)
-      );
+      [{ contract: deployedProtocolInitializationHandlerFacet }, { contract: configHandler }] =
+        await deployProtocolFacets(
+          ["ProtocolInitializationHandlerFacet", "ConfigHandlerFacet"],
+          {},
+          await getFees(maxPriorityFeePerGas)
+        );
 
       version = ethers.utils.formatBytes32String("2.2.0");
 
@@ -397,7 +411,7 @@ describe("ProtocolInitializationHandler", async function () {
     });
 
     it("Should emit MaxPremintedVouchersChanged event", async function () {
-      const calldataProtocolInitialization = deployedProtocolInitializationFacet.interface.encodeFunctionData(
+      const calldataProtocolInitialization = deployedProtocolInitializationHandlerFacet.interface.encodeFunctionData(
         "initialize",
         [version, [], [], true, initializationData, [], []]
       );
@@ -406,7 +420,7 @@ describe("ProtocolInitializationHandler", async function () {
       await expect(
         diamondCutFacet.diamondCut(
           [facetCut],
-          deployedProtocolInitializationFacet.address,
+          deployedProtocolInitializationHandlerFacet.address,
           calldataProtocolInitialization,
           await getFees(maxPriorityFeePerGas)
         )
@@ -416,7 +430,7 @@ describe("ProtocolInitializationHandler", async function () {
     });
 
     it("Should update state", async function () {
-      const calldataProtocolInitialization = deployedProtocolInitializationFacet.interface.encodeFunctionData(
+      const calldataProtocolInitialization = deployedProtocolInitializationHandlerFacet.interface.encodeFunctionData(
         "initialize",
         [version, [], [], true, initializationData, [], []]
       );
@@ -424,7 +438,7 @@ describe("ProtocolInitializationHandler", async function () {
       // Make the cut, check the event
       await diamondCutFacet.diamondCut(
         [facetCut],
-        deployedProtocolInitializationFacet.address,
+        deployedProtocolInitializationHandlerFacet.address,
         calldataProtocolInitialization,
         await getFees(maxPriorityFeePerGas)
       );
@@ -439,7 +453,7 @@ describe("ProtocolInitializationHandler", async function () {
         maxPremintedVouchers = "0";
         initializationData = ethers.utils.defaultAbiCoder.encode(["uint256"], [maxPremintedVouchers]);
 
-        const calldataProtocolInitialization = deployedProtocolInitializationFacet.interface.encodeFunctionData(
+        const calldataProtocolInitialization = deployedProtocolInitializationHandlerFacet.interface.encodeFunctionData(
           "initialize",
           [version, [], [], true, initializationData, [], []]
         );
@@ -448,7 +462,7 @@ describe("ProtocolInitializationHandler", async function () {
         await expect(
           diamondCutFacet.diamondCut(
             [facetCut],
-            deployedProtocolInitializationFacet.address,
+            deployedProtocolInitializationHandlerFacet.address,
             calldataProtocolInitialization,
             await getFees(maxPriorityFeePerGas)
           )
@@ -458,12 +472,12 @@ describe("ProtocolInitializationHandler", async function () {
       it("Current version is not 0", async () => {
         // Deploy higher version
         version = "2.3.0";
-        const interfaceId = InterfaceIds[interfaceImplementers["ProtocolInitializationFacet"]];
+        const interfaceId = InterfaceIds[interfaceImplementers["ProtocolInitializationHandlerFacet"]];
         const {
-          deployedFacets: [{ contract: deployedProtocolInitializationFacet }],
+          deployedFacets: [{ contract: deployedProtocolInitializationHandlerFacet }],
         } = await deployAndCutFacets(
           protocolDiamond.address,
-          { ProtocolInitializationFacet: [version, [], [], true] },
+          { ProtocolInitializationHandlerFacet: [version, [], [], true] },
           maxPriorityFeePerGas,
           version,
           undefined,
@@ -472,7 +486,7 @@ describe("ProtocolInitializationHandler", async function () {
 
         // Prepare 2.2.0 deployment
         version = ethers.utils.formatBytes32String("2.2.0");
-        const calldataProtocolInitialization = deployedProtocolInitializationFacet.interface.encodeFunctionData(
+        const calldataProtocolInitialization = deployedProtocolInitializationHandlerFacet.interface.encodeFunctionData(
           "initialize",
           [version, [], [], true, initializationData, [], []]
         );
@@ -481,7 +495,7 @@ describe("ProtocolInitializationHandler", async function () {
         await expect(
           diamondCutFacet.diamondCut(
             [facetCut],
-            deployedProtocolInitializationFacet.address,
+            deployedProtocolInitializationHandlerFacet.address,
             calldataProtocolInitialization,
             await getFees(maxPriorityFeePerGas)
           )

--- a/test/protocol/SellerHandlerTest.js
+++ b/test/protocol/SellerHandlerTest.js
@@ -148,7 +148,7 @@ describe("SellerHandler", function () {
       "ExchangeHandlerFacet",
       "OfferHandlerFacet",
       "PauseHandlerFacet",
-      "ProtocolInitializationFacet",
+      "ProtocolInitializationHandlerFacet",
       "ConfigHandlerFacet",
     ];
 

--- a/test/protocol/TwinHandlerTest.js
+++ b/test/protocol/TwinHandlerTest.js
@@ -130,7 +130,7 @@ describe("IBosonTwinHandler", function () {
       "OfferHandlerFacet",
       "DisputeResolverHandlerFacet",
       "PauseHandlerFacet",
-      "ProtocolInitializationFacet",
+      "ProtocolInitializationHandlerFacet",
       "ConfigHandlerFacet",
     ];
 

--- a/test/protocol/clients/BosonVoucherTest.js
+++ b/test/protocol/clients/BosonVoucherTest.js
@@ -140,7 +140,7 @@ describe("IBosonVoucher", function () {
       "SellerHandlerFacet",
       "DisputeResolverHandlerFacet",
       "FundsHandlerFacet",
-      "ProtocolInitializationFacet",
+      "ProtocolInitializationHandlerFacet",
       "ConfigHandlerFacet",
     ];
 

--- a/test/protocol/clients/ClientExternalAddressesTest.js
+++ b/test/protocol/clients/ClientExternalAddressesTest.js
@@ -75,7 +75,7 @@ describe("IClientExternalAddresses", function () {
       },
     ];
 
-    const facetNames = ["ConfigHandlerFacet", "ProtocolInitializationFacet"];
+    const facetNames = ["ConfigHandlerFacet", "ProtocolInitializationHandlerFacet"];
 
     const facetsToDeploy = await getFacetsWithArgs(facetNames, protocolConfig);
 


### PR DESCRIPTION
This PR renames ProcolInitializationFacet to ProtocolInitializationHandlerFacet on contracts and javascript files