### PR TITLE
BosonVoucher - add transferPremintedFrom

### DIFF
--- a/contracts/domain/BosonConstants.sol
+++ b/contracts/domain/BosonConstants.sol
@@ -191,6 +191,7 @@ string constant OFFER_STILL_VALID = "Offer still valid";
 string constant NOTHING_TO_BURN = "Nothing to burn";
 string constant OWNABLE_ZERO_ADDRESS = "Ownable: new owner is the zero address";
 string constant ROYALTY_FEE_INVALID = "ERC2981: royalty fee exceeds protocol limit";
+string constant NOT_COMMITTABLE = "Token not committable";
 
 // Meta Transactions - Structs
 bytes32 constant META_TRANSACTION_TYPEHASH = keccak256(

--- a/contracts/interfaces/clients/IBosonVoucher.sol
+++ b/contracts/interfaces/clients/IBosonVoucher.sol
@@ -9,7 +9,7 @@ import { IERC721MetadataUpgradeable } from "@openzeppelin/contracts-upgradeable/
  *
  * @notice This is the interface for the Boson Protocol ERC-721 Voucher contract.
  *
- * The ERC-165 identifier for this interface is: 0xc2e9f9ff
+ * The ERC-165 identifier for this interface is: 0x60490c39
  */
 interface IBosonVoucher is IERC721Upgradeable, IERC721MetadataUpgradeable {
     event ContractURIChanged(string contractURI);
@@ -188,6 +188,30 @@ interface IBosonVoucher is IERC721Upgradeable, IERC721MetadataUpgradeable {
      * @param _offerId - the id of the offer
      */
     function burnPremintedVouchers(uint256 _offerId) external;
+
+    /**
+     * @notice Non-standard ERC721 function to transfer a pre-minted token from one address to another.
+     *
+     * Reverts if:
+     * - TokenId was already used to commit
+     * - TokenId already exists (i.e. has an owner)
+     * - TokenId has not been preminted yet
+     * - TokenId was already burned
+     * - From is not the owner of the voucher contract
+     *
+     * @param _from - the address to transfer from
+     * @param _to - the address to transfer to
+     * @param _offerId - the id of the offer
+     * @param _tokenId - the id of the token
+     * @param _data - data to pass if receiver is contract
+     */
+    function transferPremintedFrom(
+        address _from,
+        address _to,
+        uint256 _offerId,
+        uint256 _tokenId,
+        bytes memory _data
+    ) external;
 
     /**
      * @notice Gets the number of vouchers available to be pre-minted for an offer.

--- a/contracts/protocol/clients/voucher/BosonVoucher.sol
+++ b/contracts/protocol/clients/voucher/BosonVoucher.sol
@@ -390,9 +390,7 @@ contract BosonVoucher is IBosonVoucher, BeaconClientBase, OwnableUpgradeable, ER
 
         if (committable) {
             // If offer is committable, temporarily update _owners, so transfer succeeds
-            silentMint(_from, _tokenId);
-            _premintStatus.committable = true;
-            _premintStatus.offerId = offerId;
+            silentMintAndSetPremintStatus(_from, _tokenId, offerId);
         }
 
         super.transferFrom(_from, _to, _tokenId);
@@ -411,10 +409,46 @@ contract BosonVoucher is IBosonVoucher, BeaconClientBase, OwnableUpgradeable, ER
 
         if (committable) {
             // If offer is committable, temporarily update _owners, so transfer succeeds
-            silentMint(_from, _tokenId);
-            _premintStatus.committable = true;
-            _premintStatus.offerId = offerId;
+            silentMintAndSetPremintStatus(_from, _tokenId, offerId);
         }
+
+        super.safeTransferFrom(_from, _to, _tokenId, _data);
+    }
+
+    /**
+     * @notice Non-standard ERC721 function to transfer a pre-minted token from one address to another.
+     *
+     * Reverts if:
+     * - TokenId was already used to commit
+     * - TokenId already exists (i.e. has an owner)
+     * - TokenId has not been preminted yet
+     * - TokenId was already burned
+     * - From is not the owner of the voucher contract
+     *
+     * @param _from - the address to transfer from
+     * @param _to - the address to transfer to
+     * @param _offerId - the id of the offer
+     * @param _tokenId - the id of the token
+     * @param _data - data to pass if receiver is contract
+     */
+    function transferPremintedFrom(
+        address _from,
+        address _to,
+        uint256 _offerId,
+        uint256 _tokenId,
+        bytes memory _data
+    ) external override {
+        // Check that token has not been used yet
+        require(!_committed[_tokenId] && !_exists(_tokenId), NOT_COMMITTABLE);
+
+        // Get range associated with offer
+        Range storage range = _rangeByOfferId[_offerId];
+
+        // Check if token is committable
+        require(range.start + range.minted - 1 >= _tokenId && _tokenId > range.lastBurnedTokenId, NOT_COMMITTABLE);
+
+        // Temporarily update _owners, so transfer succeeds
+        silentMintAndSetPremintStatus(_from, _tokenId, _offerId);
 
         super.safeTransferFrom(_from, _to, _tokenId, _data);
     }
@@ -670,7 +704,7 @@ contract BosonVoucher is IBosonVoucher, BeaconClientBase, OwnableUpgradeable, ER
      * @return committable - whether the token is committable
      * @return offerId - the associated offer id if committable
      */
-    function getPreMintStatus(uint256 _tokenId) internal view returns (bool committable, uint256 offerId) {
+    function getPreMintStatus(uint256 _tokenId) public view returns (bool committable, uint256 offerId) {
         // Not committable if _committed already or if token has an owner
         if (!_committed[_tokenId] && !_exists(_tokenId)) {
             // If are reserved ranges, search them
@@ -733,10 +767,18 @@ contract BosonVoucher is IBosonVoucher, BeaconClientBase, OwnableUpgradeable, ER
     /*
      * Updates balance and owner, but do not emit Transfer event. Event was already emited during pre-mint.
      */
-    function silentMint(address _from, uint256 _tokenId) internal {
+    function silentMintAndSetPremintStatus(
+        address _from,
+        uint256 _tokenId,
+        uint256 _offerId
+    ) internal {
         require(_from == owner(), NO_SILENT_MINT_ALLOWED);
 
         // update data, so transfer will succeed
         getERC721UpgradeableStorage()._owners[_tokenId] = _from;
+
+        // Update premint status
+        _premintStatus.committable = true;
+        _premintStatus.offerId = _offerId;
     }
 }

--- a/scripts/config/revert-reasons.js
+++ b/scripts/config/revert-reasons.js
@@ -138,6 +138,7 @@ exports.RevertReasons = {
   OFFER_EXPIRED_OR_VOIDED: "Offer expired or voided",
   OFFER_STILL_VALID: "Offer still valid",
   NOTHING_TO_BURN: "Nothing to burn",
+  NOT_COMMITTABLE: "Token not committable",
 
   // Funds related
   NATIVE_WRONG_ADDRESS: "Native token address must be 0",

--- a/test/protocol/clients/BosonVoucherTest.js
+++ b/test/protocol/clients/BosonVoucherTest.js
@@ -1136,7 +1136,7 @@ describe("IBosonVoucher", function () {
     });
   });
 
-  context.only("Token transfers", function () {
+  context("Token transfers", function () {
     afterEach(async function () {
       // Reset the accountId iterator
       accountId.next(true);
@@ -1415,7 +1415,7 @@ describe("IBosonVoucher", function () {
                 bosonVoucher.connect(operator)[selector](operator.address, rando.address, tokenId, ...additionalArgs)
               ).to.be.revertedWith(RevertReasons.ERC721_CALLER_NOT_OWNER_OR_APPROVED);
 
-              // It should also fail if trasnfer done with transferPremintedFrom
+              // It should also fail if transfer done with transferPremintedFrom
               await expect(
                 bosonVoucher
                   .connect(operator)

--- a/test/protocol/clients/BosonVoucherTest.js
+++ b/test/protocol/clients/BosonVoucherTest.js
@@ -1071,7 +1071,7 @@ describe("IBosonVoucher", function () {
           let startTokenId = Number(startId) + Number(amount);
           let endTokenId = Number(startId) + Number(length);
 
-          // None of reserverd but not preminted tokens should have an owner
+          // None of reserved but not preminted tokens should have an owner
           for (let i = startTokenId; i < endTokenId; i++) {
             await expect(bosonVoucher.connect(rando).ownerOf(i)).to.be.revertedWith(RevertReasons.ERC721_NON_EXISTENT);
           }
@@ -1445,7 +1445,7 @@ describe("IBosonVoucher", function () {
               // Burn preminted vouchers
               await bosonVoucher.connect(operator).burnPremintedVouchers(offerId);
 
-              // None of reserverd but not preminted tokens should have an owner
+              // None of reserved but not preminted tokens should have an owner
               await expect(
                 bosonVoucher.connect(operator)[selector](operator.address, rando.address, tokenId, ...additionalArgs)
               ).to.be.revertedWith(RevertReasons.ERC721_NON_EXISTENT);
@@ -1630,7 +1630,7 @@ describe("IBosonVoucher", function () {
           // Burn preminted vouchers
           await bosonVoucher.connect(operator).burnPremintedVouchers(offerId);
 
-          // None of reserverd but not preminted tokens should have an owner
+          // None of reserved but not preminted tokens should have an owner
           await expect(
             bosonVoucher
               .connect(operator)


### PR DESCRIPTION
TransferPremintedFrom is non-standart method to transfer preminted tokens. It is more efficient than generic transferFrom methods, since it does not have to perform binary search.
To make that possible, user must also supply `offerId` as input argument. To get `offerId` from `tokenId`, user can call `getPreMintStatus`, which was made public in this PR.