### PR TITLE
Remove files before the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:gas-reporter": "npx hardhat test test/domain/** test/access/** test/protocol/**.js test/protocol/clients/**",
     "check:contracts": "solhint 'contracts/**/*.sol' && prettier --list-different contracts/**",
     "check:scripts": "eslint test/** scripts/** '*.js' && prettier --list-different test/** scripts/** '*.js'",
-    "docgen": "npx truffle compile --contracts_directory contracts/interfaces && npx truffle compile --contracts_directory contracts/domain && npx solidoc && rm -rf build",
+    "docgen": "npx truffle compile --contracts_directory contracts/interfaces && npx truffle compile --contracts_directory contracts/domain && rm -rf contract_docs && npx solidoc && rm -rf build",
     "tidy:contracts": "solhint --fix contracts/**/*.sol && prettier --write contracts/**",
     "tidy:scripts": "eslint --fix test/** scripts/** '*.js' && prettier --write test/** scripts/** '*.js'",
     "size": "npx hardhat size-contracts",


### PR DESCRIPTION
Simple fix that prevent the failure of doc generation in https://github.com/bosonprotocol/docs.bosonprotocol.io
In some cases if there some old files remain the the doc folder, it can result in broken link. This PR solves that by adding a command that always cleans the folder with old docs before generating new.