### PR TITLE
fix: getInterfaceNames so that it works in core-components

### DIFF
--- a/scripts/config/supported-interfaces.js
+++ b/scripts/config/supported-interfaces.js
@@ -69,7 +69,10 @@ async function getInterfaceNames() {
     const [source, name] = contractName.split(":");
 
     // If starts with prefix and is not in skip list, return name
-    return /.*contracts\/interfaces\/(.*)/.test(source) && !skip.some((s) => new RegExp(`.*contracts/interfaces/${s}`).test(source)) ? name : [];
+    return /.*contracts\/interfaces\/(.*)/.test(source) &&
+      !skip.some((s) => new RegExp(`.*contracts/interfaces/${s}`).test(source))
+      ? name
+      : [];
   });
 
   return interfaces;

--- a/scripts/config/supported-interfaces.js
+++ b/scripts/config/supported-interfaces.js
@@ -59,8 +59,8 @@ async function getInterfaceIds(useCache = true) {
 // Function to get all interface names
 async function getInterfaceNames() {
   // Folder where interfaces are stored
-  const prefix = "contracts/interfaces/";
-  const prefixProtocolContracts = "protocol-contracts/contracts/interfaces/";
+  const prefixRegex = /.*contracts\/interfaces/;
+  const regex = new RegExp(`${prefixRegex}(.*)/`);
   const skip = ["events", "IERC20.sol", "IERC20Metadata"]; // ERC20 interfaces are skipped since no contract implements them directly.
 
   // Get build info
@@ -71,10 +71,7 @@ async function getInterfaceNames() {
     const [source, name] = contractName.split(":");
 
     // If starts with prefix and is not in skip list, return name
-    return (source.startsWith(`${prefix}`) || source.startsWith(`${prefixProtocolContracts}`)) &&
-      !skip.some((s) => source.startsWith(`${prefix}${s}`) || source.startsWith(`${prefixProtocolContracts}${s}`))
-      ? name
-      : [];
+    return regex.test(source) && !skip.some((s) => new RegExp(`${prefixRegex}${s}`).test(source)) ? name : [];
   });
 
   return interfaces;

--- a/scripts/config/supported-interfaces.js
+++ b/scripts/config/supported-interfaces.js
@@ -59,8 +59,6 @@ async function getInterfaceIds(useCache = true) {
 // Function to get all interface names
 async function getInterfaceNames() {
   // Folder where interfaces are stored
-  const prefixRegex = /.*contracts\/interfaces/;
-  const regex = new RegExp(`${prefixRegex}(.*)/`);
   const skip = ["events", "IERC20.sol", "IERC20Metadata"]; // ERC20 interfaces are skipped since no contract implements them directly.
 
   // Get build info
@@ -71,7 +69,7 @@ async function getInterfaceNames() {
     const [source, name] = contractName.split(":");
 
     // If starts with prefix and is not in skip list, return name
-    return regex.test(source) && !skip.some((s) => new RegExp(`${prefixRegex}${s}`).test(source)) ? name : [];
+    return /.*contracts\/interfaces\/(.*)/.test(source) && !skip.some((s) => new RegExp(`.*contracts/interfaces/${s}`).test(source)) ? name : [];
   });
 
   return interfaces;

--- a/scripts/config/supported-interfaces.js
+++ b/scripts/config/supported-interfaces.js
@@ -60,6 +60,7 @@ async function getInterfaceIds(useCache = true) {
 async function getInterfaceNames() {
   // Folder where interfaces are stored
   const prefix = "contracts/interfaces/";
+  const prefixProtocolContracts = "protocol-contracts/contracts/interfaces/";
   const skip = ["events", "IERC20.sol", "IERC20Metadata"]; // ERC20 interfaces are skipped since no contract implements them directly.
 
   // Get build info
@@ -70,7 +71,10 @@ async function getInterfaceNames() {
     const [source, name] = contractName.split(":");
 
     // If starts with prefix and is not in skip list, return name
-    return source.startsWith(`${prefix}`) && !skip.some((s) => source.startsWith(`${prefix}${s}`)) ? name : [];
+    return (source.startsWith(`${prefix}`) || source.startsWith(`${prefixProtocolContracts}`)) &&
+      !skip.some((s) => source.startsWith(`${prefix}${s}`) || source.startsWith(`${prefixProtocolContracts}${s}`))
+      ? name
+      : [];
   });
 
   return interfaces;


### PR DESCRIPTION
as this repo is added in core-components as a submodule in another subfolder called _protocol-contracts_, our deploy script fails. This should fix it