### PR TITLE
Upgrade clients to v2.2.0-rc.2 on staging and test env

### DIFF
--- a/addresses/80001-mumbai-staging.json
+++ b/addresses/80001-mumbai-staging.json
@@ -2,7 +2,7 @@
   "chainId": 80001,
   "network": "mumbai",
   "env": "staging",
-  "protocolVersion": "2.1.0",
+  "protocolVersion": "2.2.0-rc.2",
   "contracts": [
     {
       "name": "AccessController",
@@ -140,12 +140,6 @@
       "interfaceId": "0x9ddb8ca6"
     },
     {
-      "name": "BosonVoucher Logic",
-      "address": "0x7Ec228D90F62116c607a556eb0610C056E097581",
-      "args": [],
-      "interfaceId": ""
-    },
-    {
       "name": "BosonVoucher Beacon",
       "address": "0xaFca5eAA6a6826a405c60110942150979Ff78281",
       "args": [
@@ -183,6 +177,12 @@
       "address": "0x8aaB601E4cFCfAebBBeB99F03b7992AA8c336430",
       "args": [],
       "interfaceId": "0xb8667cfd"
+    },
+    {
+      "name": "BosonVoucher Logic",
+      "address": "0x56Cbc86c5eC3e2D64B66F53C25A90Cff0E324b1B",
+      "args": [],
+      "interfaceId": ""
     }
   ]
 }

--- a/addresses/80001-mumbai-test.json
+++ b/addresses/80001-mumbai-test.json
@@ -2,7 +2,7 @@
   "chainId": 80001,
   "network": "mumbai",
   "env": "test",
-  "protocolVersion": "2.2.0-rc.1",
+  "protocolVersion": "2.2.0-rc.2",
   "contracts": [
     {
       "name": "AccessController",
@@ -108,12 +108,6 @@
       "interfaceId": "0x1f891681"
     },
     {
-      "name": "BosonVoucher Logic",
-      "address": "0x85B3Ae514fF85E9931314C3fD26f498a28841b39",
-      "args": [],
-      "interfaceId": ""
-    },
-    {
       "name": "ProtocolInitializationHandlerFacet",
       "address": "0xAA7D28Bcc8127E706B0630208D53652F8BA306BD",
       "args": [],
@@ -182,6 +176,12 @@
       "address": "0x234485F4A7D8d9CB5f45c25d670b519CdbFbF9b9",
       "args": [],
       "interfaceId": "0x60b30e70"
+    },
+    {
+      "name": "BosonVoucher Logic",
+      "address": "0x6DEBc2cc817c65b81E654790DB75c85D57F6D147",
+      "args": [],
+      "interfaceId": ""
     }
   ]
 }

--- a/logs/mumbai-staging.upgrade.contracts.txt
+++ b/logs/mumbai-staging.upgrade.contracts.txt
@@ -74,3 +74,172 @@ Removed supported interface 0x6db2c812 from supported interfaces.
 📋 Diamond upgraded.
 
 
+[
+  {
+    name: 'AccessController',
+    address: '0x955AbDE524CEd6A8AcA3A4a097bd3484c09f58bE',
+    args: [],
+    interfaceId: ''
+  },
+  {
+    name: 'DiamondLoupeFacet',
+    address: '0x120643A4c4EDcd2e86C67193006B1e0c44EEF1A9',
+    args: [],
+    interfaceId: '0x48e2b093'
+  },
+  {
+    name: 'DiamondCutFacet',
+    address: '0x77Ca7EBAAfC81433e46601e1acA7c245B33e2421',
+    args: [],
+    interfaceId: '0x1f931c1c'
+  },
+  {
+    name: 'ProtocolDiamond',
+    address: '0xf9719c7e641964D83cC50ea2d4d0D4e6C300d50E',
+    args: [ '0x955AbDE524CEd6A8AcA3A4a097bd3484c09f58bE', [Array], [Array] ],
+    interfaceId: ''
+  },
+  {
+    name: 'ConfigHandlerFacet',
+    address: '0xC656c68b48926a429Aa7165fFace65246126d682',
+    args: [],
+    interfaceId: '0x2ad335b8'
+  },
+  {
+    name: 'BuyerHandlerFacet',
+    address: '0x5Bb476E32d1e88B31bBC82d999D760eCb0c14d7D',
+    args: [],
+    interfaceId: '0xb8667cfd'
+  },
+  {
+    name: 'AgentHandlerFacet',
+    address: '0x954E0018cD1acc808774048231417c5b39687E22',
+    args: [],
+    interfaceId: '0xb8667cfd'
+  },
+  {
+    name: 'BundleHandlerFacet',
+    address: '0x75a762D427f584b49Df816C7B8EF35f366C5021e',
+    args: [],
+    interfaceId: '0x7b53dece'
+  },
+  {
+    name: 'DisputeHandlerFacet',
+    address: '0x506040028eB82d9bcD04f0834E7413D580C12777',
+    args: [],
+    interfaceId: '0xd9ea8317'
+  },
+  {
+    name: 'ExchangeHandlerFacet',
+    address: '0xE9745a15ff08f4a1Ef9f35FafF6afc5C3c81d92A',
+    args: [],
+    interfaceId: '0xbc114381'
+  },
+  {
+    name: 'FundsHandlerFacet',
+    address: '0x2330876E961a1A247f38813B78CdD4c00c7f2852',
+    args: [],
+    interfaceId: '0x18834247'
+  },
+  {
+    name: 'GroupHandlerFacet',
+    address: '0x44132DC5471F013530a5Fa69b89B651073Ca093e',
+    args: [],
+    interfaceId: '0xe2bf2256'
+  },
+  {
+    name: 'MetaTransactionsHandlerFacet',
+    address: '0x76C3bf69519ACc8Ad5fF2B720Ef1F623754e1842',
+    args: [],
+    interfaceId: '0xd25fcdc1'
+  },
+  {
+    name: 'OfferHandlerFacet',
+    address: '0x89682edb5A902A49d73Bf3139Eaa9c52F1551b63',
+    args: [],
+    interfaceId: '0xde051f34'
+  },
+  {
+    name: 'OrchestrationHandlerFacet',
+    address: '0x6e599ec84e16B9444bE392eD489493aebB139692',
+    args: [],
+    interfaceId: '0xb698ded2'
+  },
+  {
+    name: 'TwinHandlerFacet',
+    address: '0xa6Ff006d7a3A66AE432381c0030Ea6A7561A0A36',
+    args: [],
+    interfaceId: '0x60b30e70'
+  },
+  {
+    name: 'PauseHandlerFacet',
+    address: '0xd65517cc0c987AfCd1Ae62e281410f8F1fA636dD',
+    args: [],
+    interfaceId: '0x9ddb8ca6'
+  },
+  {
+    name: 'BosonVoucher Logic',
+    address: '0x7Ec228D90F62116c607a556eb0610C056E097581',
+    args: [],
+    interfaceId: ''
+  },
+  {
+    name: 'BosonVoucher Beacon',
+    address: '0xaFca5eAA6a6826a405c60110942150979Ff78281',
+    args: [
+      '0xf9719c7e641964D83cC50ea2d4d0D4e6C300d50E',
+      '0x7Ec228D90F62116c607a556eb0610C056E097581'
+    ],
+    interfaceId: ''
+  },
+  {
+    name: 'BosonVoucher Proxy',
+    address: '0xC54A578dbcBD57d844976eABDA61B853d0a0a724',
+    args: [],
+    interfaceId: ''
+  },
+  {
+    name: 'ERC165Facet',
+    address: '0x877BFA1fA72bFe974FD255f0b6D62aAb6d1482f0',
+    args: [],
+    interfaceId: '0x2ae6ea10'
+  },
+  {
+    name: 'AccountHandlerFacet',
+    address: '0x59cFcF5003Ea794c2676D5198142a815Cae9D77E',
+    args: [],
+    interfaceId: '0xb8667cfd'
+  },
+  {
+    name: 'SellerHandlerFacet',
+    address: '0x91D0c8e4DcBD558C8F6eDC1713112BA92e34F3Ef',
+    args: [],
+    interfaceId: '0xb8667cfd'
+  },
+  {
+    name: 'DisputeResolverHandlerFacet',
+    address: '0x8aaB601E4cFCfAebBBeB99F03b7992AA8c336430',
+    args: [],
+    interfaceId: '0xb8667cfd'
+  }
+]
+--------------------------------------------------------------------------------
+Boson Protocol Client Upgrader
+--------------------------------------------------------------------------------
+⛓  Network: mumbai
+📅 Thu Jan 26 2023 16:25:43 GMT-0300 (Brasilia Standard Time)
+🔱 Admin account:  0x2a91A0148EE62fA638bE38C7eE05c29a3e568dD8
+--------------------------------------------------------------------------------
+
+📋 Deploying new logic contract
+BosonVoucher deployed to: 0x56Cbc86c5eC3e2D64B66F53C25A90Cff0E324b1B
+
+📋 Updating implementation address on beacon
+✅ BosonVoucher Logic deployed to: 0x56Cbc86c5eC3e2D64B66F53C25A90Cff0E324b1B
+--------------------------------------------------------------------------------
+✅ Contracts written to /Users/anajulia/Dev/work/boson-protocol-contracts/scripts/util/../../addresses/80001-mumbai-staging.json
+--------------------------------------------------------------------------------
+
+📋 Client upgraded.
+
+

--- a/logs/mumbai-test.upgrade.contracts.txt
+++ b/logs/mumbai-test.upgrade.contracts.txt
@@ -326,3 +326,517 @@ You might need to remove its interfaceId from "supportsInterface" manually.
 📋 Diamond upgraded.
 
 
+--------------------------------------------------------------------------------
+Boson Protocol Client Upgrader
+--------------------------------------------------------------------------------
+⛓  Network: mumbai
+📅 Thu Jan 26 2023 16:14:57 GMT-0300 (Brasilia Standard Time)
+🔱 Admin account:  0x2a91A0148EE62fA638bE38C7eE05c29a3e568dD8
+--------------------------------------------------------------------------------
+
+--------------------------------------------------------------------------------
+Boson Protocol Client Upgrader
+--------------------------------------------------------------------------------
+⛓  Network: mumbai
+📅 Thu Jan 26 2023 16:16:00 GMT-0300 (Brasilia Standard Time)
+🔱 Admin account:  0x2a91A0148EE62fA638bE38C7eE05c29a3e568dD8
+--------------------------------------------------------------------------------
+
+--------------------------------------------------------------------------------
+Boson Protocol Client Upgrader
+--------------------------------------------------------------------------------
+⛓  Network: mumbai
+📅 Thu Jan 26 2023 16:18:47 GMT-0300 (Brasilia Standard Time)
+🔱 Admin account:  0x2a91A0148EE62fA638bE38C7eE05c29a3e568dD8
+--------------------------------------------------------------------------------
+Calling client upgrade
+
+chainId 80001
+network mumbai
+env test
+[
+  {
+    name: 'AccessController',
+    address: '0xAA34Bb04B4Efbe7D7733b92F8F585F4803987d04',
+    args: []
+  },
+  {
+    name: 'DiamondLoupeFacet',
+    address: '0x959C39BF5859263FC6efb8b871dA3e6B9e8CE500',
+    args: []
+  },
+  {
+    name: 'DiamondCutFacet',
+    address: '0xbA555eE251357b202eD9C5F67f2AB8f23f39d6A0',
+    args: []
+  },
+  {
+    name: 'ProtocolDiamond',
+    address: '0x785a225EBAC1b600cA3170C6c7fA3488A203Fc21',
+    args: [ '0xAA34Bb04B4Efbe7D7733b92F8F585F4803987d04', [Array], [Array] ]
+  },
+  {
+    name: 'BuyerHandlerFacet',
+    address: '0xe2439C0Bee3e3764a73113dd0b1E75408392166E',
+    args: []
+  },
+  {
+    name: 'AgentHandlerFacet',
+    address: '0xfae9F984E8F632634e6e1d979139770537Bca4Fe',
+    args: []
+  },
+  {
+    name: 'FundsHandlerFacet',
+    address: '0x5980CE2C787B9033Ff578c4A60676d35C09887a6',
+    args: []
+  },
+  {
+    name: 'GroupHandlerFacet',
+    address: '0x3D05697E821A91c38AF1ed145B6f667E68d5aC8b',
+    args: []
+  },
+  {
+    name: 'PauseHandlerFacet',
+    address: '0x8528d132331Ec469A2d7CE412A7089Feb54392EC',
+    args: []
+  },
+  {
+    name: 'BosonVoucher Beacon',
+    address: '0xc3552C2F8331Be2fFAA1e80504A0813C3d8816C5',
+    args: [
+      '0x785a225EBAC1b600cA3170C6c7fA3488A203Fc21',
+      '0x12b2194bdBDabE12B723c0865714327f940eFb63'
+    ]
+  },
+  {
+    name: 'BosonVoucher Proxy',
+    address: '0xaC991233dB3EDAB7f5605ceb111738D5dd7B8484',
+    args: []
+  },
+  {
+    name: 'ERC165Facet',
+    address: '0x8A8c38674005423fD4B102964fE5E05365a28F42',
+    args: [],
+    interfaceId: '0x2ae6ea10'
+  },
+  {
+    name: 'AccountHandlerFacet',
+    address: '0x04e9635d14dE63Fb50f3e629d24F8153FE6629FA',
+    args: [],
+    interfaceId: '0x1f891681'
+  },
+  {
+    name: 'BosonVoucher Logic',
+    address: '0x85B3Ae514fF85E9931314C3fD26f498a28841b39',
+    args: [],
+    interfaceId: ''
+  },
+  {
+    name: 'ProtocolInitializationHandlerFacet',
+    address: '0xAA7D28Bcc8127E706B0630208D53652F8BA306BD',
+    args: [],
+    interfaceId: '0x0d8e6e2c'
+  },
+  {
+    name: 'OrchestrationHandlerFacet1',
+    address: '0x0A0C68dD3f844d32BC7497c5e33714852A4C313A',
+    args: []
+  },
+  {
+    name: 'OrchestrationHandlerFacet2',
+    address: '0x6286d3d8E5ceCB5F17f4255957A5926450d37C21',
+    args: []
+  },
+  {
+    name: 'BundleHandlerFacet',
+    address: '0x173adA3Bb27aC711CD07669785c558ccaEab5BE3',
+    args: [],
+    interfaceId: '0x7b53dece'
+  },
+  {
+    name: 'ConfigHandlerFacet',
+    address: '0x9A0ce59548e485B57bC88207659116883Bf50a29',
+    args: [],
+    interfaceId: '0xe393ad01'
+  },
+  {
+    name: 'DisputeHandlerFacet',
+    address: '0x137312CE9641C8627915BE4f080dDDBa63cD2E8A',
+    args: [],
+    interfaceId: '0xd9ea8317'
+  },
+  {
+    name: 'DisputeResolverHandlerFacet',
+    address: '0xd737766891D40ceE4E27b07B7A4D4cF678234DD3',
+    args: [],
+    interfaceId: '0x1f891681'
+  },
+  {
+    name: 'ExchangeHandlerFacet',
+    address: '0xbd95A57897AF8A18D7389768fAC3Ca672a5AC4ea',
+    args: [],
+    interfaceId: '0xe300dfc1'
+  },
+  {
+    name: 'MetaTransactionsHandlerFacet',
+    address: '0x7156930e1c08fFB1D6e7DB22C3cc48eB405fb268',
+    args: [],
+    interfaceId: '0xb3e4e803'
+  },
+  {
+    name: 'OfferHandlerFacet',
+    address: '0x7707fCe9eFD69f25d35cA817A6936374c8DFD52f',
+    args: [],
+    interfaceId: '0xdd282b34'
+  },
+  {
+    name: 'SellerHandlerFacet',
+    address: '0xB6778C2F131eFf794b7379337FD888475E4213bb',
+    args: [],
+    interfaceId: '0x1f891681'
+  },
+  {
+    name: 'TwinHandlerFacet',
+    address: '0x234485F4A7D8d9CB5f45c25d670b519CdbFbF9b9',
+    args: [],
+    interfaceId: '0x60b30e70'
+  }
+]
+--------------------------------------------------------------------------------
+Boson Protocol Client Upgrader
+--------------------------------------------------------------------------------
+⛓  Network: mumbai
+📅 Thu Jan 26 2023 16:20:30 GMT-0300 (Brasilia Standard Time)
+🔱 Admin account:  0x2a91A0148EE62fA638bE38C7eE05c29a3e568dD8
+--------------------------------------------------------------------------------
+Calling client upgrade
+
+calling script
+chainId 80001
+network mumbai
+env test
+[
+  {
+    name: 'AccessController',
+    address: '0xAA34Bb04B4Efbe7D7733b92F8F585F4803987d04',
+    args: []
+  },
+  {
+    name: 'DiamondLoupeFacet',
+    address: '0x959C39BF5859263FC6efb8b871dA3e6B9e8CE500',
+    args: []
+  },
+  {
+    name: 'DiamondCutFacet',
+    address: '0xbA555eE251357b202eD9C5F67f2AB8f23f39d6A0',
+    args: []
+  },
+  {
+    name: 'ProtocolDiamond',
+    address: '0x785a225EBAC1b600cA3170C6c7fA3488A203Fc21',
+    args: [ '0xAA34Bb04B4Efbe7D7733b92F8F585F4803987d04', [Array], [Array] ]
+  },
+  {
+    name: 'BuyerHandlerFacet',
+    address: '0xe2439C0Bee3e3764a73113dd0b1E75408392166E',
+    args: []
+  },
+  {
+    name: 'AgentHandlerFacet',
+    address: '0xfae9F984E8F632634e6e1d979139770537Bca4Fe',
+    args: []
+  },
+  {
+    name: 'FundsHandlerFacet',
+    address: '0x5980CE2C787B9033Ff578c4A60676d35C09887a6',
+    args: []
+  },
+  {
+    name: 'GroupHandlerFacet',
+    address: '0x3D05697E821A91c38AF1ed145B6f667E68d5aC8b',
+    args: []
+  },
+  {
+    name: 'PauseHandlerFacet',
+    address: '0x8528d132331Ec469A2d7CE412A7089Feb54392EC',
+    args: []
+  },
+  {
+    name: 'BosonVoucher Beacon',
+    address: '0xc3552C2F8331Be2fFAA1e80504A0813C3d8816C5',
+    args: [
+      '0x785a225EBAC1b600cA3170C6c7fA3488A203Fc21',
+      '0x12b2194bdBDabE12B723c0865714327f940eFb63'
+    ]
+  },
+  {
+    name: 'BosonVoucher Proxy',
+    address: '0xaC991233dB3EDAB7f5605ceb111738D5dd7B8484',
+    args: []
+  },
+  {
+    name: 'ERC165Facet',
+    address: '0x8A8c38674005423fD4B102964fE5E05365a28F42',
+    args: [],
+    interfaceId: '0x2ae6ea10'
+  },
+  {
+    name: 'AccountHandlerFacet',
+    address: '0x04e9635d14dE63Fb50f3e629d24F8153FE6629FA',
+    args: [],
+    interfaceId: '0x1f891681'
+  },
+  {
+    name: 'BosonVoucher Logic',
+    address: '0x85B3Ae514fF85E9931314C3fD26f498a28841b39',
+    args: [],
+    interfaceId: ''
+  },
+  {
+    name: 'ProtocolInitializationHandlerFacet',
+    address: '0xAA7D28Bcc8127E706B0630208D53652F8BA306BD',
+    args: [],
+    interfaceId: '0x0d8e6e2c'
+  },
+  {
+    name: 'OrchestrationHandlerFacet1',
+    address: '0x0A0C68dD3f844d32BC7497c5e33714852A4C313A',
+    args: []
+  },
+  {
+    name: 'OrchestrationHandlerFacet2',
+    address: '0x6286d3d8E5ceCB5F17f4255957A5926450d37C21',
+    args: []
+  },
+  {
+    name: 'BundleHandlerFacet',
+    address: '0x173adA3Bb27aC711CD07669785c558ccaEab5BE3',
+    args: [],
+    interfaceId: '0x7b53dece'
+  },
+  {
+    name: 'ConfigHandlerFacet',
+    address: '0x9A0ce59548e485B57bC88207659116883Bf50a29',
+    args: [],
+    interfaceId: '0xe393ad01'
+  },
+  {
+    name: 'DisputeHandlerFacet',
+    address: '0x137312CE9641C8627915BE4f080dDDBa63cD2E8A',
+    args: [],
+    interfaceId: '0xd9ea8317'
+  },
+  {
+    name: 'DisputeResolverHandlerFacet',
+    address: '0xd737766891D40ceE4E27b07B7A4D4cF678234DD3',
+    args: [],
+    interfaceId: '0x1f891681'
+  },
+  {
+    name: 'ExchangeHandlerFacet',
+    address: '0xbd95A57897AF8A18D7389768fAC3Ca672a5AC4ea',
+    args: [],
+    interfaceId: '0xe300dfc1'
+  },
+  {
+    name: 'MetaTransactionsHandlerFacet',
+    address: '0x7156930e1c08fFB1D6e7DB22C3cc48eB405fb268',
+    args: [],
+    interfaceId: '0xb3e4e803'
+  },
+  {
+    name: 'OfferHandlerFacet',
+    address: '0x7707fCe9eFD69f25d35cA817A6936374c8DFD52f',
+    args: [],
+    interfaceId: '0xdd282b34'
+  },
+  {
+    name: 'SellerHandlerFacet',
+    address: '0xB6778C2F131eFf794b7379337FD888475E4213bb',
+    args: [],
+    interfaceId: '0x1f891681'
+  },
+  {
+    name: 'TwinHandlerFacet',
+    address: '0x234485F4A7D8d9CB5f45c25d670b519CdbFbF9b9',
+    args: [],
+    interfaceId: '0x60b30e70'
+  }
+]
+--------------------------------------------------------------------------------
+Boson Protocol Client Upgrader
+--------------------------------------------------------------------------------
+⛓  Network: mumbai
+📅 Thu Jan 26 2023 16:21:25 GMT-0300 (Brasilia Standard Time)
+🔱 Admin account:  0x2a91A0148EE62fA638bE38C7eE05c29a3e568dD8
+--------------------------------------------------------------------------------
+Calling client upgrade
+
+[
+  {
+    name: 'AccessController',
+    address: '0xAA34Bb04B4Efbe7D7733b92F8F585F4803987d04',
+    args: []
+  },
+  {
+    name: 'DiamondLoupeFacet',
+    address: '0x959C39BF5859263FC6efb8b871dA3e6B9e8CE500',
+    args: []
+  },
+  {
+    name: 'DiamondCutFacet',
+    address: '0xbA555eE251357b202eD9C5F67f2AB8f23f39d6A0',
+    args: []
+  },
+  {
+    name: 'ProtocolDiamond',
+    address: '0x785a225EBAC1b600cA3170C6c7fA3488A203Fc21',
+    args: [ '0xAA34Bb04B4Efbe7D7733b92F8F585F4803987d04', [Array], [Array] ]
+  },
+  {
+    name: 'BuyerHandlerFacet',
+    address: '0xe2439C0Bee3e3764a73113dd0b1E75408392166E',
+    args: []
+  },
+  {
+    name: 'AgentHandlerFacet',
+    address: '0xfae9F984E8F632634e6e1d979139770537Bca4Fe',
+    args: []
+  },
+  {
+    name: 'FundsHandlerFacet',
+    address: '0x5980CE2C787B9033Ff578c4A60676d35C09887a6',
+    args: []
+  },
+  {
+    name: 'GroupHandlerFacet',
+    address: '0x3D05697E821A91c38AF1ed145B6f667E68d5aC8b',
+    args: []
+  },
+  {
+    name: 'PauseHandlerFacet',
+    address: '0x8528d132331Ec469A2d7CE412A7089Feb54392EC',
+    args: []
+  },
+  {
+    name: 'BosonVoucher Beacon',
+    address: '0xc3552C2F8331Be2fFAA1e80504A0813C3d8816C5',
+    args: [
+      '0x785a225EBAC1b600cA3170C6c7fA3488A203Fc21',
+      '0x12b2194bdBDabE12B723c0865714327f940eFb63'
+    ]
+  },
+  {
+    name: 'BosonVoucher Proxy',
+    address: '0xaC991233dB3EDAB7f5605ceb111738D5dd7B8484',
+    args: []
+  },
+  {
+    name: 'ERC165Facet',
+    address: '0x8A8c38674005423fD4B102964fE5E05365a28F42',
+    args: [],
+    interfaceId: '0x2ae6ea10'
+  },
+  {
+    name: 'AccountHandlerFacet',
+    address: '0x04e9635d14dE63Fb50f3e629d24F8153FE6629FA',
+    args: [],
+    interfaceId: '0x1f891681'
+  },
+  {
+    name: 'BosonVoucher Logic',
+    address: '0x85B3Ae514fF85E9931314C3fD26f498a28841b39',
+    args: [],
+    interfaceId: ''
+  },
+  {
+    name: 'ProtocolInitializationHandlerFacet',
+    address: '0xAA7D28Bcc8127E706B0630208D53652F8BA306BD',
+    args: [],
+    interfaceId: '0x0d8e6e2c'
+  },
+  {
+    name: 'OrchestrationHandlerFacet1',
+    address: '0x0A0C68dD3f844d32BC7497c5e33714852A4C313A',
+    args: []
+  },
+  {
+    name: 'OrchestrationHandlerFacet2',
+    address: '0x6286d3d8E5ceCB5F17f4255957A5926450d37C21',
+    args: []
+  },
+  {
+    name: 'BundleHandlerFacet',
+    address: '0x173adA3Bb27aC711CD07669785c558ccaEab5BE3',
+    args: [],
+    interfaceId: '0x7b53dece'
+  },
+  {
+    name: 'ConfigHandlerFacet',
+    address: '0x9A0ce59548e485B57bC88207659116883Bf50a29',
+    args: [],
+    interfaceId: '0xe393ad01'
+  },
+  {
+    name: 'DisputeHandlerFacet',
+    address: '0x137312CE9641C8627915BE4f080dDDBa63cD2E8A',
+    args: [],
+    interfaceId: '0xd9ea8317'
+  },
+  {
+    name: 'DisputeResolverHandlerFacet',
+    address: '0xd737766891D40ceE4E27b07B7A4D4cF678234DD3',
+    args: [],
+    interfaceId: '0x1f891681'
+  },
+  {
+    name: 'ExchangeHandlerFacet',
+    address: '0xbd95A57897AF8A18D7389768fAC3Ca672a5AC4ea',
+    args: [],
+    interfaceId: '0xe300dfc1'
+  },
+  {
+    name: 'MetaTransactionsHandlerFacet',
+    address: '0x7156930e1c08fFB1D6e7DB22C3cc48eB405fb268',
+    args: [],
+    interfaceId: '0xb3e4e803'
+  },
+  {
+    name: 'OfferHandlerFacet',
+    address: '0x7707fCe9eFD69f25d35cA817A6936374c8DFD52f',
+    args: [],
+    interfaceId: '0xdd282b34'
+  },
+  {
+    name: 'SellerHandlerFacet',
+    address: '0xB6778C2F131eFf794b7379337FD888475E4213bb',
+    args: [],
+    interfaceId: '0x1f891681'
+  },
+  {
+    name: 'TwinHandlerFacet',
+    address: '0x234485F4A7D8d9CB5f45c25d670b519CdbFbF9b9',
+    args: [],
+    interfaceId: '0x60b30e70'
+  }
+]
+--------------------------------------------------------------------------------
+Boson Protocol Client Upgrader
+--------------------------------------------------------------------------------
+⛓  Network: mumbai
+📅 Thu Jan 26 2023 16:24:48 GMT-0300 (Brasilia Standard Time)
+🔱 Admin account:  0x2a91A0148EE62fA638bE38C7eE05c29a3e568dD8
+--------------------------------------------------------------------------------
+
+📋 Deploying new logic contract
+BosonVoucher deployed to: 0x6DEBc2cc817c65b81E654790DB75c85D57F6D147
+
+📋 Updating implementation address on beacon
+✅ BosonVoucher Logic deployed to: 0x6DEBc2cc817c65b81E654790DB75c85D57F6D147
+--------------------------------------------------------------------------------
+✅ Contracts written to /Users/anajulia/Dev/work/boson-protocol-contracts/scripts/util/../../addresses/80001-mumbai-test.json
+--------------------------------------------------------------------------------
+
+📋 Client upgraded.
+
+

--- a/scripts/config/client-upgrade.js
+++ b/scripts/config/client-upgrade.js
@@ -3,7 +3,8 @@ module.exports = {
     mainnet: "0x494f5238b40119e707582Ce87E0ca3627dB23Bcb", //dummy
     hardhat: "0x494f5238b40119e707582Ce87E0ca3627dB23Bcb", //dummy
     localhost: "0x494f5238b40119e707582Ce87E0ca3627dB23Bcb", //dummy
-    test: "0x494f5238b40119e707582Ce87E0ca3627dB23Bcb", //dummy
+    test: "0x69015912AA33720b842dCD6aC059Ed623F28d9f7",
+    staging: "0x69015912AA33720b842dCD6aC059Ed623F28d9f7",
     mumbai: "0x494f5238b40119e707582Ce87E0ca3627dB23Bcb", //dummy
     polygon: "0x17CDD65bebDe68cd8A4045422Fcff825A0740Ef9", //dummy
   },

--- a/scripts/upgrade-clients.js
+++ b/scripts/upgrade-clients.js
@@ -30,6 +30,7 @@ async function main(env, clientConfig) {
   if (network === "hardhat" && env !== "upgrade-test") process.exit();
 
   const { chainId } = await ethers.provider.getNetwork();
+
   let { contracts } = readContracts(chainId, network, env);
 
   const divider = "-".repeat(80);
@@ -69,13 +70,15 @@ async function main(env, clientConfig) {
   // Validate that admin has UPGRADER role
   checkRole(contracts, Role.UPGRADER, adminAddress);
 
-  clientConfig = JSON.parse(clientConfig) || require("./config/client-upgrade");
+  clientConfig = (clientConfig && JSON.parse(clientConfig)) || require("./config/client-upgrade");
 
   // Deploy Protocol Client implementation contracts
   console.log(`\n📋 Deploying new logic contract`);
 
-  const implementationArgs = Object.values(clientConfig).map((config) => config[network]);
-  const [bosonVoucherImplementation] = await deployProtocolClientImpls(implementationArgs, maxPriorityFeePerGas);
+  const clientImplementationArgs = Object.values(clientConfig).map(
+    (config) => process.env.FORWARDER_ADDRESS || config[network]
+  );
+  const [bosonVoucherImplementation] = await deployProtocolClientImpls(clientImplementationArgs, maxPriorityFeePerGas);
 
   // Update implementation address on beacon contract
   console.log(`\n📋 Updating implementation address on beacon`);


### PR DESCRIPTION
This PR adds logs of upgrade to tag `v2.2.0-rc.2` on staging and test environments.

This PR also fixes a bug on upgrade-clients script. 