### PR TITLE
Fix bug on tokenURI method on BosonVoucher

### DIFF
--- a/contracts/protocol/clients/voucher/BosonVoucher.sol
+++ b/contracts/protocol/clients/voucher/BosonVoucher.sol
@@ -499,16 +499,24 @@ contract BosonVoucherBase is IBosonVoucher, BeaconClientBase, OwnableUpgradeable
      * replaceable baseURI template, since the latter is not compatible
      * with IPFS hashes.
      *
-     * @param _exchangeId - id of the voucher's associated exchange
+     * @param _tokenId - id of the voucher's associated exchange or pre-minted
      * @return the uri for the associated offer's off-chain metadata (blank if not found)
      */
-    function tokenURI(uint256 _exchangeId)
+    function tokenURI(uint256 _tokenId)
         public
         view
         override(ERC721Upgradeable, IERC721MetadataUpgradeable)
         returns (string memory)
     {
-        (bool exists, Offer memory offer) = getBosonOfferByExchangeId(_exchangeId);
+        (bool exists, Offer memory offer) = getBosonOfferByExchangeId(_tokenId);
+
+        if (!exists) {
+            (bool committable, uint256 offerId) = getPreMintStatus(_tokenId);
+            if (committable) {
+                exists = true;
+                (offer, ) = getBosonOffer(offerId);
+            }
+        }
         return exists ? offer.metadataUri : "";
     }
 

--- a/contracts/protocol/clients/voucher/BosonVoucher.sol
+++ b/contracts/protocol/clients/voucher/BosonVoucher.sol
@@ -499,7 +499,7 @@ contract BosonVoucherBase is IBosonVoucher, BeaconClientBase, OwnableUpgradeable
      * replaceable baseURI template, since the latter is not compatible
      * with IPFS hashes.
      *
-     * @param _tokenId - id of the voucher's associated exchange or pre-minted
+     * @param _tokenId - id of the voucher's associated exchange or pre-minted token id
      * @return the uri for the associated offer's off-chain metadata (blank if not found)
      */
     function tokenURI(uint256 _tokenId)

--- a/package-lock.json
+++ b/package-lock.json
@@ -20188,7 +20188,6 @@
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.5.tgz",
       "integrity": "sha512-HTm14iMQKK2FjFLRTM5lAVcyaUzOnqbPtesFIvREgXpJHdQm8bWS+GkQgIkfaBYRHuCnea7w8UVNfwiAQhlr9A==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -20501,7 +20500,6 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.7.tgz",
       "integrity": "sha512-vLt1O5Pp+flcArHGIyKEQq883nBt8nN8tVBcoL0qUXj2XT1n7p70yGIq2VK98I5FdZ1YHc0wk/koOnHjnXWk1Q==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"


### PR DESCRIPTION
TokenURI was returning data only for offers with existing exchanges. 
Preminted vouchers have no exchange associated. 
