### PR TITLE
Allow vouchers to be preMinted to voucher contract

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,8 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-find . -name '*.js' -not -path '*/node_modules/*' | xargs git diff --cached --name-only | xargs npm run tidy:scripts
-git diff --cached --name-only | grep contracts | xargs npm run tidy:contracts
+find . -name '*.js' -not -path '*/node_modules/*' | xargs git diff --cached --name-only | xargs npx eslint --fix
+find . -name '*.js' -not -path '*/node_modules/*' | xargs git diff --cached --name-only | xargs npx prettier --write
+git diff --cached --name-only | grep contracts | xargs npx solhint --fix 
+git diff --cached --name-only | grep contracts | xargs npx prettier --write
 npm run natspec-interface-id:fix

--- a/contracts/domain/BosonConstants.sol
+++ b/contracts/domain/BosonConstants.sol
@@ -193,6 +193,7 @@ string constant NOTHING_TO_BURN = "Nothing to burn";
 string constant OWNABLE_ZERO_ADDRESS = "Ownable: new owner is the zero address";
 string constant ROYALTY_FEE_INVALID = "ERC2981: royalty fee exceeds protocol limit";
 string constant NOT_COMMITTABLE = "Token not committable";
+string constant INVALID_TO_ADDRESS = "Tokens can only be pre-mined to the contract address or contract owner address";
 
 // Meta Transactions - Structs
 bytes32 constant META_TRANSACTION_TYPEHASH = keccak256(

--- a/contracts/domain/BosonConstants.sol
+++ b/contracts/domain/BosonConstants.sol
@@ -193,7 +193,7 @@ string constant NOTHING_TO_BURN = "Nothing to burn";
 string constant OWNABLE_ZERO_ADDRESS = "Ownable: new owner is the zero address";
 string constant ROYALTY_FEE_INVALID = "ERC2981: royalty fee exceeds protocol limit";
 string constant NOT_COMMITTABLE = "Token not committable";
-string constant INVALID_TO_ADDRESS = "Tokens can only be pre-mined to the contract address or contract owner address";
+string constant INVALID_TO_ADDRESS = "Tokens can only be pre-mined to the contract or contract owner address";
 
 // Meta Transactions - Structs
 bytes32 constant META_TRANSACTION_TYPEHASH = keccak256(

--- a/contracts/interfaces/clients/IBosonVoucher.sol
+++ b/contracts/interfaces/clients/IBosonVoucher.sol
@@ -9,7 +9,7 @@ import { IERC721MetadataUpgradeable } from "@openzeppelin/contracts-upgradeable/
  *
  * @notice This is the interface for the Boson Protocol ERC-721 Voucher contract.
  *
- * The ERC-165 identifier for this interface is: 0x49cfea61
+ * The ERC-165 identifier for this interface is: 0x98eb5f84
  */
 interface IBosonVoucher is IERC721Upgradeable, IERC721MetadataUpgradeable {
     event ContractURIChanged(string contractURI);
@@ -23,6 +23,7 @@ interface IBosonVoucher is IERC721Upgradeable, IERC721MetadataUpgradeable {
         uint256 length; // Length of range
         uint256 minted; // Amount pre-minted so far
         uint256 lastBurnedTokenId; // Last burned token id
+        address owner; // The range owner
     }
 
     /**
@@ -123,15 +124,18 @@ interface IBosonVoucher is IERC721Upgradeable, IERC721MetadataUpgradeable {
      * - Range length is zero
      * - Range length is too large, i.e., would cause an overflow
      * - Offer id is already associated with a range
+     * - _to is not the contract address or the contract owner
      *
      * @param _offerId - the id of the offer
      * @param _start - the first id of the token range
      * @param _length - the length of the range
+     * @param _to - the address to send the pre-minted vouchers to (contract address or contract owner)
      */
     function reserveRange(
         uint256 _offerId,
         uint256 _start,
-        uint256 _length
+        uint256 _length,
+        address _to
     ) external;
 
     /**
@@ -163,13 +167,8 @@ interface IBosonVoucher is IERC721Upgradeable, IERC721MetadataUpgradeable {
      *
      * @param _offerId - the id of the offer
      * @param _amount - the amount to mint
-     * @param _to - the address to send the minted vouchers to (contract address or contract owner)
      */
-    function preMint(
-        uint256 _offerId,
-        uint256 _amount,
-        address _to
-    ) external;
+    function preMint(uint256 _offerId, uint256 _amount) external;
 
     /**
      * @notice Burn all or part of an offer's preminted vouchers.
@@ -235,4 +234,9 @@ interface IBosonVoucher is IERC721Upgradeable, IERC721MetadataUpgradeable {
      * @return range - range struct with information about range start, length and already minted tokens
      */
     function getRangeByOfferId(uint256 _offerId) external view returns (Range memory range);
+
+    /**
+     * @dev Returns the address of the current contract owner.
+     */
+    function owner() external view returns (address);
 }

--- a/contracts/interfaces/clients/IBosonVoucher.sol
+++ b/contracts/interfaces/clients/IBosonVoucher.sol
@@ -9,7 +9,7 @@ import { IERC721MetadataUpgradeable } from "@openzeppelin/contracts-upgradeable/
  *
  * @notice This is the interface for the Boson Protocol ERC-721 Voucher contract.
  *
- * The ERC-165 identifier for this interface is: 0x210d2e65
+ * The ERC-165 identifier for this interface is: 0x49cfea61
  */
 interface IBosonVoucher is IERC721Upgradeable, IERC721MetadataUpgradeable {
     event ContractURIChanged(string contractURI);
@@ -163,44 +163,12 @@ interface IBosonVoucher is IERC721Upgradeable, IERC721MetadataUpgradeable {
      *
      * @param _offerId - the id of the offer
      * @param _amount - the amount to mint
+     * @param _to - the address to send the minted vouchers to (contract address or contract owner)
      */
-    function preMint(uint256 _offerId, uint256 _amount) external;
-
-    /**
-     * @notice Pre-mints all or part of an offer's reserved vouchers.
-     *
-     * For small offer quantities, this method may only need to be
-     * called once.
-     *
-     * But, if the range is large, e.g., 10k vouchers, block gas limit
-     * could cause the transaction to fail. Thus, in order to support
-     * a batched approach to pre-minting an offer's vouchers,
-     * this method can be called multiple times, until the whole
-     * range is minted.
-     *
-     * A benefit to the batched approach is that the entire reserved
-     * range for an offer need not be pre-minted at one time. A seller
-     * could just mint batches periodically, controlling the amount
-     * that are available on the market at any given time, e.g.,
-     * creating a pre-minted offer with a validity period of one year,
-     * causing the token range to be reserved, but only pre-minting
-     * a certain amount monthly.
-     *
-     * Caller must be contract owner (seller assistant address).
-     *
-     * Reverts if:
-     * - Offer id is not associated with a range
-     * - Amount to mint is more than remaining un-minted in range
-     * - Too many to mint in a single transaction, given current block gas limit
-     *
-     * @param _to - the address to mint the vouchers to
-     * @param _offerId - the id of the offer
-     * @param _amount - the amount to mint
-     */
-    function preMintTo(
-        address _to,
+    function preMint(
         uint256 _offerId,
-        uint256 _amount
+        uint256 _amount,
+        address _to
     ) external;
 
     /**

--- a/contracts/interfaces/clients/IBosonVoucher.sol
+++ b/contracts/interfaces/clients/IBosonVoucher.sol
@@ -9,7 +9,7 @@ import { IERC721MetadataUpgradeable } from "@openzeppelin/contracts-upgradeable/
  *
  * @notice This is the interface for the Boson Protocol ERC-721 Voucher contract.
  *
- * The ERC-165 identifier for this interface is: 0x60490c39
+ * The ERC-165 identifier for this interface is: 0x210d2e65
  */
 interface IBosonVoucher is IERC721Upgradeable, IERC721MetadataUpgradeable {
     event ContractURIChanged(string contractURI);
@@ -165,6 +165,43 @@ interface IBosonVoucher is IERC721Upgradeable, IERC721MetadataUpgradeable {
      * @param _amount - the amount to mint
      */
     function preMint(uint256 _offerId, uint256 _amount) external;
+
+    /**
+     * @notice Pre-mints all or part of an offer's reserved vouchers.
+     *
+     * For small offer quantities, this method may only need to be
+     * called once.
+     *
+     * But, if the range is large, e.g., 10k vouchers, block gas limit
+     * could cause the transaction to fail. Thus, in order to support
+     * a batched approach to pre-minting an offer's vouchers,
+     * this method can be called multiple times, until the whole
+     * range is minted.
+     *
+     * A benefit to the batched approach is that the entire reserved
+     * range for an offer need not be pre-minted at one time. A seller
+     * could just mint batches periodically, controlling the amount
+     * that are available on the market at any given time, e.g.,
+     * creating a pre-minted offer with a validity period of one year,
+     * causing the token range to be reserved, but only pre-minting
+     * a certain amount monthly.
+     *
+     * Caller must be contract owner (seller assistant address).
+     *
+     * Reverts if:
+     * - Offer id is not associated with a range
+     * - Amount to mint is more than remaining un-minted in range
+     * - Too many to mint in a single transaction, given current block gas limit
+     *
+     * @param _to - the address to mint the vouchers to
+     * @param _offerId - the id of the offer
+     * @param _amount - the amount to mint
+     */
+    function preMintTo(
+        address _to,
+        uint256 _offerId,
+        uint256 _amount
+    ) external;
 
     /**
      * @notice Burn all or part of an offer's preminted vouchers.

--- a/contracts/interfaces/clients/IBosonVoucher.sol
+++ b/contracts/interfaces/clients/IBosonVoucher.sol
@@ -9,7 +9,7 @@ import { IERC721MetadataUpgradeable } from "@openzeppelin/contracts-upgradeable/
  *
  * @notice This is the interface for the Boson Protocol ERC-721 Voucher contract.
  *
- * The ERC-165 identifier for this interface is: 0x98eb5f84
+ * The ERC-165 identifier for this interface is: 0x154e94df
  */
 interface IBosonVoucher is IERC721Upgradeable, IERC721MetadataUpgradeable {
     event ContractURIChanged(string contractURI);

--- a/contracts/interfaces/events/IBosonOfferEvents.sol
+++ b/contracts/interfaces/events/IBosonOfferEvents.sol
@@ -32,6 +32,7 @@ interface IBosonOfferEvents {
         uint256 indexed sellerId,
         uint256 startExchangeId,
         uint256 endExchangeId,
+        address owner,
         address indexed executedBy
     );
 }

--- a/contracts/interfaces/handlers/IBosonOfferHandler.sol
+++ b/contracts/interfaces/handlers/IBosonOfferHandler.sol
@@ -9,7 +9,7 @@ import { IBosonOfferEvents } from "../events/IBosonOfferEvents.sol";
  *
  * @notice Handles creation, voiding, and querying of offers within the protocol.
  *
- * The ERC-165 identifier for this interface is: 0xdd282b34
+ * The ERC-165 identifier for this interface is: 0xa1598d02
  */
 interface IBosonOfferHandler is IBosonOfferEvents {
     /**
@@ -111,11 +111,17 @@ interface IBosonOfferHandler is IBosonOfferEvents {
      * - Range length is greater than quantity available
      * - Range length is greater than maximum allowed range length
      * - Call to BosonVoucher.reserveRange() reverts
+     * - _to is not the BosonVoucher contract address or the BosonVoucher contract owner
      *
      * @param _offerId - the id of the offer
      * @param _length - the length of the range
+     * @param _to - the address to send the pre-minted vouchers to (contract address or contract owner)
      */
-    function reserveRange(uint256 _offerId, uint256 _length) external;
+    function reserveRange(
+        uint256 _offerId,
+        uint256 _length,
+        address _to
+    ) external;
 
     /**
      * @notice Voids a given offer.

--- a/contracts/interfaces/handlers/IBosonOrchestrationHandler.sol
+++ b/contracts/interfaces/handlers/IBosonOrchestrationHandler.sol
@@ -13,7 +13,7 @@ import { IBosonBundleEvents } from "../events/IBosonBundleEvents.sol";
  *
  * @notice Combines creation of multiple entities (accounts, offers, groups, twins, bundles) in a single transaction
  *
- * The ERC-165 identifier for this interface is: 0x6fa524ec
+ * The ERC-165 identifier for this interface is: 0xa38bc2e7
  */
 interface IBosonOrchestrationHandler is
     IBosonAccountEvents,
@@ -162,6 +162,7 @@ interface IBosonOrchestrationHandler is
      * - When agent id is non zero:
      *   - If Agent does not exist
      *   - If the sum of agent fee amount and protocol fee amount is greater than the offer fee limit
+     * - _to is not the BosonVoucher contract address or the BosonVoucher contract owner
      *
      * @dev No reentrancy guard here since already implemented by called functions. If added here, they would clash.
      *
@@ -171,6 +172,7 @@ interface IBosonOrchestrationHandler is
      * @param _offerDurations - the fully populated offer durations struct
      * @param _disputeResolverId - the id of chosen dispute resolver (can be 0)
      * @param _reservedRangeLength - the amount of tokens to be reserved for preminting
+     * @param _to - the address to send the pre-minted vouchers to (contract address or contract owner)
      * @param _authToken - optional AuthToken struct that specifies an AuthToken type and tokenId that the seller can use to do admin functions
      * @param _voucherInitValues - the fully populated BosonTypes.VoucherInitValues struct
      * @param _agentId - the id of agent
@@ -182,6 +184,7 @@ interface IBosonOrchestrationHandler is
         BosonTypes.OfferDurations calldata _offerDurations,
         uint256 _disputeResolverId,
         uint256 _reservedRangeLength,
+        address _to,
         BosonTypes.AuthToken calldata _authToken,
         BosonTypes.VoucherInitValues calldata _voucherInitValues,
         uint256 _agentId
@@ -268,6 +271,7 @@ interface IBosonOrchestrationHandler is
      * - When agent id is non zero:
      *   - If Agent does not exist
      *   - If the sum of agent fee amount and protocol fee amount is greater than the offer fee limit
+     * - _to is not the BosonVoucher contract address or the BosonVoucher contract owner
      *
      * @dev No reentrancy guard here since already implemented by called functions. If added here, they would clash.
      *
@@ -276,6 +280,7 @@ interface IBosonOrchestrationHandler is
      * @param _offerDurations - the fully populated offer durations struct
      * @param _disputeResolverId - the id of chosen dispute resolver (can be 0)
      * @param _reservedRangeLength - the amount of tokens to be reserved for preminting
+     * @param _to - the address to send the pre-minted vouchers to (contract address or contract owner)
      * @param _condition - the fully populated condition struct
      * @param _agentId - the id of agent
      */
@@ -285,6 +290,7 @@ interface IBosonOrchestrationHandler is
         BosonTypes.OfferDurations calldata _offerDurations,
         uint256 _disputeResolverId,
         uint256 _reservedRangeLength,
+        address _to,
         BosonTypes.Condition calldata _condition,
         uint256 _agentId
     ) external;
@@ -376,6 +382,7 @@ interface IBosonOrchestrationHandler is
      * - When agent id is non zero:
      *   - If Agent does not exist
      *   - If the sum of agent fee amount and protocol fee amount is greater than the offer fee limit
+     * - _to is not the BosonVoucher contract address or the BosonVoucher contract owner
      *
      * @dev No reentrancy guard here since already implemented by called functions. If added here, they would clash.
      *
@@ -384,6 +391,7 @@ interface IBosonOrchestrationHandler is
      * @param _offerDurations - the fully populated offer durations struct
      * @param _disputeResolverId - the id of chosen dispute resolver (can be 0)
      * @param _reservedRangeLength - the amount of tokens to be reserved for preminting
+     * @param _to - the address to send the pre-minted vouchers to (contract address or contract owner)
      * @param _groupId - id of the group, to which offer will be added
      * @param _agentId - the id of agent
      */
@@ -393,6 +401,7 @@ interface IBosonOrchestrationHandler is
         BosonTypes.OfferDurations calldata _offerDurations,
         uint256 _disputeResolverId,
         uint256 _reservedRangeLength,
+        address _to,
         uint256 _groupId,
         uint256 _agentId
     ) external;
@@ -494,6 +503,7 @@ interface IBosonOrchestrationHandler is
      * - When agent id is non zero:
      *   - If Agent does not exist
      *   - If the sum of agent fee amount and protocol fee amount is greater than the offer fee limit
+     * - _to is not the BosonVoucher contract address or the BosonVoucher contract owner
      *
      * @dev No reentrancy guard here since already implemented by called functions. If added here, they would clash.
      *
@@ -502,6 +512,7 @@ interface IBosonOrchestrationHandler is
      * @param _offerDurations - the fully populated offer durations struct
      * @param _disputeResolverId - the id of chosen dispute resolver (can be 0)
      * @param _reservedRangeLength - the amount of tokens to be reserved for preminting
+     * @param _to - the address to send the pre-minted vouchers to (contract address or contract owner)
      * @param _twin - the fully populated twin struct
      * @param _agentId - the id of agent
      */
@@ -511,6 +522,7 @@ interface IBosonOrchestrationHandler is
         BosonTypes.OfferDurations calldata _offerDurations,
         uint256 _disputeResolverId,
         uint256 _reservedRangeLength,
+        address _to,
         BosonTypes.Twin memory _twin,
         uint256 _agentId
     ) external;
@@ -620,6 +632,7 @@ interface IBosonOrchestrationHandler is
      * - When agent id is non zero:
      *   - If Agent does not exist
      *   - If the sum of agent fee amount and protocol fee amount is greater than the offer fee limit
+     * - _to is not the BosonVoucher contract address or the BosonVoucher contract owner
      *
      * @dev No reentrancy guard here since already implemented by called functions. If added here, they would clash.
      *
@@ -628,6 +641,7 @@ interface IBosonOrchestrationHandler is
      * @param _offerDurations - the fully populated offer durations struct
      * @param _disputeResolverId - the id of chosen dispute resolver (can be 0)
      * @param _reservedRangeLength - the amount of tokens to be reserved for preminting
+     * @param _to - the address to send the pre-minted vouchers to (contract address or contract owner)
      * @param _condition - the fully populated condition struct
      * @param _twin - the fully populated twin struct
      * @param _agentId - the id of agent
@@ -638,6 +652,7 @@ interface IBosonOrchestrationHandler is
         BosonTypes.OfferDurations calldata _offerDurations,
         uint256 _disputeResolverId,
         uint256 _reservedRangeLength,
+        address _to,
         BosonTypes.Condition calldata _condition,
         BosonTypes.Twin memory _twin,
         uint256 _agentId
@@ -766,6 +781,7 @@ interface IBosonOrchestrationHandler is
      * - When agent id is non zero:
      *   - If Agent does not exist
      *   - If the sum of agent fee amount and protocol fee amount is greater than the offer fee limit
+     * - _to is not the BosonVoucher contract address or the BosonVoucher contract owner
      *
      * @dev No reentrancy guard here since already implemented by called functions. If added here, they would clash.
      *
@@ -775,6 +791,7 @@ interface IBosonOrchestrationHandler is
      * @param _offerDurations - the fully populated offer durations struct
      * @param _disputeResolverId - the id of chosen dispute resolver (can be 0)
      * @param _reservedRangeLength - the amount of tokens to be reserved for preminting
+     * @param _to - the address to send the pre-minted vouchers to (contract address or contract owner)
      * @param _condition - the fully populated condition struct
      * @param _authToken - optional AuthToken struct that specifies an AuthToken type and tokenId that the seller can use to do admin functions
      * @param _voucherInitValues - the fully populated BosonTypes.VoucherInitValues struct
@@ -787,6 +804,7 @@ interface IBosonOrchestrationHandler is
         BosonTypes.OfferDurations calldata _offerDurations,
         uint256 _disputeResolverId,
         uint256 _reservedRangeLength,
+        address _to,
         BosonTypes.Condition calldata _condition,
         BosonTypes.AuthToken calldata _authToken,
         BosonTypes.VoucherInitValues calldata _voucherInitValues,
@@ -932,6 +950,7 @@ interface IBosonOrchestrationHandler is
      * - When agent id is non zero:
      *   - If Agent does not exist
      *   - If the sum of agent fee amount and protocol fee amount is greater than the offer fee limit
+     * - _to is not the BosonVoucher contract address or the BosonVoucher contract owner
      *
      * @dev No reentrancy guard here since already implemented by called functions. If added here, they would clash.
      *
@@ -941,6 +960,7 @@ interface IBosonOrchestrationHandler is
      * @param _offerDurations - the fully populated offer durations struct
      * @param _disputeResolverId - the id of chosen dispute resolver (can be 0)
      * @param _reservedRangeLength - the amount of tokens to be reserved for preminting
+     * @param _to - the address to send the pre-minted vouchers to (contract address or contract owner)
      * @param _twin - the fully populated twin struct
      * @param _authToken - optional AuthToken struct that specifies an AuthToken type and tokenId that the seller can use to do admin functions
      * @param _voucherInitValues - the fully populated BosonTypes.VoucherInitValues struct
@@ -953,6 +973,7 @@ interface IBosonOrchestrationHandler is
         BosonTypes.OfferDurations calldata _offerDurations,
         uint256 _disputeResolverId,
         uint256 _reservedRangeLength,
+        address _to,
         BosonTypes.Twin memory _twin,
         BosonTypes.AuthToken calldata _authToken,
         BosonTypes.VoucherInitValues calldata _voucherInitValues,
@@ -1105,6 +1126,7 @@ interface IBosonOrchestrationHandler is
      * - When agent id is non zero:
      *   - If Agent does not exist
      *   - If the sum of agent fee amount and protocol fee amount is greater than the offer fee limit
+     * - _to is not the BosonVoucher contract address or the BosonVoucher contract owner
      *
      * @dev No reentrancy guard here since already implemented by called functions. If added here, they would clash.
      *
@@ -1114,6 +1136,7 @@ interface IBosonOrchestrationHandler is
      * @param _offerDurations - the fully populated offer durations struct
      * @param _disputeResolverId - the id of chosen dispute resolver (can be 0)
      * @param _reservedRangeLength - the amount of tokens to be reserved for preminting
+     * @param _to - the address to send the pre-minted vouchers to (contract address or contract owner)
      * @param _condition - the fully populated condition struct
      * @param _twin - the fully populated twin struct
      * @param _authToken - optional AuthToken struct that specifies an AuthToken type and tokenId that the seller can use to do admin functions
@@ -1127,6 +1150,7 @@ interface IBosonOrchestrationHandler is
         BosonTypes.OfferDurations calldata _offerDurations,
         uint256 _disputeResolverId,
         uint256 _reservedRangeLength,
+        address _to,
         BosonTypes.Condition calldata _condition,
         BosonTypes.Twin memory _twin,
         BosonTypes.AuthToken calldata _authToken,

--- a/contracts/protocol/bases/OfferBase.sol
+++ b/contracts/protocol/bases/OfferBase.sol
@@ -332,6 +332,6 @@ contract OfferBase is ProtocolBase, IBosonOfferEvents {
         }
 
         // Notify external observers
-        emit RangeReserved(_offerId, offer.sellerId, _startId, _startId + _length - 1, msgSender());
+        emit RangeReserved(_offerId, offer.sellerId, _startId, _startId + _length - 1, _to, msgSender());
     }
 }

--- a/contracts/protocol/bases/OfferBase.sol
+++ b/contracts/protocol/bases/OfferBase.sol
@@ -317,8 +317,10 @@ contract OfferBase is ProtocolBase, IBosonOfferEvents {
 
         IBosonVoucher bosonVoucher = IBosonVoucher(protocolLookups().cloneAddress[offer.sellerId]);
 
+        address sender = msgSender();
+
         // _to must be the contract address or the contract owner
-        require(_to == address(bosonVoucher) || _to == bosonVoucher.owner(), INVALID_TO_ADDRESS);
+        require(_to == address(bosonVoucher) || _to == sender, INVALID_TO_ADDRESS);
 
         // Call reserveRange on voucher
         bosonVoucher.reserveRange(_offerId, _startId, _length, _to);
@@ -332,6 +334,6 @@ contract OfferBase is ProtocolBase, IBosonOfferEvents {
         }
 
         // Notify external observers
-        emit RangeReserved(_offerId, offer.sellerId, _startId, _startId + _length - 1, _to, msgSender());
+        emit RangeReserved(_offerId, offer.sellerId, _startId, _startId + _length - 1, _to, sender);
     }
 }

--- a/contracts/protocol/clients/voucher/BosonVoucher.sol
+++ b/contracts/protocol/clients/voucher/BosonVoucher.sol
@@ -61,7 +61,7 @@ contract BosonVoucherBase is IBosonVoucher, BeaconClientBase, OwnableUpgradeable
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[42] private __gap;
+    uint256[43] private __gap;
 
     /**
      * @notice Initializes the voucher.
@@ -246,20 +246,21 @@ contract BosonVoucherBase is IBosonVoucher, BeaconClientBase, OwnableUpgradeable
 
         // Get the first token to mint
         uint256 start = range.start + range.minted;
+        address to = range.owner;
 
         // Pre-mint the range
         uint256 tokenId;
         for (uint256 i = 0; i < _amount; i++) {
             tokenId = start + i;
 
-            emit Transfer(address(0), range.owner, tokenId);
+            emit Transfer(address(0), to, tokenId);
         }
 
         // Bump the minted count
         range.minted += _amount;
 
         // Update to total balance
-        getERC721UpgradeableStorage()._balances[range.owner] += _amount;
+        getERC721UpgradeableStorage()._balances[to] += _amount;
     }
 
     /**

--- a/contracts/protocol/clients/voucher/BosonVoucher.sol
+++ b/contracts/protocol/clients/voucher/BosonVoucher.sol
@@ -391,7 +391,7 @@ contract BosonVoucherBase is IBosonVoucher, BeaconClientBase, OwnableUpgradeable
             bool committable;
             // If _tokenId does not exist, but offer is committable, report contract owner as token owner
             (committable, , tokenOwner) = getPreMintStatus(_tokenId);
-            if (committable) return super.owner();
+            if (committable) return tokenOwner;
 
             // Otherwise revert
             revert("ERC721: invalid token ID");

--- a/contracts/protocol/clients/voucher/BosonVoucher.sol
+++ b/contracts/protocol/clients/voucher/BosonVoucher.sol
@@ -499,16 +499,24 @@ contract BosonVoucherBase is IBosonVoucher, BeaconClientBase, OwnableUpgradeable
      * replaceable baseURI template, since the latter is not compatible
      * with IPFS hashes.
      *
-     * @param _exchangeId - id of the voucher's associated exchange
+     * @param _tokenId - id of the voucher's associated exchange or pre-minted token id
      * @return the uri for the associated offer's off-chain metadata (blank if not found)
      */
-    function tokenURI(uint256 _exchangeId)
+    function tokenURI(uint256 _tokenId)
         public
         view
         override(ERC721Upgradeable, IERC721MetadataUpgradeable)
         returns (string memory)
     {
-        (bool exists, Offer memory offer) = getBosonOfferByExchangeId(_exchangeId);
+        (bool exists, Offer memory offer) = getBosonOfferByExchangeId(_tokenId);
+
+        if (!exists) {
+            (bool committable, uint256 offerId) = getPreMintStatus(_tokenId);
+            if (committable) {
+                exists = true;
+                (offer, ) = getBosonOffer(offerId);
+            }
+        }
         return exists ? offer.metadataUri : "";
     }
 

--- a/contracts/protocol/clients/voucher/BosonVoucher.sol
+++ b/contracts/protocol/clients/voucher/BosonVoucher.sol
@@ -63,8 +63,7 @@ contract BosonVoucherBase is IBosonVoucher, BeaconClientBase, OwnableUpgradeable
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    // @TODO
-    uint256[43] private __gap;
+    uint256[42] private __gap;
 
     /**
      * @notice Initializes the voucher.

--- a/contracts/protocol/clients/voucher/BosonVoucher.sol
+++ b/contracts/protocol/clients/voucher/BosonVoucher.sol
@@ -810,6 +810,8 @@ contract BosonVoucherBase is IBosonVoucher, BeaconClientBase, OwnableUpgradeable
         uint256 _tokenId,
         uint256 _offerId
     ) internal {
+        require(_from == owner() || _from == address(this), NO_SILENT_MINT_ALLOWED);
+
         // update data, so transfer will succeed
         getERC721UpgradeableStorage()._owners[_tokenId] = _from;
 

--- a/contracts/protocol/clients/voucher/BosonVoucher.sol
+++ b/contracts/protocol/clients/voucher/BosonVoucher.sol
@@ -56,11 +56,14 @@ contract BosonVoucherBase is IBosonVoucher, BeaconClientBase, OwnableUpgradeable
     // Tell if preminted voucher has already been _committed
     mapping(uint256 => bool) private _committed;
 
+    mapping(uint256 => address) private _preMintOwners;
+
     /**
      * @dev This empty reserved space is put in place to allow future versions to add new
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
+    // @TODO
     uint256[43] private __gap;
 
     /**
@@ -217,42 +220,53 @@ contract BosonVoucherBase is IBosonVoucher, BeaconClientBase, OwnableUpgradeable
      * @param _amount - the amount to mint
      */
     function preMint(uint256 _offerId, uint256 _amount) external onlyOwner {
-        // Get the offer's range
-        Range storage range = _rangeByOfferId[_offerId];
-
-        // Revert if id not associated with a range
-        require(range.length != 0, NO_RESERVED_RANGE_FOR_OFFER);
-
-        // Revert if no more to mint in range
-        require(range.length >= range.minted + _amount, INVALID_AMOUNT_TO_MINT);
-
-        // Get max amount that can be minted in a single transaction
-        address protocolDiamond = IClientExternalAddresses(BeaconClientLib._beacon()).getProtocolAddress();
-        uint256 maxPremintedVouchers = IBosonConfigHandler(protocolDiamond).getMaxPremintedVouchers();
-
-        // Revert if too many to mint in a single transaction
-        require(_amount <= maxPremintedVouchers, TOO_MANY_TO_MINT);
-
-        // Make sure that offer is not expired or voided
-        (Offer memory offer, OfferDates memory offerDates) = getBosonOffer(_offerId);
-        require(!offer.voided && (offerDates.validUntil > block.timestamp), OFFER_EXPIRED_OR_VOIDED);
-
-        // Get the first token to mint
-        uint256 start = range.start + range.minted;
-
-        // Pre-mint the range to the seller
-        uint256 tokenId;
         address seller = owner();
-        for (uint256 i = 0; i < _amount; i++) {
-            tokenId = start + i;
-            emit Transfer(address(0), seller, tokenId);
-        }
 
-        // Bump the minted count
-        range.minted += _amount;
+        preMintInternal(seller, _offerId, _amount);
+    }
 
-        // Update seller's total balance
-        getERC721UpgradeableStorage()._balances[seller] += _amount;
+    /**
+     * @notice Pre-mints all or part of an offer's reserved vouchers.
+     *
+     * For small offer quantities, this method may only need to be
+     * called once.
+     *
+     * But, if the range is large, e.g., 10k vouchers, block gas limit
+     * could cause the transaction to fail. Thus, in order to support
+     * a batched approach to pre-minting an offer's vouchers,
+     * this method can be called multiple times, until the whole
+     * range is minted.
+     *
+     * A benefit to the batched approach is that the entire reserved
+     * range for an offer need not be pre-minted at one time. A seller
+     * could just mint batches periodically, controlling the amount
+     * that are available on the market at any given time, e.g.,
+     * creating a pre-minted offer with a validity period of one year,
+     * causing the token range to be reserved, but only pre-minting
+     * a certain amount monthly.
+     *
+     * Caller must be contract owner (seller assistant address).
+     *
+     * Reverts if:
+     * - Offer id is not associated with a range
+     * - Amount to mint is more than remaining un-minted in range
+     * - Too many to mint in a single transaction, given current block gas limit
+     * - Offer already expired
+     * - Offer is voided
+     * - _to address is zero address
+     *
+     * @param _to - the address to mint the vouchers to
+     * @param _offerId - the id of the offer
+     * @param _amount - the amount to mint
+     */
+    function preMintTo(
+        address _to,
+        uint256 _offerId,
+        uint256 _amount
+    ) external onlyOwner {
+        require(_to != address(0), INVALID_ADDRESS);
+
+        preMintInternal(_to, _offerId, _amount);
     }
 
     /**
@@ -383,7 +397,7 @@ contract BosonVoucherBase is IBosonVoucher, BeaconClientBase, OwnableUpgradeable
         } else {
             // If _tokenId does not exist, but offer is committable, report contract owner as token owner
             (bool committable, ) = getPreMintStatus(_tokenId);
-            if (committable) return super.owner();
+            if (committable) return _preMintOwners[_tokenId];
 
             // Otherwise revert
             revert("ERC721: invalid token ID");
@@ -785,14 +799,58 @@ contract BosonVoucherBase is IBosonVoucher, BeaconClientBase, OwnableUpgradeable
         uint256 _tokenId,
         uint256 _offerId
     ) internal {
-        require(_from == owner(), NO_SILENT_MINT_ALLOWED);
-
         // update data, so transfer will succeed
         getERC721UpgradeableStorage()._owners[_tokenId] = _from;
 
         // Update premint status
         _premintStatus.committable = true;
         _premintStatus.offerId = _offerId;
+    }
+
+    function preMintInternal(
+        address _to,
+        uint256 _offerId,
+        uint256 _amount
+    ) internal {
+        // Get the offer's range
+        Range storage range = _rangeByOfferId[_offerId];
+
+        // Revert if id not associated with a range
+        require(range.length != 0, NO_RESERVED_RANGE_FOR_OFFER);
+
+        // Revert if no more to mint in range
+        require(range.length >= range.minted + _amount, INVALID_AMOUNT_TO_MINT);
+
+        // Get max amount that can be minted in a single transaction
+        address protocolDiamond = IClientExternalAddresses(BeaconClientLib._beacon()).getProtocolAddress();
+        uint256 maxPremintedVouchers = IBosonConfigHandler(protocolDiamond).getMaxPremintedVouchers();
+
+        // Revert if too many to mint in a single transaction
+        require(_amount <= maxPremintedVouchers, TOO_MANY_TO_MINT);
+
+        // Make sure that offer is not expired or voided
+        (Offer memory offer, OfferDates memory offerDates) = getBosonOffer(_offerId);
+        require(!offer.voided && (offerDates.validUntil > block.timestamp), OFFER_EXPIRED_OR_VOIDED);
+
+        // Get the first token to mint
+        uint256 start = range.start + range.minted;
+
+        // Pre-mint the range
+        uint256 tokenId;
+        for (uint256 i = 0; i < _amount; i++) {
+            tokenId = start + i;
+
+            // Set preMint token owner
+            _preMintOwners[tokenId] = _to;
+
+            emit Transfer(address(0), _to, tokenId);
+        }
+
+        // Bump the minted count
+        range.minted += _amount;
+
+        // Update to total balance
+        getERC721UpgradeableStorage()._balances[_to] += _amount;
     }
 }
 

--- a/contracts/protocol/facets/OfferHandlerFacet.sol
+++ b/contracts/protocol/facets/OfferHandlerFacet.sol
@@ -137,12 +137,18 @@ contract OfferHandlerFacet is IBosonOfferHandler, OfferBase {
      * - Range length is greater than quantity available
      * - Range length is greater than maximum allowed range length
      * - Call to BosonVoucher.reserveRange() reverts
+     * - _to is not the BosonVoucher contract address or the BosonVoucher contract owner
      *
      * @param _offerId - the id of the offer
      * @param _length - the length of the range
+     * @param _to - the address to send the pre-minted vouchers to (contract address or contract owner)
      */
-    function reserveRange(uint256 _offerId, uint256 _length) external override nonReentrant {
-        reserveRangeInternal(_offerId, _length);
+    function reserveRange(
+        uint256 _offerId,
+        uint256 _length,
+        address _to
+    ) external override nonReentrant {
+        reserveRangeInternal(_offerId, _length, _to);
     }
 
     /**

--- a/contracts/protocol/facets/OrchestrationHandlerFacet1.sol
+++ b/contracts/protocol/facets/OrchestrationHandlerFacet1.sol
@@ -142,6 +142,7 @@ contract OrchestrationHandlerFacet1 is PausableBase, SellerBase, OfferBase, Grou
      * - When agent id is non zero:
      *   - If Agent does not exist
      *   - If the sum of agent fee amount and protocol fee amount is greater than the offer fee limit
+     * - _to is not the BosonVoucher contract address or the BosonVoucher contract owner
      *
      * @dev No reentrancy guard here since already implemented by called functions. If added here, they would clash.
      *
@@ -151,6 +152,7 @@ contract OrchestrationHandlerFacet1 is PausableBase, SellerBase, OfferBase, Grou
      * @param _offerDurations - the fully populated offer durations struct
      * @param _disputeResolverId - the id of chosen dispute resolver (can be 0)
      * @param _reservedRangeLength - the amount of tokens to be reserved for preminting
+     * @param _to - the address to send the pre-minted vouchers to (contract address or contract owner)
      * @param _authToken - optional AuthToken struct that specifies an AuthToken type and tokenId that the seller can use to do admin functions
      * @param _voucherInitValues - the fully populated BosonTypes.VoucherInitValues struct
      * @param _agentId - the id of agent
@@ -162,6 +164,7 @@ contract OrchestrationHandlerFacet1 is PausableBase, SellerBase, OfferBase, Grou
         OfferDurations calldata _offerDurations,
         uint256 _disputeResolverId,
         uint256 _reservedRangeLength,
+        address _to,
         AuthToken calldata _authToken,
         VoucherInitValues calldata _voucherInitValues,
         uint256 _agentId
@@ -176,7 +179,7 @@ contract OrchestrationHandlerFacet1 is PausableBase, SellerBase, OfferBase, Grou
             _voucherInitValues,
             _agentId
         );
-        reserveRangeInternal(_offer.id, _reservedRangeLength);
+        reserveRangeInternal(_offer.id, _reservedRangeLength, _to);
     }
 
     /**
@@ -274,6 +277,7 @@ contract OrchestrationHandlerFacet1 is PausableBase, SellerBase, OfferBase, Grou
      * - When agent id is non zero:
      *   - If Agent does not exist
      *   - If the sum of agent fee amount and protocol fee amount is greater than the offer fee limit
+     * - _to is not the BosonVoucher contract address or the BosonVoucher contract owner
      *
      * @dev No reentrancy guard here since already implemented by called functions. If added here, they would clash.
      *
@@ -281,7 +285,7 @@ contract OrchestrationHandlerFacet1 is PausableBase, SellerBase, OfferBase, Grou
      * @param _offerDates - the fully populated offer dates struct
      * @param _offerDurations - the fully populated offer durations struct
      * @param _disputeResolverId - the id of chosen dispute resolver (can be 0)
-     * @param _reservedRangeLength - the amount of tokens to be reserved for preminting
+     * @param _to - the address to send the pre-minted vouchers to (contract address or contract owner)
      * @param _condition - the fully populated condition struct
      * @param _agentId - the id of agent
      */
@@ -291,11 +295,12 @@ contract OrchestrationHandlerFacet1 is PausableBase, SellerBase, OfferBase, Grou
         OfferDurations calldata _offerDurations,
         uint256 _disputeResolverId,
         uint256 _reservedRangeLength,
+        address _to,
         Condition calldata _condition,
         uint256 _agentId
     ) public {
         createOfferWithCondition(_offer, _offerDates, _offerDurations, _disputeResolverId, _condition, _agentId);
-        reserveRangeInternal(_offer.id, _reservedRangeLength);
+        reserveRangeInternal(_offer.id, _reservedRangeLength, _to);
     }
 
     /**
@@ -393,6 +398,7 @@ contract OrchestrationHandlerFacet1 is PausableBase, SellerBase, OfferBase, Grou
      * - When agent id is non zero:
      *   - If Agent does not exist
      *   - If the sum of agent fee amount and protocol fee amount is greater than the offer fee limit
+     * - _to is not the BosonVoucher contract address or the BosonVoucher contract owner
      *
      * @dev No reentrancy guard here since already implemented by called functions. If added here, they would clash.
      *
@@ -401,6 +407,7 @@ contract OrchestrationHandlerFacet1 is PausableBase, SellerBase, OfferBase, Grou
      * @param _offerDurations - the fully populated offer durations struct
      * @param _disputeResolverId - the id of chosen dispute resolver (can be 0)
      * @param _reservedRangeLength - the amount of tokens to be reserved for preminting
+     * @param _to - the address to send the pre-minted vouchers to (contract address or contract owner)
      * @param _groupId - id of the group, to which offer will be added
      * @param _agentId - the id of agent
      */
@@ -410,11 +417,12 @@ contract OrchestrationHandlerFacet1 is PausableBase, SellerBase, OfferBase, Grou
         OfferDurations calldata _offerDurations,
         uint256 _disputeResolverId,
         uint256 _reservedRangeLength,
+        address _to,
         uint256 _groupId,
         uint256 _agentId
     ) external {
         createOfferAddToGroup(_offer, _offerDates, _offerDurations, _disputeResolverId, _groupId, _agentId);
-        reserveRangeInternal(_offer.id, _reservedRangeLength);
+        reserveRangeInternal(_offer.id, _reservedRangeLength, _to);
     }
 
     /**
@@ -520,6 +528,7 @@ contract OrchestrationHandlerFacet1 is PausableBase, SellerBase, OfferBase, Grou
      * - When agent id is non zero:
      *   - If Agent does not exist
      *   - If the sum of agent fee amount and protocol fee amount is greater than the offer fee limit
+     * - _to is not the BosonVoucher contract address or the BosonVoucher contract owner
      *
      * @dev No reentrancy guard here since already implemented by called functions. If added here, they would clash.
      *
@@ -528,8 +537,11 @@ contract OrchestrationHandlerFacet1 is PausableBase, SellerBase, OfferBase, Grou
      * @param _offerDurations - the fully populated offer durations struct
      * @param _disputeResolverId - the id of chosen dispute resolver (can be 0)
      * @param _reservedRangeLength - the amount of tokens to be reserved for preminting
+     * @param _to - the address to send the pre-minted vouchers to (contract address or contract owner)
      * @param _twin - the fully populated twin struct
      * @param _agentId - the id of agent
+
+     * @param _to - the address to send the pre-minted vouchers to (contract address or contract owner)
      */
     function createPremintedOfferAndTwinWithBundle(
         Offer memory _offer,
@@ -537,11 +549,12 @@ contract OrchestrationHandlerFacet1 is PausableBase, SellerBase, OfferBase, Grou
         OfferDurations calldata _offerDurations,
         uint256 _disputeResolverId,
         uint256 _reservedRangeLength,
+        address _to,
         Twin memory _twin,
         uint256 _agentId
     ) public {
         createOfferAndTwinWithBundle(_offer, _offerDates, _offerDurations, _disputeResolverId, _twin, _agentId);
-        reserveRangeInternal(_offer.id, _reservedRangeLength);
+        reserveRangeInternal(_offer.id, _reservedRangeLength, _to);
     }
 
     /**
@@ -656,6 +669,7 @@ contract OrchestrationHandlerFacet1 is PausableBase, SellerBase, OfferBase, Grou
      * - When agent id is non zero:
      *   - If Agent does not exist
      *   - If the sum of agent fee amount and protocol fee amount is greater than the offer fee limit
+     * - _to is not the BosonVoucher contract address or the BosonVoucher contract owner
      *
      * @dev No reentrancy guard here since already implemented by called functions. If added here, they would clash.
      *
@@ -664,6 +678,7 @@ contract OrchestrationHandlerFacet1 is PausableBase, SellerBase, OfferBase, Grou
      * @param _offerDurations - the fully populated offer durations struct
      * @param _disputeResolverId - the id of chosen dispute resolver (can be 0)
      * @param _reservedRangeLength - the amount of tokens to be reserved for preminting
+     * @param _to - the address to send the pre-minted vouchers to (contract address or contract owner)
      * @param _condition - the fully populated condition struct
      * @param _twin - the fully populated twin struct
      * @param _agentId - the id of agent
@@ -674,6 +689,7 @@ contract OrchestrationHandlerFacet1 is PausableBase, SellerBase, OfferBase, Grou
         OfferDurations calldata _offerDurations,
         uint256 _disputeResolverId,
         uint256 _reservedRangeLength,
+        address _to,
         Condition calldata _condition,
         Twin memory _twin,
         uint256 _agentId
@@ -687,7 +703,7 @@ contract OrchestrationHandlerFacet1 is PausableBase, SellerBase, OfferBase, Grou
             _twin,
             _agentId
         );
-        reserveRangeInternal(_offer.id, _reservedRangeLength);
+        reserveRangeInternal(_offer.id, _reservedRangeLength, _to);
     }
 
     /**
@@ -818,6 +834,7 @@ contract OrchestrationHandlerFacet1 is PausableBase, SellerBase, OfferBase, Grou
      * - When agent id is non zero:
      *   - If Agent does not exist
      *   - If the sum of agent fee amount and protocol fee amount is greater than the offer fee limit
+     * - _to is not the BosonVoucher contract address or the BosonVoucher contract owner
      *
      * @dev No reentrancy guard here since already implemented by called functions. If added here, they would clash.
      *
@@ -827,6 +844,7 @@ contract OrchestrationHandlerFacet1 is PausableBase, SellerBase, OfferBase, Grou
      * @param _offerDurations - the fully populated offer durations struct
      * @param _disputeResolverId - the id of chosen dispute resolver (can be 0)
      * @param _reservedRangeLength - the amount of tokens to be reserved for preminting
+     * @param _to - the address to send the pre-minted vouchers to (contract address or contract owner)
      * @param _condition - the fully populated condition struct
      * @param _authToken - optional AuthToken struct that specifies an AuthToken type and tokenId that the seller can use to do admin functions
      * @param _voucherInitValues - the fully populated BosonTypes.VoucherInitValues struct
@@ -839,6 +857,7 @@ contract OrchestrationHandlerFacet1 is PausableBase, SellerBase, OfferBase, Grou
         OfferDurations calldata _offerDurations,
         uint256 _disputeResolverId,
         uint256 _reservedRangeLength,
+        address _to,
         Condition calldata _condition,
         AuthToken calldata _authToken,
         VoucherInitValues calldata _voucherInitValues,
@@ -855,7 +874,7 @@ contract OrchestrationHandlerFacet1 is PausableBase, SellerBase, OfferBase, Grou
             _voucherInitValues,
             _agentId
         );
-        reserveRangeInternal(_offer.id, _reservedRangeLength);
+        reserveRangeInternal(_offer.id, _reservedRangeLength, _to);
     }
 
     /**
@@ -1002,6 +1021,7 @@ contract OrchestrationHandlerFacet1 is PausableBase, SellerBase, OfferBase, Grou
      * - When agent id is non zero:
      *   - If Agent does not exist
      *   - If the sum of agent fee amount and protocol fee amount is greater than the offer fee limit
+     * - _to is not the BosonVoucher contract address or the BosonVoucher contract owner
      *
      * @dev No reentrancy guard here since already implemented by called functions. If added here, they would clash.
      *
@@ -1011,6 +1031,7 @@ contract OrchestrationHandlerFacet1 is PausableBase, SellerBase, OfferBase, Grou
      * @param _offerDurations - the fully populated offer durations struct
      * @param _disputeResolverId - the id of chosen dispute resolver (can be 0)
      * @param _reservedRangeLength - the amount of tokens to be reserved for preminting
+     * @param _to - the address to send the pre-minted vouchers to (contract address or contract owner)
      * @param _twin - the fully populated twin struct
      * @param _authToken - optional AuthToken struct that specifies an AuthToken type and tokenId that the seller can use to do admin functions
      * @param _voucherInitValues - the fully populated BosonTypes.VoucherInitValues struct
@@ -1023,6 +1044,7 @@ contract OrchestrationHandlerFacet1 is PausableBase, SellerBase, OfferBase, Grou
         OfferDurations calldata _offerDurations,
         uint256 _disputeResolverId,
         uint256 _reservedRangeLength,
+        address _to,
         Twin memory _twin,
         AuthToken calldata _authToken,
         VoucherInitValues calldata _voucherInitValues,
@@ -1039,7 +1061,7 @@ contract OrchestrationHandlerFacet1 is PausableBase, SellerBase, OfferBase, Grou
             _voucherInitValues,
             _agentId
         );
-        reserveRangeInternal(_offer.id, _reservedRangeLength);
+        reserveRangeInternal(_offer.id, _reservedRangeLength, _to);
     }
 
     /**
@@ -1201,6 +1223,7 @@ contract OrchestrationHandlerFacet1 is PausableBase, SellerBase, OfferBase, Grou
      * - When agent id is non zero:
      *   - If Agent does not exist
      *   - If the sum of agent fee amount and protocol fee amount is greater than the offer fee limit
+     * - _to is not the BosonVoucher contract address or the BosonVoucher contract owner
      *
      * @dev No reentrancy guard here since already implemented by called functions. If added here, they would clash.
      *
@@ -1210,6 +1233,7 @@ contract OrchestrationHandlerFacet1 is PausableBase, SellerBase, OfferBase, Grou
      * @param _offerDurations - the fully populated offer durations struct
      * @param _disputeResolverId - the id of chosen dispute resolver (can be 0)
      * @param _reservedRangeLength - the amount of tokens to be reserved for preminting
+     * @param _to - the address to send the pre-minted vouchers to (contract address or contract owner)
      * @param _condition - the fully populated condition struct
      * @param _twin - the fully populated twin struct
      * @param _authToken - optional AuthToken struct that specifies an AuthToken type and tokenId that the seller can use to do admin functions
@@ -1223,6 +1247,7 @@ contract OrchestrationHandlerFacet1 is PausableBase, SellerBase, OfferBase, Grou
         OfferDurations calldata _offerDurations,
         uint256 _disputeResolverId,
         uint256 _reservedRangeLength,
+        address _to,
         Condition calldata _condition,
         Twin memory _twin,
         AuthToken calldata _authToken,
@@ -1241,7 +1266,7 @@ contract OrchestrationHandlerFacet1 is PausableBase, SellerBase, OfferBase, Grou
             _voucherInitValues,
             _agentId
         );
-        reserveRangeInternal(_offer.id, _reservedRangeLength);
+        reserveRangeInternal(_offer.id, _reservedRangeLength, _to);
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -20188,7 +20188,6 @@
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.5.tgz",
       "integrity": "sha512-HTm14iMQKK2FjFLRTM5lAVcyaUzOnqbPtesFIvREgXpJHdQm8bWS+GkQgIkfaBYRHuCnea7w8UVNfwiAQhlr9A==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -20501,7 +20500,6 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.7.tgz",
       "integrity": "sha512-vLt1O5Pp+flcArHGIyKEQq883nBt8nN8tVBcoL0qUXj2XT1n7p70yGIq2VK98I5FdZ1YHc0wk/koOnHjnXWk1Q==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@nomiclabs/hardhat-web3": "^2.0.0",
         "@openzeppelin/test-helpers": "^0.5.16",
         "chai": "^4.3.7",
+        "decache": "^4.6.1",
         "dotenv": "^16.0.3",
         "eip55": "^2.1.0",
         "eslint": "^8.32.0",
@@ -7102,6 +7103,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/callsite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -8135,6 +8145,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decache": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/decache/-/decache-4.6.1.tgz",
+      "integrity": "sha512-ohApBM8u9ygepJCjgBrEZSSxPjc0T/PJkD+uNyxXPkqudyUpdXpwJYp0VISm2WrPVzASU6DZyIi6BWdyw7uJ2Q==",
+      "dev": true,
+      "dependencies": {
+        "callsite": "^1.0.0"
       }
     },
     "node_modules/decamelize": {
@@ -37147,6 +37166,12 @@
         "caller-callsite": "^2.0.0"
       }
     },
+    "callsite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==",
+      "dev": true
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -37981,6 +38006,15 @@
       "dev": true,
       "requires": {
         "ms": "2.1.2"
+      }
+    },
+    "decache": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/decache/-/decache-4.6.1.tgz",
+      "integrity": "sha512-ohApBM8u9ygepJCjgBrEZSSxPjc0T/PJkD+uNyxXPkqudyUpdXpwJYp0VISm2WrPVzASU6DZyIi6BWdyw7uJ2Q==",
+      "dev": true,
+      "requires": {
+        "callsite": "^1.0.0"
       }
     },
     "decamelize": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@nomiclabs/hardhat-web3": "^2.0.0",
     "@openzeppelin/test-helpers": "^0.5.16",
     "chai": "^4.3.7",
+    "decache": "^4.6.1",
     "dotenv": "^16.0.3",
     "eip55": "^2.1.0",
     "eslint": "^8.32.0",

--- a/scripts/config/revert-reasons.js
+++ b/scripts/config/revert-reasons.js
@@ -140,6 +140,7 @@ exports.RevertReasons = {
   OFFER_STILL_VALID: "Offer still valid",
   NOTHING_TO_BURN: "Nothing to burn",
   NOT_COMMITTABLE: "Token not committable",
+  INVALID_TO_ADDRESS: "Tokens can only be pre-mined to the contract or contract owner address",
 
   // Funds related
   NATIVE_WRONG_ADDRESS: "Native token address must be 0",

--- a/scripts/domain/Range.js
+++ b/scripts/domain/Range.js
@@ -1,4 +1,4 @@
-const { bigNumberIsValid } = require("../util/validations.js");
+const { bigNumberIsValid, addressIsValid } = require("../util/validations.js");
 
 /**
  * Boson Client Entity: Range
@@ -12,14 +12,16 @@ class Range {
       uint256 length;
       uint256 minted;
       uint256 lastBurnedTokenId;
+      address owner;
       }
   */
 
-  constructor(start, length, minted, lastBurnedTokenId) {
+  constructor(start, length, minted, lastBurnedTokenId, owner) {
     this.start = start;
     this.length = length;
     this.minted = minted;
     this.lastBurnedTokenId = lastBurnedTokenId;
+    this.owner = owner;
   }
 
   /**
@@ -28,8 +30,8 @@ class Range {
    * @returns {Range}
    */
   static fromObject(o) {
-    const { start, length, minted, lastBurnedTokenId } = o;
-    return new Range(start, length, minted, lastBurnedTokenId);
+    const { start, length, minted, lastBurnedTokenId, owner } = o;
+    return new Range(start, length, minted, lastBurnedTokenId, owner);
   }
 
   /**
@@ -38,16 +40,15 @@ class Range {
    * @returns {*}
    */
   static fromStruct(struct) {
-    let start, length, minted, lastBurnedTokenId;
-
     // destructure struct
-    [start, length, minted, lastBurnedTokenId] = struct;
+    let [start, length, minted, lastBurnedTokenId, owner] = struct;
 
     return Range.fromObject({
       start: start.toString(),
       length: length.toString(),
       minted: minted.toString(),
       lastBurnedTokenId: lastBurnedTokenId.toString(),
+      owner,
     });
   }
 
@@ -72,7 +73,7 @@ class Range {
    * @returns {string}
    */
   toStruct() {
-    return [this.start, this.length, this.minted, this.lastBurnedTokenId];
+    return [this.start, this.length, this.minted, this.lastBurnedTokenId, this.owner];
   }
 
   /**
@@ -117,6 +118,15 @@ class Range {
    */
   lastBurnedTokenIdIsValid() {
     return bigNumberIsValid(this.lastBurnedTokenId, { optional: true });
+  }
+
+  /**
+   * Is this Range instance's assistant field valid?
+   * Must be a eip55 compliant Ethereum address
+   * @returns {boolean}
+   */
+  ownerIsValid() {
+    return addressIsValid(this.owner);
   }
 
   /**

--- a/test/protocol/ExchangeHandlerTest.js
+++ b/test/protocol/ExchangeHandlerTest.js
@@ -819,7 +819,7 @@ describe("IBosonExchangeHandler", function () {
       let tokenId;
       beforeEach(async function () {
         // Reserve range
-        await offerHandler.connect(assistant).reserveRange(offer.id, offer.quantityAvailable);
+        await offerHandler.connect(assistant).reserveRange(offer.id, offer.quantityAvailable, assistant.address);
 
         // expected address of the first clone
         const voucherCloneAddress = calculateContractAddress(accountHandler.address, "1");
@@ -945,7 +945,7 @@ describe("IBosonExchangeHandler", function () {
           .depositFunds(seller.id, ethers.constants.AddressZero, offer.sellerDeposit, { value: offer.sellerDeposit });
 
         // reserve half of the offer, so it's still possible to commit directly
-        await offerHandler.connect(assistant).reserveRange(offerId, rangeLength);
+        await offerHandler.connect(assistant).reserveRange(offerId, rangeLength, assistant.address);
 
         // Commit to offer directly
         expect(
@@ -1028,7 +1028,7 @@ describe("IBosonExchangeHandler", function () {
 
           // Reserve a range and premint vouchers
           tokenId = await exchangeHandler.getNextExchangeId();
-          await offerHandler.connect(assistant).reserveRange(offerId, "1");
+          await offerHandler.connect(assistant).reserveRange(offerId, "1", assistant.address);
           await bosonVoucher.connect(assistant).preMint(offerId, "1");
 
           // Attempt to commit to the not availabe offer, expecting revert

--- a/test/protocol/FundsHandlerTest.js
+++ b/test/protocol/FundsHandlerTest.js
@@ -1879,7 +1879,9 @@ describe("IBosonFundsHandler", function () {
         const sellersAvailableFundsBefore = FundsList.fromStruct(await fundsHandler.getAvailableFunds(seller.id));
 
         // reserve a range and premint vouchers
-        await offerHandler.connect(assistant).reserveRange(offerToken.id, offerToken.quantityAvailable);
+        await offerHandler
+          .connect(assistant)
+          .reserveRange(offerToken.id, offerToken.quantityAvailable, assistant.address);
         const voucherCloneAddress = calculateContractAddress(accountHandler.address, "1");
         const bosonVoucher = await ethers.getContractAt("BosonVoucher", voucherCloneAddress);
         await bosonVoucher.connect(assistant).preMint(offerToken.id, offerToken.quantityAvailable);
@@ -1920,7 +1922,9 @@ describe("IBosonFundsHandler", function () {
 
         // reserve a range and premint vouchers
         tokenId = await exchangeHandler.getNextExchangeId();
-        await offerHandler.connect(assistant).reserveRange(offerNative.id, offerNative.quantityAvailable);
+        await offerHandler
+          .connect(assistant)
+          .reserveRange(offerNative.id, offerNative.quantityAvailable, assistant.address);
         await bosonVoucher.connect(assistant).preMint(offerNative.id, offerNative.quantityAvailable);
 
         // commit to an offer via preminted voucher
@@ -2063,7 +2067,9 @@ describe("IBosonFundsHandler", function () {
 
         it("Seller'a availableFunds is less than the required sellerDeposit + price for preminted offer", async function () {
           // reserve a range and premint vouchers for offer in tokens
-          await offerHandler.connect(assistant).reserveRange(offerToken.id, offerToken.quantityAvailable);
+          await offerHandler
+            .connect(assistant)
+            .reserveRange(offerToken.id, offerToken.quantityAvailable, assistant.address);
           const voucherCloneAddress = calculateContractAddress(accountHandler.address, "1");
           const bosonVoucher = await ethers.getContractAt("BosonVoucher", voucherCloneAddress);
           await bosonVoucher.connect(assistant).preMint(offerToken.id, offerToken.quantityAvailable);
@@ -2079,7 +2085,9 @@ describe("IBosonFundsHandler", function () {
 
           // reserve a range and premint vouchers for offer in native currency
           tokenId = await exchangeHandler.getNextExchangeId();
-          await offerHandler.connect(assistant).reserveRange(offerNative.id, offerNative.quantityAvailable);
+          await offerHandler
+            .connect(assistant)
+            .reserveRange(offerNative.id, offerNative.quantityAvailable, assistant.address);
           await bosonVoucher.connect(assistant).preMint(offerNative.id, offerNative.quantityAvailable);
 
           // Attempt to commit to an offer, expecting revert

--- a/test/protocol/OfferHandlerTest.js
+++ b/test/protocol/OfferHandlerTest.js
@@ -1298,12 +1298,12 @@ describe("IBosonOfferHandler", function () {
         length = 100;
         firstTokenId = 1;
         lastTokenId = firstTokenId + length - 1;
-        range = new Range(firstTokenId.toString(), length.toString(), "0", "0");
+        range = new Range(firstTokenId.toString(), length.toString(), "0", "0", assistant.address);
       });
 
       it("should emit an RangeReserved event", async function () {
         // Reserve a range, testing for the event
-        const tx = await offerHandler.connect(assistant).reserveRange(id, length);
+        const tx = await offerHandler.connect(assistant).reserveRange(id, length, assistant.address);
 
         await expect(tx)
           .to.emit(offerHandler, "RangeReserved")
@@ -1319,7 +1319,7 @@ describe("IBosonOfferHandler", function () {
         const nextExchangeIdBefore = await exchangeHandler.getNextExchangeId();
 
         // Reserve a range
-        await offerHandler.connect(assistant).reserveRange(id, length);
+        await offerHandler.connect(assistant).reserveRange(id, length, assistant.address);
 
         // Quantity available should be updated
         [, offerStruct] = await offerHandler.connect(rando).getOffer(id);
@@ -1351,7 +1351,7 @@ describe("IBosonOfferHandler", function () {
         await exchangeHandler.connect(rando).commitToOffer(rando.address, id, { value: price });
 
         // Reserve a range, testing for the event
-        await expect(offerHandler.connect(assistant).reserveRange(id, length))
+        await expect(offerHandler.connect(assistant).reserveRange(id, length, assistant.address))
           .to.emit(offerHandler, "RangeReserved")
           .withArgs(id, offer.sellerId, firstTokenId + 2, lastTokenId + 2, assistant.address);
       });
@@ -1365,7 +1365,7 @@ describe("IBosonOfferHandler", function () {
 
         // Set maximum allowed length
         length = ethers.BigNumber.from(2).pow(128).sub(1);
-        await expect(offerHandler.connect(assistant).reserveRange(nextOfferId, length)).to.emit(
+        await expect(offerHandler.connect(assistant).reserveRange(nextOfferId, length, assistant.address)).to.emit(
           offerHandler,
           "RangeReserved"
         );
@@ -1383,7 +1383,7 @@ describe("IBosonOfferHandler", function () {
         const quantityAvailableBefore = offerStruct.quantityAvailable;
 
         // Reserve a range
-        await offerHandler.connect(assistant).reserveRange(nextOfferId, length);
+        await offerHandler.connect(assistant).reserveRange(nextOfferId, length, assistant.address);
 
         // Quantity available should not change
         [, offerStruct] = await offerHandler.connect(rando).getOffer(nextOfferId);
@@ -1395,13 +1395,57 @@ describe("IBosonOfferHandler", function () {
         );
       });
 
+      context("Owner range is contract", async function () {
+        beforeEach(async function () {
+          range.owner = bosonVoucher.address;
+        });
+
+        it("should emit an RangeReserved event", async function () {
+          // Reserve a range, testing for the event
+          const tx = await offerHandler.connect(assistant).reserveRange(id, length, bosonVoucher.address);
+
+          await expect(tx)
+            .to.emit(offerHandler, "RangeReserved")
+            .withArgs(id, offer.sellerId, firstTokenId, lastTokenId, assistant.address);
+
+          await expect(tx).to.emit(bosonVoucher, "RangeReserved").withArgs(id, range.toStruct());
+        });
+
+        it("should update state", async function () {
+          // Get the offer and nextExchangeId before reservation
+          [, offerStruct] = await offerHandler.connect(rando).getOffer(id);
+          const quantityAvailableBefore = offerStruct.quantityAvailable;
+          const nextExchangeIdBefore = await exchangeHandler.getNextExchangeId();
+
+          // Reserve a range
+          await offerHandler.connect(assistant).reserveRange(id, length, bosonVoucher.address);
+
+          // Quantity available should be updated
+          [, offerStruct] = await offerHandler.connect(rando).getOffer(id);
+          const quantityAvailableAfter = offerStruct.quantityAvailable;
+          assert.equal(
+            quantityAvailableBefore.sub(quantityAvailableAfter).toNumber(),
+            length,
+            "Quantity available mismatch"
+          );
+
+          // nextExchangeId should be updated
+          const nextExchangeIdAfter = await exchangeHandler.getNextExchangeId();
+          assert.equal(nextExchangeIdAfter.sub(nextExchangeIdBefore).toNumber(), length, "nextExchangeId mismatch");
+
+          // Get range object from the voucher contract
+          const returnedRange = Range.fromStruct(await bosonVoucher.getRangeByOfferId(id));
+          assert.equal(returnedRange.toString(), range.toString(), "Range mismatch");
+        });
+      });
+
       context("💔 Revert Reasons", async function () {
         it("The offers region of protocol is paused", async function () {
           // Pause the offers region of the protocol
           await pauseHandler.connect(pauser).pause([PausableRegion.Offers]);
 
           // Attempt to reserve a range, expecting revert
-          await expect(offerHandler.connect(assistant).reserveRange(id, length)).to.revertedWith(
+          await expect(offerHandler.connect(assistant).reserveRange(id, length, assistant.address)).to.revertedWith(
             RevertReasons.REGION_PAUSED
           );
         });
@@ -1411,7 +1455,7 @@ describe("IBosonOfferHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.Exchanges]);
 
           // Attempt to reserve a range, expecting revert
-          await expect(offerHandler.connect(assistant).reserveRange(id, length)).to.revertedWith(
+          await expect(offerHandler.connect(assistant).reserveRange(id, length, assistant.address)).to.revertedWith(
             RevertReasons.REGION_PAUSED
           );
         });
@@ -1421,7 +1465,7 @@ describe("IBosonOfferHandler", function () {
           id = "444";
 
           // Attempt to reserve a range, expecting revert
-          await expect(offerHandler.connect(assistant).reserveRange(id, length)).to.revertedWith(
+          await expect(offerHandler.connect(assistant).reserveRange(id, length, assistant.address)).to.revertedWith(
             RevertReasons.NO_SUCH_OFFER
           );
 
@@ -1429,7 +1473,7 @@ describe("IBosonOfferHandler", function () {
           id = "0";
 
           // Attempt to reserve a range, expecting revert
-          await expect(offerHandler.connect(assistant).reserveRange(id, length)).to.revertedWith(
+          await expect(offerHandler.connect(assistant).reserveRange(id, length, assistant.address)).to.revertedWith(
             RevertReasons.NO_SUCH_OFFER
           );
         });
@@ -1439,7 +1483,7 @@ describe("IBosonOfferHandler", function () {
           await offerHandler.connect(assistant).voidOffer(id);
 
           // Attempt to reserve a range, expecting revert
-          await expect(offerHandler.connect(assistant).reserveRange(id, length)).to.revertedWith(
+          await expect(offerHandler.connect(assistant).reserveRange(id, length, assistant.address)).to.revertedWith(
             RevertReasons.OFFER_HAS_BEEN_VOIDED
           );
         });
@@ -1447,7 +1491,7 @@ describe("IBosonOfferHandler", function () {
         it("Caller is not seller", async function () {
           // caller is not the assistant of any seller
           // Attempt to reserve a range, expecting revert
-          await expect(offerHandler.connect(rando).reserveRange(id, length)).to.revertedWith(
+          await expect(offerHandler.connect(rando).reserveRange(id, length, assistant.address)).to.revertedWith(
             RevertReasons.NOT_ASSISTANT
           );
 
@@ -1461,7 +1505,7 @@ describe("IBosonOfferHandler", function () {
           await accountHandler.connect(rando).createSeller(seller, emptyAuthToken, voucherInitValues);
 
           // Attempt to reserve a range, expecting revert
-          await expect(offerHandler.connect(rando).reserveRange(id, length)).to.revertedWith(
+          await expect(offerHandler.connect(rando).reserveRange(id, length, assistant.address)).to.revertedWith(
             RevertReasons.NOT_ASSISTANT
           );
         });
@@ -1471,7 +1515,7 @@ describe("IBosonOfferHandler", function () {
           length = 0;
 
           // Attempt to reserve a range, expecting revert
-          await expect(offerHandler.connect(assistant).reserveRange(id, length)).to.revertedWith(
+          await expect(offerHandler.connect(assistant).reserveRange(id, length, assistant.address)).to.revertedWith(
             RevertReasons.INVALID_RANGE_LENGTH
           );
         });
@@ -1481,7 +1525,7 @@ describe("IBosonOfferHandler", function () {
           length = Number(offer.quantityAvailable) + 1;
 
           // Attempt to reserve a range, expecting revert
-          await expect(offerHandler.connect(assistant).reserveRange(id, length)).to.revertedWith(
+          await expect(offerHandler.connect(assistant).reserveRange(id, length, assistant.address)).to.revertedWith(
             RevertReasons.INVALID_RANGE_LENGTH
           );
         });
@@ -1497,18 +1541,25 @@ describe("IBosonOfferHandler", function () {
           length = ethers.BigNumber.from(2).pow(128);
 
           // Attempt to reserve a range, expecting revert
-          await expect(offerHandler.connect(assistant).reserveRange(nextOfferId, length)).to.revertedWith(
-            RevertReasons.INVALID_RANGE_LENGTH
-          );
+          await expect(
+            offerHandler.connect(assistant).reserveRange(nextOfferId, length, assistant.address)
+          ).to.revertedWith(RevertReasons.INVALID_RANGE_LENGTH);
         });
 
         it("Call to BosonVoucher.reserveRange() reverts", async function () {
           // Reserve a range
-          await offerHandler.connect(assistant).reserveRange(id, length);
+          await offerHandler.connect(assistant).reserveRange(id, length, assistant.address);
 
           // Attempt to reserve the same range again, expecting revert
-          await expect(offerHandler.connect(assistant).reserveRange(id, length)).to.revertedWith(
+          await expect(offerHandler.connect(assistant).reserveRange(id, length, assistant.address)).to.revertedWith(
             RevertReasons.OFFER_RANGE_ALREADY_RESERVED
+          );
+        });
+
+        it("_to address isn't contract address or contract owner address", async function () {
+          // Try to reserve range for rando address, it should fail
+          await expect(offerHandler.connect(assistant).reserveRange(id, length, rando.address)).to.be.revertedWith(
+            RevertReasons.INVALID_TO_ADDRESS
           );
         });
       });

--- a/test/protocol/OfferHandlerTest.js
+++ b/test/protocol/OfferHandlerTest.js
@@ -1307,7 +1307,7 @@ describe("IBosonOfferHandler", function () {
 
         await expect(tx)
           .to.emit(offerHandler, "RangeReserved")
-          .withArgs(id, offer.sellerId, firstTokenId, lastTokenId, assistant.address);
+          .withArgs(id, offer.sellerId, firstTokenId, lastTokenId, assistant.address, assistant.address);
 
         await expect(tx).to.emit(bosonVoucher, "RangeReserved").withArgs(id, range.toStruct());
       });
@@ -1353,7 +1353,7 @@ describe("IBosonOfferHandler", function () {
         // Reserve a range, testing for the event
         await expect(offerHandler.connect(assistant).reserveRange(id, length, assistant.address))
           .to.emit(offerHandler, "RangeReserved")
-          .withArgs(id, offer.sellerId, firstTokenId + 2, lastTokenId + 2, assistant.address);
+          .withArgs(id, offer.sellerId, firstTokenId + 2, lastTokenId + 2, assistant.address, assistant.address);
       });
 
       it("It's possible to reserve a range with maximum allowed length", async function () {
@@ -1406,7 +1406,7 @@ describe("IBosonOfferHandler", function () {
 
           await expect(tx)
             .to.emit(offerHandler, "RangeReserved")
-            .withArgs(id, offer.sellerId, firstTokenId, lastTokenId, assistant.address);
+            .withArgs(id, offer.sellerId, firstTokenId, lastTokenId, bosonVoucher.address, assistant.address);
 
           await expect(tx).to.emit(bosonVoucher, "RangeReserved").withArgs(id, range.toStruct());
         });

--- a/test/protocol/OrchestrationHandlerTest.js
+++ b/test/protocol/OrchestrationHandlerTest.js
@@ -1234,7 +1234,7 @@ describe("IBosonOrchestrationHandler", function () {
           offerStruct = offer.toStruct();
           firstTokenId = 1;
           lastTokenId = firstTokenId + reservedRangeLength - 1;
-          range = new Range(firstTokenId.toString(), reservedRangeLength.toString(), "0", "0");
+          range = new Range(firstTokenId.toString(), reservedRangeLength.toString(), "0", "0", assistant.address);
         });
 
         it("should emit a SellerCreated, OfferCreated and RangeReserved events with auth token", async function () {
@@ -1251,6 +1251,7 @@ describe("IBosonOrchestrationHandler", function () {
               offerDurations,
               disputeResolver.id,
               reservedRangeLength,
+              assistant.address,
               authToken,
               voucherInitValues,
               agentId
@@ -1278,7 +1279,7 @@ describe("IBosonOrchestrationHandler", function () {
 
           await expect(tx)
             .to.emit(orchestrationHandler, "RangeReserved")
-            .withArgs(nextOfferId, offer.sellerId, firstTokenId, lastTokenId, assistant.address);
+            .withArgs(nextOfferId, offer.sellerId, firstTokenId, lastTokenId, assistant.address, assistant.address);
 
           // Voucher clone contract
           bosonVoucher = await ethers.getContractAt("IBosonVoucher", expectedCloneAddress);
@@ -1311,6 +1312,7 @@ describe("IBosonOrchestrationHandler", function () {
               offerDurations,
               disputeResolver.id,
               reservedRangeLength,
+              assistant.address,
               authToken,
               voucherInitValues,
               agentId
@@ -1458,6 +1460,7 @@ describe("IBosonOrchestrationHandler", function () {
                 offerDurations,
                 disputeResolver.id,
                 reservedRangeLength,
+                assistant.address,
                 emptyAuthToken,
                 voucherInitValues,
                 agentId
@@ -2081,6 +2084,7 @@ describe("IBosonOrchestrationHandler", function () {
                 offerDurations,
                 disputeResolver.id,
                 reservedRangeLength,
+                assistant.address,
                 emptyAuthToken,
                 voucherInitValues,
                 agentId
@@ -2103,6 +2107,7 @@ describe("IBosonOrchestrationHandler", function () {
                 offerDurations,
                 disputeResolver.id,
                 reservedRangeLength,
+                assistant.address,
                 emptyAuthToken,
                 voucherInitValues,
                 agentId
@@ -2125,6 +2130,7 @@ describe("IBosonOrchestrationHandler", function () {
                 offerDurations,
                 disputeResolver.id,
                 reservedRangeLength,
+                assistant.address,
                 emptyAuthToken,
                 voucherInitValues,
                 agentId
@@ -2655,11 +2661,12 @@ describe("IBosonOrchestrationHandler", function () {
           offerStruct = offer.toStruct();
           firstTokenId = 1;
           lastTokenId = firstTokenId + reservedRangeLength - 1;
-          range = new Range(firstTokenId.toString(), reservedRangeLength.toString(), "0", "0");
 
           // Voucher clone contract
           expectedCloneAddress = calculateContractAddress(orchestrationHandler.address, "1");
           bosonVoucher = await ethers.getContractAt("IBosonVoucher", expectedCloneAddress);
+
+          range = new Range(firstTokenId.toString(), reservedRangeLength.toString(), "0", "0", bosonVoucher.address);
         });
 
         it("should emit an OfferCreated, a GroupCreated and a RangeReserved events", async function () {
@@ -2673,6 +2680,7 @@ describe("IBosonOrchestrationHandler", function () {
               offerDurations,
               disputeResolver.id,
               reservedRangeLength,
+              bosonVoucher.address,
               condition,
               agentId
             );
@@ -2695,7 +2703,7 @@ describe("IBosonOrchestrationHandler", function () {
           // RangeReserved event (on protocol contract)
           await expect(tx)
             .to.emit(orchestrationHandler, "RangeReserved")
-            .withArgs(nextOfferId, offer.sellerId, firstTokenId, lastTokenId, assistant.address);
+            .withArgs(nextOfferId, offer.sellerId, firstTokenId, lastTokenId, bosonVoucher.address, assistant.address);
 
           // Events with structs that contain arrays must be tested differently
           const txReceipt = await tx.wait();
@@ -2725,6 +2733,7 @@ describe("IBosonOrchestrationHandler", function () {
               offerDurations,
               disputeResolver.id,
               reservedRangeLength,
+              bosonVoucher.address,
               condition,
               agentId
             );
@@ -2833,6 +2842,7 @@ describe("IBosonOrchestrationHandler", function () {
                 offerDurations,
                 disputeResolver.id,
                 reservedRangeLength,
+                bosonVoucher.address,
                 condition,
                 agentId
               )
@@ -3339,7 +3349,7 @@ describe("IBosonOrchestrationHandler", function () {
           offerStruct = offer.toStruct();
           firstTokenId = 1;
           lastTokenId = firstTokenId + reservedRangeLength - 1;
-          range = new Range(firstTokenId.toString(), reservedRangeLength.toString(), "0", "0");
+          range = new Range(firstTokenId.toString(), reservedRangeLength.toString(), "0", "0", assistant.address);
 
           // Voucher clone contract
           expectedCloneAddress = calculateContractAddress(orchestrationHandler.address, "1");
@@ -3356,6 +3366,7 @@ describe("IBosonOrchestrationHandler", function () {
               offerDurations,
               disputeResolver.id,
               reservedRangeLength,
+              assistant.address,
               nextGroupId,
               agentId
             );
@@ -3378,7 +3389,7 @@ describe("IBosonOrchestrationHandler", function () {
           // RangeReserved event (on protocol contract)
           await expect(tx)
             .to.emit(orchestrationHandler, "RangeReserved")
-            .withArgs(nextOfferId, offer.sellerId, firstTokenId, lastTokenId, assistant.address);
+            .withArgs(nextOfferId, offer.sellerId, firstTokenId, lastTokenId, assistant.address, assistant.address);
 
           // Events with structs that contain arrays must be tested differently
           const txReceipt = await tx.wait();
@@ -3407,6 +3418,7 @@ describe("IBosonOrchestrationHandler", function () {
               offerDurations,
               disputeResolver.id,
               reservedRangeLength,
+              assistant.address,
               nextGroupId,
               agentId
             );
@@ -3506,6 +3518,7 @@ describe("IBosonOrchestrationHandler", function () {
                 offerDurations,
                 disputeResolver.id,
                 reservedRangeLength,
+                assistant.address,
                 nextGroupId,
                 agentId
               )
@@ -4016,11 +4029,12 @@ describe("IBosonOrchestrationHandler", function () {
           offerStruct = offer.toStruct();
           firstTokenId = 1;
           lastTokenId = firstTokenId + reservedRangeLength - 1;
-          range = new Range(firstTokenId.toString(), reservedRangeLength.toString(), "0", "0");
 
           // Voucher clone contract
           expectedCloneAddress = calculateContractAddress(orchestrationHandler.address, "1");
           bosonVoucher = await ethers.getContractAt("IBosonVoucher", expectedCloneAddress);
+
+          range = new Range(firstTokenId.toString(), reservedRangeLength.toString(), "0", "0", bosonVoucher.address);
         });
 
         it("should emit an OfferCreated, a TwinCreated, a BundleCreated and a RangeReserved events", async function () {
@@ -4033,6 +4047,7 @@ describe("IBosonOrchestrationHandler", function () {
               offerDurations,
               disputeResolver.id,
               reservedRangeLength,
+              bosonVoucher.address,
               twin,
               agentId
             );
@@ -4055,7 +4070,7 @@ describe("IBosonOrchestrationHandler", function () {
           // RangeReserved event (on protocol contract)
           await expect(tx)
             .to.emit(orchestrationHandler, "RangeReserved")
-            .withArgs(nextOfferId, offer.sellerId, firstTokenId, lastTokenId, assistant.address);
+            .withArgs(nextOfferId, offer.sellerId, firstTokenId, lastTokenId, bosonVoucher.address, assistant.address);
 
           // Events with structs that contain arrays must be tested differently
           const txReceipt = await tx.wait();
@@ -4094,6 +4109,7 @@ describe("IBosonOrchestrationHandler", function () {
               offerDurations,
               disputeResolver.id,
               reservedRangeLength,
+              bosonVoucher.address,
               twin,
               agentId
             );
@@ -4220,6 +4236,7 @@ describe("IBosonOrchestrationHandler", function () {
                 offerDurations,
                 disputeResolver.id,
                 reservedRangeLength,
+                bosonVoucher.address,
                 twin,
                 agentId
               )
@@ -4919,7 +4936,7 @@ describe("IBosonOrchestrationHandler", function () {
           offerStruct = offer.toStruct();
           firstTokenId = 1;
           lastTokenId = firstTokenId + reservedRangeLength - 1;
-          range = new Range(firstTokenId.toString(), reservedRangeLength.toString(), "0", "0");
+          range = new Range(firstTokenId.toString(), reservedRangeLength.toString(), "0", "0", assistant.address);
 
           // Voucher clone contract
           expectedCloneAddress = calculateContractAddress(orchestrationHandler.address, "1");
@@ -4936,6 +4953,7 @@ describe("IBosonOrchestrationHandler", function () {
               offerDurations,
               disputeResolver.id,
               reservedRangeLength,
+              assistant.address,
               condition,
               twin,
               agentId
@@ -4959,7 +4977,7 @@ describe("IBosonOrchestrationHandler", function () {
           // RangeReserved event (on protocol contract)
           await expect(tx)
             .to.emit(orchestrationHandler, "RangeReserved")
-            .withArgs(nextOfferId, offer.sellerId, firstTokenId, lastTokenId, assistant.address);
+            .withArgs(nextOfferId, offer.sellerId, firstTokenId, lastTokenId, assistant.address, assistant.address);
 
           // Events with structs that contain arrays must be tested differently
           const txReceipt = await tx.wait();
@@ -5008,6 +5026,7 @@ describe("IBosonOrchestrationHandler", function () {
               offerDurations,
               disputeResolver.id,
               reservedRangeLength,
+              assistant.address,
               condition,
               twin,
               agentId
@@ -5206,6 +5225,7 @@ describe("IBosonOrchestrationHandler", function () {
                 offerDurations,
                 disputeResolver.id,
                 reservedRangeLength,
+                assistant.address,
                 condition,
                 twin,
                 agentId
@@ -5633,7 +5653,7 @@ describe("IBosonOrchestrationHandler", function () {
           offerStruct = offer.toStruct();
           firstTokenId = 1;
           lastTokenId = firstTokenId + reservedRangeLength - 1;
-          range = new Range(firstTokenId.toString(), reservedRangeLength.toString(), "0", "0");
+          range = new Range(firstTokenId.toString(), reservedRangeLength.toString(), "0", "0", assistant.address);
         });
 
         it("should emit a SellerCreated, an OfferCreated, a GroupCreated and a RangeReserved event", async function () {
@@ -5647,6 +5667,7 @@ describe("IBosonOrchestrationHandler", function () {
               offerDurations,
               disputeResolver.id,
               reservedRangeLength,
+              assistant.address,
               condition,
               emptyAuthToken,
               voucherInitValues,
@@ -5676,7 +5697,7 @@ describe("IBosonOrchestrationHandler", function () {
 
           await expect(tx)
             .to.emit(orchestrationHandler, "RangeReserved")
-            .withArgs(nextOfferId, offer.sellerId, firstTokenId, lastTokenId, assistant.address);
+            .withArgs(nextOfferId, offer.sellerId, firstTokenId, lastTokenId, assistant.address, assistant.address);
 
           // Events with structs that contain arrays must be tested differently
           const txReceipt = await tx.wait();
@@ -5719,6 +5740,7 @@ describe("IBosonOrchestrationHandler", function () {
               offerDurations,
               disputeResolver.id,
               reservedRangeLength,
+              assistant.address,
               condition,
               emptyAuthToken,
               voucherInitValues,
@@ -5911,6 +5933,7 @@ describe("IBosonOrchestrationHandler", function () {
                 offerDurations,
                 disputeResolver.id,
                 reservedRangeLength,
+                assistant.address,
                 condition,
                 emptyAuthToken,
                 voucherInitValues,
@@ -6407,7 +6430,7 @@ describe("IBosonOrchestrationHandler", function () {
           offerStruct = offer.toStruct();
           firstTokenId = 1;
           lastTokenId = firstTokenId + reservedRangeLength - 1;
-          range = new Range(firstTokenId.toString(), reservedRangeLength.toString(), "0", "0");
+          range = new Range(firstTokenId.toString(), reservedRangeLength.toString(), "0", "0", assistant.address);
         });
 
         it("should emit a SellerCreated, an OfferCreated, a TwinCreated, a BundleCreated and RangeReserved event", async function () {
@@ -6424,6 +6447,7 @@ describe("IBosonOrchestrationHandler", function () {
               offerDurations,
               disputeResolver.id,
               reservedRangeLength,
+              assistant.address,
               twin,
               emptyAuthToken,
               voucherInitValues,
@@ -6453,7 +6477,7 @@ describe("IBosonOrchestrationHandler", function () {
 
           await expect(tx)
             .to.emit(orchestrationHandler, "RangeReserved")
-            .withArgs(nextOfferId, offer.sellerId, firstTokenId, lastTokenId, assistant.address);
+            .withArgs(nextOfferId, offer.sellerId, firstTokenId, lastTokenId, assistant.address, assistant.address);
 
           // Events with structs that contain arrays must be tested differently
           const txReceipt = await tx.wait();
@@ -6511,6 +6535,7 @@ describe("IBosonOrchestrationHandler", function () {
               offerDurations,
               disputeResolver.id,
               reservedRangeLength,
+              assistant.address,
               twin,
               emptyAuthToken,
               voucherInitValues,
@@ -6731,6 +6756,7 @@ describe("IBosonOrchestrationHandler", function () {
                 offerDurations,
                 disputeResolver.id,
                 reservedRangeLength,
+                assistant.address,
                 twin,
                 emptyAuthToken,
                 voucherInitValues,
@@ -7304,7 +7330,7 @@ describe("IBosonOrchestrationHandler", function () {
           offerStruct = offer.toStruct();
           firstTokenId = 1;
           lastTokenId = firstTokenId + reservedRangeLength - 1;
-          range = new Range(firstTokenId.toString(), reservedRangeLength.toString(), "0", "0");
+          range = new Range(firstTokenId.toString(), reservedRangeLength.toString(), "0", "0", assistant.address);
         });
 
         it("should emit a SellerCreated, an OfferCreated, a GroupCreated, a TwinCreated, a BundleCreated and a RangeReserved event", async function () {
@@ -7321,6 +7347,7 @@ describe("IBosonOrchestrationHandler", function () {
               offerDurations,
               disputeResolver.id,
               reservedRangeLength,
+              assistant.address,
               condition,
               twin,
               emptyAuthToken,
@@ -7351,7 +7378,7 @@ describe("IBosonOrchestrationHandler", function () {
 
           await expect(tx)
             .to.emit(orchestrationHandler, "RangeReserved")
-            .withArgs(nextOfferId, offer.sellerId, firstTokenId, lastTokenId, assistant.address);
+            .withArgs(nextOfferId, offer.sellerId, firstTokenId, lastTokenId, assistant.address, assistant.address);
 
           // Events with structs that contain arrays must be tested differently
           const txReceipt = await tx.wait();
@@ -7417,6 +7444,7 @@ describe("IBosonOrchestrationHandler", function () {
               offerDurations,
               disputeResolver.id,
               reservedRangeLength,
+              assistant.address,
               condition,
               twin,
               emptyAuthToken,
@@ -7685,6 +7713,7 @@ describe("IBosonOrchestrationHandler", function () {
                 offerDurations,
                 disputeResolver.id,
                 reservedRangeLength,
+                bosonVoucher.address,
                 condition,
                 twin,
                 emptyAuthToken,

--- a/test/protocol/clients/BosonVoucherTest.js
+++ b/test/protocol/clients/BosonVoucherTest.js
@@ -35,7 +35,7 @@ const { waffle } = hre;
 const { deployMockContract } = waffle;
 const FormatTypes = ethers.utils.FormatTypes;
 
-describe("IBosonVoucher", function() {
+describe("IBosonVoucher", function () {
   let interfaceIds;
   let protocolDiamond, accessController;
   let bosonVoucher, offerHandler, accountHandler, exchangeHandler, fundsHandler, configHandler;
@@ -62,13 +62,13 @@ describe("IBosonVoucher", function() {
   let voucherInitValues, contractURI, royaltyPercentage, exchangeId, offerPrice;
   let forwarder;
 
-  before(async function() {
+  before(async function () {
     // Get interface id
     const { IBosonVoucher, IERC721, IERC2981 } = await getInterfaceIds();
     interfaceIds = { IBosonVoucher, IERC721, IERC2981 };
   });
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     // Set signers (fake protocol address to test issue and burn voucher without protocol dependencie)
     [deployer, protocol, buyer, rando, rando2, admin, treasury, adminDR, treasuryDR, protocolTreasury, bosonToken] =
       await ethers.getSigners();
@@ -173,9 +173,9 @@ describe("IBosonVoucher", function() {
   });
 
   // Interface support
-  context("📋 Interfaces", async function() {
-    context("👉 supportsInterface()", async function() {
-      it("should indicate support for IBosonVoucher, IERC721 and IERC2981 interface", async function() {
+  context("📋 Interfaces", async function () {
+    context("👉 supportsInterface()", async function () {
+      it("should indicate support for IBosonVoucher, IERC721 and IERC2981 interface", async function () {
         // IBosonVoucher interface
         let support = await bosonVoucher.supportsInterface(interfaceIds["IBosonVoucher"]);
         expect(support, "IBosonVoucher interface not supported").is.true;
@@ -191,21 +191,21 @@ describe("IBosonVoucher", function() {
     });
   });
 
-  context("issueVoucher()", function() {
+  context("issueVoucher()", function () {
     let buyerStruct;
     let buyerWallet;
 
-    before(function() {
+    before(function () {
       buyerStruct = mockBuyer(buyer.address).toStruct();
       buyerWallet = buyerStruct[1];
     });
 
-    after(async function() {
+    after(async function () {
       // Reset the accountId iterator
       accountId.next(true);
     });
 
-    it("should issue a voucher with success", async function() {
+    it("should issue a voucher with success", async function () {
       const balanceBefore = await bosonVoucher.balanceOf(buyer.address);
       await bosonVoucher.connect(protocol).issueVoucher(0, buyerWallet);
 
@@ -214,8 +214,8 @@ describe("IBosonVoucher", function() {
       expect(balanceAfter.sub(balanceBefore)).eq(1);
     });
 
-    context("💔 Revert Reasons", async function() {
-      it("should revert if caller does not have PROTOCOL role", async function() {
+    context("💔 Revert Reasons", async function () {
+      it("should revert if caller does not have PROTOCOL role", async function () {
         // Expect revert if random user attempts to issue voucher
         await expect(bosonVoucher.connect(rando).issueVoucher(0, buyerWallet)).to.be.revertedWith(
           RevertReasons.ACCESS_DENIED
@@ -232,7 +232,7 @@ describe("IBosonVoucher", function() {
         expect(balanceAfter.sub(balanceBefore)).eq(1);
       });
 
-      it("issueVoucher should revert if exchange id falls within a pre-minted offer's range", async function() {
+      it("issueVoucher should revert if exchange id falls within a pre-minted offer's range", async function () {
         const offerId = "5";
         const start = "10";
         const length = "123";
@@ -255,11 +255,11 @@ describe("IBosonVoucher", function() {
     });
   });
 
-  context("reserveRange()", function() {
+  context("reserveRange()", function () {
     let offerId, start, length;
     let range;
 
-    beforeEach(async function() {
+    beforeEach(async function () {
       offerId = "5";
       start = "10";
       length = "123";
@@ -267,14 +267,14 @@ describe("IBosonVoucher", function() {
       range = new Range(start, length, "0", "0", assistant.address);
     });
 
-    it("Should emit event RangeReserved", async function() {
+    it("Should emit event RangeReserved", async function () {
       // Reserve range, test for event
       await expect(bosonVoucher.connect(protocol).reserveRange(offerId, start, length, assistant.address))
         .to.emit(bosonVoucher, "RangeReserved")
         .withArgs(offerId, range.toStruct());
     });
 
-    it("Should update state", async function() {
+    it("Should update state", async function () {
       // Reserve range
       await bosonVoucher.connect(protocol).reserveRange(offerId, start, length, assistant.address);
 
@@ -301,19 +301,19 @@ describe("IBosonVoucher", function() {
       assert.equal(availablePremints.toString(), length, "Available Premints mismatch");
     });
 
-    context("Owner range is contract", async function() {
-      beforeEach(async function() {
+    context("Owner range is contract", async function () {
+      beforeEach(async function () {
         range.owner = bosonVoucher.address;
       });
 
-      it("Should emit event RangeReserved", async function() {
+      it("Should emit event RangeReserved", async function () {
         // Reserve range, test for event
         await expect(bosonVoucher.connect(protocol).reserveRange(offerId, start, length, bosonVoucher.address))
           .to.emit(bosonVoucher, "RangeReserved")
           .withArgs(offerId, range.toStruct());
       });
 
-      it("Should update state", async function() {
+      it("Should update state", async function () {
         // Reserve range
         await bosonVoucher.connect(protocol).reserveRange(offerId, start, length, bosonVoucher.address);
 
@@ -341,14 +341,14 @@ describe("IBosonVoucher", function() {
       });
     });
 
-    context("💔 Revert Reasons", async function() {
-      it("caller does not have PROTOCOL role", async function() {
+    context("💔 Revert Reasons", async function () {
+      it("caller does not have PROTOCOL role", async function () {
         await expect(
           bosonVoucher.connect(rando).reserveRange(offerId, start, length, assistant.address)
         ).to.be.revertedWith(RevertReasons.ACCESS_DENIED);
       });
 
-      it("Start id is not greater than zero for the first range", async function() {
+      it("Start id is not greater than zero for the first range", async function () {
         // Set start id to 0
         start = 0;
 
@@ -358,7 +358,7 @@ describe("IBosonVoucher", function() {
         ).to.be.revertedWith(RevertReasons.INVALID_RANGE_START);
       });
 
-      it("Start id is not greater than the end id of the previous range for subsequent ranges", async function() {
+      it("Start id is not greater than the end id of the previous range for subsequent ranges", async function () {
         // Reserver a range
         await bosonVoucher.connect(protocol).reserveRange(offerId, start, length, assistant.address);
 
@@ -371,7 +371,7 @@ describe("IBosonVoucher", function() {
         ).to.be.revertedWith(RevertReasons.INVALID_RANGE_START);
       });
 
-      it("Range length is zero", async function() {
+      it("Range length is zero", async function () {
         // Set length to 0
         length = "0";
 
@@ -381,7 +381,7 @@ describe("IBosonVoucher", function() {
         ).to.be.revertedWith(RevertReasons.INVALID_RANGE_LENGTH);
       });
 
-      it("Range length is too large, i.e., would cause an overflow", async function() {
+      it("Range length is too large, i.e., would cause an overflow", async function () {
         // Set such numbers that would cause an overflow
         start = ethers.constants.MaxUint256.div(2).add(2);
         length = ethers.constants.MaxUint256.div(2);
@@ -392,7 +392,7 @@ describe("IBosonVoucher", function() {
         ).to.be.revertedWith(RevertReasons.INVALID_RANGE_LENGTH);
       });
 
-      it("Offer id is already associated with a range", async function() {
+      it("Offer id is already associated with a range", async function () {
         // Reserve range for an offer
         await bosonVoucher.connect(protocol).reserveRange(offerId, start, length, assistant.address);
 
@@ -404,7 +404,7 @@ describe("IBosonVoucher", function() {
         ).to.be.revertedWith(RevertReasons.OFFER_RANGE_ALREADY_RESERVED);
       });
 
-      it("_to address isn't contract address or contract owner address", async function() {
+      it("_to address isn't contract address or contract owner address", async function () {
         // Try to reserve range for rando address, it should fail
         await expect(
           bosonVoucher.connect(protocol).reserveRange(offerId, start, length, rando.address)
@@ -413,12 +413,12 @@ describe("IBosonVoucher", function() {
     });
   });
 
-  context("preMint()", function() {
+  context("preMint()", function () {
     let offerId, start, length, amount;
     let mockProtocol;
     let offer, offerDates, offerDurations, offerFees, disputeResolutionTerms;
 
-    beforeEach(async function() {
+    beforeEach(async function () {
       mockProtocol = await deployMockProtocol();
       ({ offer, offerDates, offerDurations, offerFees } = await mockOffer());
       disputeResolutionTerms = new DisputeResolutionTerms("0", "0", "0", "0");
@@ -442,7 +442,7 @@ describe("IBosonVoucher", function() {
       amount = 50;
     });
 
-    it("Should emit Transfer events", async function() {
+    it("Should emit Transfer events", async function () {
       // Premint tokens, test for event
       const tx = await bosonVoucher.connect(assistant).preMint(offerId, amount);
 
@@ -454,8 +454,8 @@ describe("IBosonVoucher", function() {
       }
     });
 
-    context("Owner range is contract", async function() {
-      beforeEach(async function() {
+    context("Owner range is contract", async function () {
+      beforeEach(async function () {
         offer.id = offerId = ++offerId;
         await mockProtocol.mock.getOffer.returns(
           true,
@@ -472,7 +472,7 @@ describe("IBosonVoucher", function() {
         await bosonVoucher.connect(protocol).reserveRange(offerId, start, length, bosonVoucher.address);
       });
 
-      it("Transfer event should emit contract address", async function() {
+      it("Transfer event should emit contract address", async function () {
         // Premint tokens, test for event
         const tx = await bosonVoucher.connect(assistant).preMint(offerId, amount);
 
@@ -484,7 +484,7 @@ describe("IBosonVoucher", function() {
         }
       });
 
-      it("Should update state", async function() {
+      it("Should update state", async function () {
         let contractBalanceBefore = await bosonVoucher.balanceOf(bosonVoucher.address);
 
         // Premint tokens
@@ -512,7 +512,7 @@ describe("IBosonVoucher", function() {
       });
     });
 
-    it("Should update state", async function() {
+    it("Should update state", async function () {
       let sellerBalanceBefore = await bosonVoucher.balanceOf(assistant.address);
 
       // Premint tokens
@@ -539,7 +539,7 @@ describe("IBosonVoucher", function() {
       assert.equal(availablePremints.toNumber(), Number(length) - Number(amount), "Available Premints mismatch");
     });
 
-    it("MetaTx: forwarder can execute preMint on behalf of seller", async function() {
+    it("MetaTx: forwarder can execute preMint on behalf of seller", async function () {
       const nonce = Number(await forwarder.getNonce(assistant.address));
 
       const types = {
@@ -581,14 +581,14 @@ describe("IBosonVoucher", function() {
       }
     });
 
-    context("💔 Revert Reasons", async function() {
-      it("Caller is not the owner", async function() {
+    context("💔 Revert Reasons", async function () {
+      it("Caller is not the owner", async function () {
         await expect(bosonVoucher.connect(rando).preMint(offerId, amount)).to.be.revertedWith(
           RevertReasons.OWNABLE_NOT_OWNER
         );
       });
 
-      it("Offer id is not associated with a range", async function() {
+      it("Offer id is not associated with a range", async function () {
         // Set invalid offer id
         offerId = 15;
 
@@ -598,7 +598,7 @@ describe("IBosonVoucher", function() {
         );
       });
 
-      it("Amount to mint is more than remaining un-minted in range", async function() {
+      it("Amount to mint is more than remaining un-minted in range", async function () {
         // Mint 50 tokens
         await bosonVoucher.connect(assistant).preMint(offerId, amount);
 
@@ -611,7 +611,7 @@ describe("IBosonVoucher", function() {
         );
       });
 
-      it("Too many to mint in a single transaction", async function() {
+      it("Too many to mint in a single transaction", async function () {
         await mockProtocol.mock.getMaxPremintedVouchers.returns("100");
 
         // Set invalid amount
@@ -623,7 +623,7 @@ describe("IBosonVoucher", function() {
         );
       });
 
-      it("Offer already expired", async function() {
+      it("Offer already expired", async function () {
         // Skip to after offer expiration
         await setNextBlockTimestamp(ethers.BigNumber.from(offerDates.validUntil).add(1).toHexString());
 
@@ -633,7 +633,7 @@ describe("IBosonVoucher", function() {
         );
       });
 
-      it("Offer is voided", async function() {
+      it("Offer is voided", async function () {
         // Make offer voided
         offer.voided = true;
         await mockProtocol.mock.getOffer.returns(
@@ -653,13 +653,13 @@ describe("IBosonVoucher", function() {
     });
   });
 
-  context("burnPremintedVouchers()", function() {
+  context("burnPremintedVouchers()", function () {
     let offerId, start, length, amount;
     let mockProtocol;
     let offer, offerDates, offerDurations, offerFees, disputeResolutionTerms;
     let maxPremintedVouchers;
 
-    beforeEach(async function() {
+    beforeEach(async function () {
       offerId = "5";
       maxPremintedVouchers = "10";
 
@@ -687,7 +687,7 @@ describe("IBosonVoucher", function() {
         .returns(true, offer, offerDates, offerDurations, disputeResolutionTerms, offerFees);
     });
 
-    it("Should emit Transfer events", async function() {
+    it("Should emit Transfer events", async function () {
       // Burn tokens, test for event
       const tx = await bosonVoucher.connect(assistant).burnPremintedVouchers(offerId);
 
@@ -702,7 +702,7 @@ describe("IBosonVoucher", function() {
       }
     });
 
-    it("Should update state", async function() {
+    it("Should update state", async function () {
       let sellerBalanceBefore = await bosonVoucher.balanceOf(assistant.address);
 
       // Burn tokens
@@ -728,7 +728,7 @@ describe("IBosonVoucher", function() {
       assert.equal(returnedRange.toString(), range.toString(), "Range mismatch");
     });
 
-    it("Should burn all vouchers if there is less than MaxPremintedVouchers to burn", async function() {
+    it("Should burn all vouchers if there is less than MaxPremintedVouchers to burn", async function () {
       // Burn tokens, test for event
       let tx = await bosonVoucher.connect(assistant).burnPremintedVouchers(offerId);
 
@@ -746,7 +746,7 @@ describe("IBosonVoucher", function() {
       );
     });
 
-    it("Should burn only first MaxPremintedVouchers vouchers if there is more than MaxPremintedVouchers to burn", async function() {
+    it("Should burn only first MaxPremintedVouchers vouchers if there is more than MaxPremintedVouchers to burn", async function () {
       // make offer not voided so premint is possible
       offer.voided = false;
       await mockProtocol.mock.getOffer
@@ -807,7 +807,7 @@ describe("IBosonVoucher", function() {
       );
     });
 
-    it("Should skip all vouchers were already commited", async function() {
+    it("Should skip all vouchers were already commited", async function () {
       let commitedVouchers = [11, 14];
 
       // Transfer some preminted vouchers
@@ -850,7 +850,7 @@ describe("IBosonVoucher", function() {
       assert.equal(returnedRange.toString(), range.toString(), "Range mismatch");
     });
 
-    it("Burning is possible if offer not voided, but just expired", async function() {
+    it("Burning is possible if offer not voided, but just expired", async function () {
       // make offer not voided so premint is possible
       offer.voided = false;
       await mockProtocol.mock.getOffer
@@ -873,14 +873,14 @@ describe("IBosonVoucher", function() {
       }
     });
 
-    context("💔 Revert Reasons", async function() {
-      it("Caller is not the owner", async function() {
+    context("💔 Revert Reasons", async function () {
+      it("Caller is not the owner", async function () {
         await expect(bosonVoucher.connect(rando).burnPremintedVouchers(offerId)).to.be.revertedWith(
           RevertReasons.OWNABLE_NOT_OWNER
         );
       });
 
-      it("Offer id is not associated with a range", async function() {
+      it("Offer id is not associated with a range", async function () {
         // Set invalid offer id
         offerId = 15;
 
@@ -890,7 +890,7 @@ describe("IBosonVoucher", function() {
         );
       });
 
-      it("Offer is still valid", async function() {
+      it("Offer is still valid", async function () {
         // make offer not voided
         offer.voided = false;
         await mockProtocol.mock.getOffer
@@ -903,7 +903,7 @@ describe("IBosonVoucher", function() {
         );
       });
 
-      it("Nothing to burn", async function() {
+      it("Nothing to burn", async function () {
         // Burn tokens
         await bosonVoucher.connect(assistant).burnPremintedVouchers(offerId);
 
@@ -915,13 +915,13 @@ describe("IBosonVoucher", function() {
     });
   });
 
-  context("getAvailablePreMints()", function() {
+  context("getAvailablePreMints()", function () {
     let offerId, start, length, amount;
     let offer, offerDates, offerDurations, offerFees;
     let disputeResolutionTerms;
     let mockProtocol;
 
-    beforeEach(async function() {
+    beforeEach(async function () {
       // reserve a range
       offerId = "5";
       start = "10";
@@ -945,13 +945,13 @@ describe("IBosonVoucher", function() {
       );
     });
 
-    it("If nothing was preminted, return full range", async function() {
+    it("If nothing was preminted, return full range", async function () {
       // Get available premints from contract
       const availablePremints = await bosonVoucher.getAvailablePreMints(offerId);
       assert.equal(availablePremints.toString(), length, "Available Premints mismatch");
     });
 
-    it("Part of range is preminted", async function() {
+    it("Part of range is preminted", async function () {
       // Premint tokens
       await bosonVoucher.connect(assistant).preMint(offerId, amount);
 
@@ -967,7 +967,7 @@ describe("IBosonVoucher", function() {
       assert.equal(availablePremints.toNumber(), newAmount, "Available Premints mismatch");
     });
 
-    it("Range is fully minted", async function() {
+    it("Range is fully minted", async function () {
       // Adjust config value
       await configHandler.connect(deployer).setMaxPremintedVouchers(length);
 
@@ -979,7 +979,7 @@ describe("IBosonVoucher", function() {
       assert.equal(availablePremints.toNumber(), 0, "Available Premints mismatch");
     });
 
-    it("Range for offer does not exist", async function() {
+    it("Range for offer does not exist", async function () {
       // Set invalid offer id
       offerId = "20";
 
@@ -988,7 +988,7 @@ describe("IBosonVoucher", function() {
       assert.equal(availablePremints.toNumber(), 0, "Available Premints mismatch");
     });
 
-    it("Should be 0 if offer is voided", async function() {
+    it("Should be 0 if offer is voided", async function () {
       // void offer
       offer.voided = true;
       await mockProtocol.mock.getOffer.returns(
@@ -1005,7 +1005,7 @@ describe("IBosonVoucher", function() {
       assert.equal(availablePremints.toNumber(), 0, "Available Premints mismatch");
     });
 
-    it("Should be 0 if offer is expired", async function() {
+    it("Should be 0 if offer is expired", async function () {
       // Skip to after offer expiry
       await setNextBlockTimestamp(ethers.BigNumber.from(offerDates.validUntil).add(1).toHexString());
 
@@ -1015,11 +1015,11 @@ describe("IBosonVoucher", function() {
     });
   });
 
-  context("getRange()", function() {
+  context("getRange()", function () {
     let offerId, start, length, amount;
     let range;
 
-    beforeEach(async function() {
+    beforeEach(async function () {
       // reserve a range
       offerId = "5";
       start = "10";
@@ -1048,13 +1048,13 @@ describe("IBosonVoucher", function() {
       await bosonVoucher.connect(assistant).preMint(offerId, amount);
     });
 
-    it("Get range object for offer with reserved range", async function() {
+    it("Get range object for offer with reserved range", async function () {
       // Get range object from contract
       const returnedRange = Range.fromStruct(await bosonVoucher.getRangeByOfferId(offerId));
       assert.equal(returnedRange.toString(), range.toString(), "Range mismatch");
     });
 
-    it("Get empty range if offer has no reserved ranges", async function() {
+    it("Get empty range if offer has no reserved ranges", async function () {
       // Set invalid offer and empty range
       offerId = "20";
       range = new Range("0", "0", "0", "0", ethers.constants.AddressZero);
@@ -1065,13 +1065,13 @@ describe("IBosonVoucher", function() {
     });
   });
 
-  context("ownerOf()", function() {
+  context("ownerOf()", function () {
     let offerId, start, length, amount;
     let offer, offerDates, offerDurations, offerFees, disputeResolutionTerms;
     let mockProtocol;
 
-    context("No preminted tokens", async function() {
-      it("Returns true owner if token exists", async function() {
+    context("No preminted tokens", async function () {
+      it("Returns true owner if token exists", async function () {
         let tokenId = "100000";
         // Issue ordinary voucher
         await bosonVoucher.connect(protocol).issueVoucher(tokenId, buyer.address);
@@ -1081,8 +1081,8 @@ describe("IBosonVoucher", function() {
         assert.equal(tokenOwner, buyer.address, "Token owner mismatch");
       });
 
-      context("💔 Revert Reasons", async function() {
-        it("Token does not exist", async function() {
+      context("💔 Revert Reasons", async function () {
+        it("Token does not exist", async function () {
           let tokenId = "10";
           await expect(bosonVoucher.connect(rando).ownerOf(tokenId)).to.be.revertedWith(
             RevertReasons.ERC721_NON_EXISTENT
@@ -1091,8 +1091,8 @@ describe("IBosonVoucher", function() {
       });
     });
 
-    context("With preminted tokens", async function() {
-      beforeEach(async function() {
+    context("With preminted tokens", async function () {
+      beforeEach(async function () {
         // reserve a range
         offerId = "5";
         start = "10";
@@ -1117,7 +1117,7 @@ describe("IBosonVoucher", function() {
         await bosonVoucher.connect(assistant).preMint(offerId, amount);
       });
 
-      it("Returns true owner if token exists - via issue voucher", async function() {
+      it("Returns true owner if token exists - via issue voucher", async function () {
         let tokenId = "100000";
 
         // Define what should be returned when getExchange is called
@@ -1131,7 +1131,7 @@ describe("IBosonVoucher", function() {
         assert.equal(tokenOwner, buyer.address, "Token owner mismatch");
       });
 
-      it("Returns true owner if token exists - via preminted voucher transfer.", async function() {
+      it("Returns true owner if token exists - via preminted voucher transfer.", async function () {
         let tokenId = "25"; // tokens between 10 and 60 are preminted
 
         const mockProtocol = await deployMockProtocol();
@@ -1147,7 +1147,7 @@ describe("IBosonVoucher", function() {
         assert.equal(tokenOwner, buyer.address, "Token owner mismatch");
       });
 
-      it("Returns seller if token is preminted and not transferred yet", async function() {
+      it("Returns seller if token is preminted and not transferred yet", async function () {
         // Token owner should be the seller for all preminted tokens
         let startTokenId = Number(start);
         let endTokenId = startTokenId + Number(amount);
@@ -1157,7 +1157,7 @@ describe("IBosonVoucher", function() {
         }
       });
 
-      it("Multiple ranges", async function() {
+      it("Multiple ranges", async function () {
         // Add five more ranges
         // This tests more getPreMintStatus than ownerOf
         // Might even be put into integration tests
@@ -1216,7 +1216,7 @@ describe("IBosonVoucher", function() {
         }
       });
 
-      it("Consecutive ranges", async function() {
+      it("Consecutive ranges", async function () {
         // Make two consecutive ranges
 
         let nextOfferId = Number(offerId) + 1;
@@ -1261,15 +1261,15 @@ describe("IBosonVoucher", function() {
         }
       });
 
-      context("💔 Revert Reasons", async function() {
-        it("Token is outside any range and not minted", async function() {
+      context("💔 Revert Reasons", async function () {
+        it("Token is outside any range and not minted", async function () {
           let tokenId = "200000";
           await expect(bosonVoucher.connect(rando).ownerOf(tokenId)).to.be.revertedWith(
             RevertReasons.ERC721_NON_EXISTENT
           );
         });
 
-        it("Token is inside a range, but not minted yet", async function() {
+        it("Token is inside a range, but not minted yet", async function () {
           let startTokenId = Number(start) + Number(amount);
           let endTokenId = Number(start) + Number(length);
 
@@ -1279,7 +1279,7 @@ describe("IBosonVoucher", function() {
           }
         });
 
-        it("Token was preminted, transferred and burned", async function() {
+        it("Token was preminted, transferred and burned", async function () {
           let tokenId = "26";
 
           // Mock exchange handler methods (easier and more efficient than creating a real offer)
@@ -1308,7 +1308,7 @@ describe("IBosonVoucher", function() {
           );
         });
 
-        it("Token was preminted, not transferred and burned", async function() {
+        it("Token was preminted, not transferred and burned", async function () {
           let tokenId = "26";
 
           // Token owner should be the seller
@@ -1338,8 +1338,8 @@ describe("IBosonVoucher", function() {
     });
   });
 
-  context("Token transfers", function() {
-    afterEach(async function() {
+  context("Token transfers", function () {
+    afterEach(async function () {
       // Reset the accountId iterator
       accountId.next(true);
     });
@@ -1357,7 +1357,7 @@ describe("IBosonVoucher", function() {
       },
     };
 
-    beforeEach(async function() {
+    beforeEach(async function () {
       seller = mockSeller(assistant.address, admin.address, clerk.address, treasury.address);
 
       // Prepare the AuthToken and VoucherInitValues
@@ -1386,14 +1386,14 @@ describe("IBosonVoucher", function() {
         .createDisputeResolver(disputeResolver, disputeResolverFees, sellerAllowList);
     });
 
-    Object.keys(transferFunctions).forEach(function(transferFunction) {
-      context(transferFunction, function() {
+    Object.keys(transferFunctions).forEach(function (transferFunction) {
+      context(transferFunction, function () {
         let tokenId, offerId;
         let selector = transferFunctions[transferFunction].selector;
         let additionalArgs = transferFunctions[transferFunction].additionalArgs ?? [];
 
-        context("Transfer of an actual voucher", async function() {
-          beforeEach(async function() {
+        context("Transfer of an actual voucher", async function () {
+          beforeEach(async function () {
             // Create an offer
             const { offer, offerDates, offerDurations, disputeResolverId } = await mockOffer();
             await offerHandler
@@ -1420,7 +1420,7 @@ describe("IBosonVoucher", function() {
             bosonVoucher = await ethers.getContractAt("BosonVoucher", voucherAddress);
           });
 
-          it("Should emit a Transfer event", async function() {
+          it("Should emit a Transfer event", async function () {
             await expect(
               bosonVoucher.connect(buyer)[selector](buyer.address, rando.address, tokenId, ...additionalArgs)
             )
@@ -1428,7 +1428,7 @@ describe("IBosonVoucher", function() {
               .withArgs(buyer.address, rando.address, tokenId);
           });
 
-          it("Should update state", async function() {
+          it("Should update state", async function () {
             // Before transfer, buyer should be the owner
             let tokenOwner = await bosonVoucher.ownerOf(tokenId);
             assert.equal(tokenOwner, buyer.address, "Buyer is not the owner");
@@ -1440,7 +1440,7 @@ describe("IBosonVoucher", function() {
             assert.equal(tokenOwner, rando.address, "Rando is not the owner");
           });
 
-          it("Should call onVoucherTransferred", async function() {
+          it("Should call onVoucherTransferred", async function () {
             const randoBuyer = mockBuyer();
             await expect(
               bosonVoucher.connect(buyer)[selector](buyer.address, rando.address, tokenId, ...additionalArgs)
@@ -1449,7 +1449,7 @@ describe("IBosonVoucher", function() {
               .withArgs(offerId, tokenId, randoBuyer.id, bosonVoucher.address);
           });
 
-          it("Transfer on behalf of should work normally", async function() {
+          it("Transfer on behalf of should work normally", async function () {
             // Approve another address to transfer the voucher
             await bosonVoucher.connect(buyer).setApprovalForAll(rando2.address, true);
 
@@ -1460,13 +1460,13 @@ describe("IBosonVoucher", function() {
               .withArgs(buyer.address, rando.address, tokenId);
           });
 
-          it("If seller is the true owner of voucher, transfer should work same as for others", async function() {
+          it("If seller is the true owner of voucher, transfer should work same as for others", async function () {
             mockBuyer(); // Call to properly update nextAccountId
             await bosonVoucher.connect(buyer)[selector](buyer.address, assistant.address, tokenId, ...additionalArgs);
 
             const tx = await bosonVoucher
               .connect(assistant)
-            [selector](assistant.address, rando.address, tokenId, ...additionalArgs);
+              [selector](assistant.address, rando.address, tokenId, ...additionalArgs);
 
             await expect(tx).to.emit(bosonVoucher, "Transfer").withArgs(assistant.address, rando.address, tokenId);
 
@@ -1477,8 +1477,8 @@ describe("IBosonVoucher", function() {
               .withArgs(offerId, tokenId, randoBuyer.id, bosonVoucher.address);
           });
 
-          context("💔 Revert Reasons", async function() {
-            it("From does not own the voucher", async function() {
+          context("💔 Revert Reasons", async function () {
+            it("From does not own the voucher", async function () {
               await expect(
                 bosonVoucher.connect(rando)[selector](assistant.address, rando.address, tokenId, ...additionalArgs)
               ).to.be.revertedWith(RevertReasons.ERC721_CALLER_NOT_OWNER_OR_APPROVED);
@@ -1486,9 +1486,9 @@ describe("IBosonVoucher", function() {
           });
         });
 
-        context("Transfer of a preminted voucher", async function() {
+        context("Transfer of a preminted voucher", async function () {
           let voucherRedeemableFrom, voucherValid, offerValid;
-          beforeEach(async function() {
+          beforeEach(async function () {
             // Create preminted offer
             const { offer, offerDates, offerDurations, disputeResolverId } = await mockOffer();
             offer.quantityAvailable = "2";
@@ -1522,7 +1522,7 @@ describe("IBosonVoucher", function() {
             await bosonVoucher.connect(assistant).preMint(offerId, offer.quantityAvailable);
           });
 
-          it("Should emit a Transfer event", async function() {
+          it("Should emit a Transfer event", async function () {
             await expect(
               bosonVoucher.connect(assistant)[selector](assistant.address, rando.address, tokenId, ...additionalArgs)
             )
@@ -1530,25 +1530,25 @@ describe("IBosonVoucher", function() {
               .withArgs(assistant.address, rando.address, tokenId);
           });
 
-          it("Should update state", async function() {
+          it("Should update state", async function () {
             // Before transfer, seller should be the owner
             let tokenOwner = await bosonVoucher.ownerOf(tokenId);
             assert.equal(tokenOwner, assistant.address, "Seller is not the owner");
 
             await bosonVoucher
               .connect(assistant)
-            [selector](assistant.address, rando.address, tokenId, ...additionalArgs);
+              [selector](assistant.address, rando.address, tokenId, ...additionalArgs);
 
             // After transfer, rando should be the owner
             tokenOwner = await bosonVoucher.ownerOf(tokenId);
             assert.equal(tokenOwner, rando.address, "Rando is not the owner");
           });
 
-          it("Should call commitToPreMintedOffer", async function() {
+          it("Should call commitToPreMintedOffer", async function () {
             const randoBuyer = mockBuyer();
             const tx = await bosonVoucher
               .connect(assistant)
-            [selector](assistant.address, rando.address, tokenId, ...additionalArgs);
+              [selector](assistant.address, rando.address, tokenId, ...additionalArgs);
 
             // Get the block timestamp of the confirmed tx
             const blockNumber = tx.blockNumber;
@@ -1568,30 +1568,30 @@ describe("IBosonVoucher", function() {
               .withArgs(offerId, randoBuyer.id, tokenId, exchange.toStruct(), voucher.toStruct(), bosonVoucher.address);
           });
 
-          it("Second transfer should behave as normal voucher transfer", async function() {
+          it("Second transfer should behave as normal voucher transfer", async function () {
             // First transfer should call commitToPreMintedOffer, and not onVoucherTransferred
             let tx = await bosonVoucher
               .connect(assistant)
-            [selector](assistant.address, rando.address, tokenId, ...additionalArgs);
+              [selector](assistant.address, rando.address, tokenId, ...additionalArgs);
             await expect(tx).to.emit(exchangeHandler, "BuyerCommitted");
             await expect(tx).to.not.emit(exchangeHandler, "VoucherTransferred");
 
             // Second transfer should call onVoucherTransferred, and not commitToPreMintedOffer
             tx = await bosonVoucher
               .connect(rando)
-            [selector](rando.address, assistant.address, tokenId, ...additionalArgs);
+              [selector](rando.address, assistant.address, tokenId, ...additionalArgs);
             await expect(tx).to.emit(exchangeHandler, "VoucherTransferred");
             await expect(tx).to.not.emit(exchangeHandler, "BuyerCommitted");
 
             // Next transfer should call onVoucherTransferred, and not commitToPreMintedOffer, even if seller is the owner
             tx = await bosonVoucher
               .connect(assistant)
-            [selector](assistant.address, rando.address, tokenId, ...additionalArgs);
+              [selector](assistant.address, rando.address, tokenId, ...additionalArgs);
             await expect(tx).to.emit(exchangeHandler, "VoucherTransferred");
             await expect(tx).to.not.emit(exchangeHandler, "BuyerCommitted");
           });
 
-          it("Transfer on behalf of should work normally", async function() {
+          it("Transfer on behalf of should work normally", async function () {
             // Approve another address to transfer the voucher
             await bosonVoucher.connect(assistant).setApprovalForAll(rando2.address, true);
 
@@ -1602,12 +1602,12 @@ describe("IBosonVoucher", function() {
               .withArgs(assistant.address, rando.address, tokenId);
           });
 
-          context("💔 Revert Reasons", async function() {
-            it("Cannot transfer preminted voucher twice", async function() {
+          context("💔 Revert Reasons", async function () {
+            it("Cannot transfer preminted voucher twice", async function () {
               // Make first transfer
               await bosonVoucher
                 .connect(assistant)
-              [selector](assistant.address, buyer.address, tokenId, ...additionalArgs);
+                [selector](assistant.address, buyer.address, tokenId, ...additionalArgs);
 
               // Second transfer should fail, since voucher has an owner
               await expect(
@@ -1622,10 +1622,10 @@ describe("IBosonVoucher", function() {
               ).to.be.revertedWith(RevertReasons.NOT_COMMITTABLE);
             });
 
-            it("Transfer preminted voucher, which was committed and burned already", async function() {
+            it("Transfer preminted voucher, which was committed and burned already", async function () {
               await bosonVoucher
                 .connect(assistant)
-              [selector](assistant.address, buyer.address, tokenId, ...additionalArgs);
+                [selector](assistant.address, buyer.address, tokenId, ...additionalArgs);
 
               // Redeem voucher, effectively burning it
               await setNextBlockTimestamp(ethers.BigNumber.from(voucherRedeemableFrom).toHexString());
@@ -1637,7 +1637,7 @@ describe("IBosonVoucher", function() {
               ).to.be.revertedWith(RevertReasons.ERC721_NON_EXISTENT);
             });
 
-            it("Transfer preminted voucher, which was not committed but burned already", async function() {
+            it("Transfer preminted voucher, which was not committed but burned already", async function () {
               // Void offer
               await offerHandler.connect(assistant).voidOffer(offerId);
 
@@ -1650,7 +1650,7 @@ describe("IBosonVoucher", function() {
               ).to.be.revertedWith(RevertReasons.ERC721_NON_EXISTENT);
             });
 
-            it("Transfer preminted voucher, where offer was voided", async function() {
+            it("Transfer preminted voucher, where offer was voided", async function () {
               // Void offer
               await offerHandler.connect(assistant).voidOffer(offerId);
 
@@ -1660,7 +1660,7 @@ describe("IBosonVoucher", function() {
               ).to.be.revertedWith(RevertReasons.OFFER_HAS_BEEN_VOIDED);
             });
 
-            it("Transfer preminted voucher, where offer has expired", async function() {
+            it("Transfer preminted voucher, where offer has expired", async function () {
               // Skip past offer expiry
               await setNextBlockTimestamp(ethers.BigNumber.from(offerValid).toHexString());
 
@@ -1670,10 +1670,10 @@ describe("IBosonVoucher", function() {
               ).to.be.revertedWith(RevertReasons.OFFER_HAS_EXPIRED);
             });
 
-            it("Transfer preminted voucher, but from is not the voucher owner", async function() {
+            it("Transfer preminted voucher, but from is not the voucher owner", async function () {
               await bosonVoucher
                 .connect(assistant)
-              [selector](assistant.address, rando.address, tokenId, ...additionalArgs);
+                [selector](assistant.address, rando.address, tokenId, ...additionalArgs);
 
               // next token id. Make sure that assistant is the owner
               tokenId = Number(tokenId) + 1;
@@ -1690,10 +1690,10 @@ describe("IBosonVoucher", function() {
       });
     });
 
-    context("transferPremintedFrom()", async function() {
+    context("transferPremintedFrom()", async function () {
       let voucherRedeemableFrom, voucherValid, offerValid;
       let tokenId, offerId;
-      beforeEach(async function() {
+      beforeEach(async function () {
         // Create preminted offer
         const { offer, offerDates, offerDurations, disputeResolverId } = await mockOffer();
         offer.quantityAvailable = "2";
@@ -1722,7 +1722,7 @@ describe("IBosonVoucher", function() {
         await bosonVoucher.connect(assistant).preMint(offerId, offer.quantityAvailable);
       });
 
-      it("Should emit a Transfer event", async function() {
+      it("Should emit a Transfer event", async function () {
         await expect(
           bosonVoucher
             .connect(assistant)
@@ -1732,7 +1732,7 @@ describe("IBosonVoucher", function() {
           .withArgs(assistant.address, rando.address, tokenId);
       });
 
-      it("Should update state", async function() {
+      it("Should update state", async function () {
         // Before transfer, seller should be the owner
         let tokenOwner = await bosonVoucher.ownerOf(tokenId);
         assert.equal(tokenOwner, assistant.address, "Seller is not the owner");
@@ -1746,7 +1746,7 @@ describe("IBosonVoucher", function() {
         assert.equal(tokenOwner, rando.address, "Rando is not the owner");
       });
 
-      it("Should call commitToPreMintedOffer", async function() {
+      it("Should call commitToPreMintedOffer", async function () {
         const randoBuyer = mockBuyer();
         const tx = await bosonVoucher
           .connect(assistant)
@@ -1770,7 +1770,7 @@ describe("IBosonVoucher", function() {
           .withArgs(offerId, randoBuyer.id, tokenId, exchange.toStruct(), voucher.toStruct(), bosonVoucher.address);
       });
 
-      it("Second transfer should behave as normal voucher transfer", async function() {
+      it("Second transfer should behave as normal voucher transfer", async function () {
         // First transfer should call commitToPreMintedOffer, and not onVoucherTransferred
         let tx = await bosonVoucher
           .connect(assistant)
@@ -1781,12 +1781,12 @@ describe("IBosonVoucher", function() {
         // Second transfer should call onVoucherTransferred, and not commitToPreMintedOffer
         tx = await bosonVoucher
           .connect(rando)
-        ["safeTransferFrom(address,address,uint256,bytes)"](rando.address, assistant.address, tokenId, "0x");
+          ["safeTransferFrom(address,address,uint256,bytes)"](rando.address, assistant.address, tokenId, "0x");
         await expect(tx).to.emit(exchangeHandler, "VoucherTransferred");
         await expect(tx).to.not.emit(exchangeHandler, "BuyerCommitted");
       });
 
-      it("Transfer on behalf of should work normally", async function() {
+      it("Transfer on behalf of should work normally", async function () {
         // Approve another address to transfer the voucher
         await bosonVoucher.connect(assistant).setApprovalForAll(rando2.address, true);
 
@@ -1797,8 +1797,8 @@ describe("IBosonVoucher", function() {
           .withArgs(assistant.address, rando.address, tokenId);
       });
 
-      context("💔 Revert Reasons", async function() {
-        it("Cannot transfer preminted voucher twice", async function() {
+      context("💔 Revert Reasons", async function () {
+        it("Cannot transfer preminted voucher twice", async function () {
           // Make first transfer
           await bosonVoucher
             .connect(assistant)
@@ -1815,11 +1815,11 @@ describe("IBosonVoucher", function() {
           await expect(
             bosonVoucher
               .connect(assistant)
-            ["safeTransferFrom(address,address,uint256,bytes)"](assistant.address, rando.address, tokenId, "0x")
+              ["safeTransferFrom(address,address,uint256,bytes)"](assistant.address, rando.address, tokenId, "0x")
           ).to.be.revertedWith(RevertReasons.ERC721_CALLER_NOT_OWNER_OR_APPROVED);
         });
 
-        it("Transfer preminted voucher, which was committed and burned already", async function() {
+        it("Transfer preminted voucher, which was committed and burned already", async function () {
           await bosonVoucher
             .connect(assistant)
             .transferPremintedFrom(assistant.address, buyer.address, offerId, tokenId, "0x");
@@ -1836,7 +1836,7 @@ describe("IBosonVoucher", function() {
           ).to.be.revertedWith(RevertReasons.NOT_COMMITTABLE);
         });
 
-        it("Transfer preminted voucher, which was not committed but burned already", async function() {
+        it("Transfer preminted voucher, which was not committed but burned already", async function () {
           // Void offer
           await offerHandler.connect(assistant).voidOffer(offerId);
 
@@ -1851,7 +1851,7 @@ describe("IBosonVoucher", function() {
           ).to.be.revertedWith(RevertReasons.NOT_COMMITTABLE);
         });
 
-        it("Transfer preminted voucher, where offer was voided", async function() {
+        it("Transfer preminted voucher, where offer was voided", async function () {
           // Void offer
           await offerHandler.connect(assistant).voidOffer(offerId);
 
@@ -1863,7 +1863,7 @@ describe("IBosonVoucher", function() {
           ).to.be.revertedWith(RevertReasons.OFFER_HAS_BEEN_VOIDED);
         });
 
-        it("Transfer preminted voucher, where offer has expired", async function() {
+        it("Transfer preminted voucher, where offer has expired", async function () {
           // Skip past offer expiry
           await setNextBlockTimestamp(ethers.BigNumber.from(offerValid).toHexString());
 
@@ -1875,7 +1875,7 @@ describe("IBosonVoucher", function() {
           ).to.be.revertedWith(RevertReasons.OFFER_HAS_EXPIRED);
         });
 
-        it("Transfer preminted voucher, but from is not the voucher owner", async function() {
+        it("Transfer preminted voucher, but from is not the voucher owner", async function () {
           await bosonVoucher.connect(assistant).transferFrom(assistant.address, rando.address, tokenId);
 
           // next token id. Make sure that assistant is the owner
@@ -1892,13 +1892,13 @@ describe("IBosonVoucher", function() {
     });
   });
 
-  context("burnVoucher()", function() {
-    after(async function() {
+  context("burnVoucher()", function () {
+    after(async function () {
       // Reset the accountId iterator
       accountId.next(true);
     });
 
-    it("should burn a voucher with success", async function() {
+    it("should burn a voucher with success", async function () {
       const buyerStruct = mockBuyer(buyer.address).toStruct();
       const buyerWallet = buyerStruct[1];
       await bosonVoucher.connect(protocol).issueVoucher(0, buyerWallet);
@@ -1912,7 +1912,7 @@ describe("IBosonVoucher", function() {
       expect(balanceBefore.sub(balanceAfter)).eq(1);
     });
 
-    it("should revert if caller does not have PROTOCOL role", async function() {
+    it("should revert if caller does not have PROTOCOL role", async function () {
       // Expect revert if random user attempts to burn voucher
       await expect(bosonVoucher.connect(rando).burnVoucher(0)).to.be.revertedWith(RevertReasons.ACCESS_DENIED);
 
@@ -1933,10 +1933,10 @@ describe("IBosonVoucher", function() {
     });
   });
 
-  context("tokenURI", function() {
+  context("tokenURI", function () {
     let metadataUri, offerId, offerPrice;
 
-    beforeEach(async function() {
+    beforeEach(async function () {
       seller = mockSeller(assistant.address, admin.address, clerk.address, treasury.address);
 
       // prepare the VoucherInitValues
@@ -1991,21 +1991,21 @@ describe("IBosonVoucher", function() {
       bosonVoucher = await ethers.getContractAt("BosonVoucher", voucherAddress);
     });
 
-    afterEach(async function() {
+    afterEach(async function () {
       // Reset the accountId iterator
       accountId.next(true);
     });
 
-    it("should return the correct tokenURI", async function() {
+    it("should return the correct tokenURI", async function () {
       await exchangeHandler.connect(buyer).commitToOffer(buyer.address, offerId, { value: offerPrice });
 
       const tokenURI = await bosonVoucher.tokenURI(1);
       expect(tokenURI).eq(metadataUri);
     });
 
-    context("pre-minted", async function() {
+    context("pre-minted", async function () {
       let start;
-      beforeEach(async function() {
+      beforeEach(async function () {
         // reserve a range
         start = "10";
         const length = "1";
@@ -2014,12 +2014,12 @@ describe("IBosonVoucher", function() {
         // premint
         await bosonVoucher.connect(assistant).preMint(offerId, 1);
       });
-      it("should return the correct tokenURI", async function() {
+      it("should return the correct tokenURI", async function () {
         const tokenURI = await bosonVoucher.tokenURI(start);
         expect(tokenURI).eq(metadataUri);
       });
 
-      it("should return correct tokenURI when token is preminted and transferred", async function() {
+      it("should return correct tokenURI when token is preminted and transferred", async function () {
         await bosonVoucher.connect(assistant).transferFrom(assistant.address, buyer.address, start);
 
         const tokenURI = await bosonVoucher.tokenURI(start);
@@ -2028,15 +2028,15 @@ describe("IBosonVoucher", function() {
     });
   });
 
-  context("transferOwnership()", function() {
-    it("should emit OwnershipTransferred", async function() {
+  context("transferOwnership()", function () {
+    it("should emit OwnershipTransferred", async function () {
       const ownable = await ethers.getContractAt("OwnableUpgradeable", bosonVoucher.address);
       await expect(bosonVoucher.connect(protocol).transferOwnership(rando.address))
         .to.emit(ownable, "OwnershipTransferred")
         .withArgs(assistant.address, rando.address);
     });
 
-    it("should transfer ownership with success", async function() {
+    it("should transfer ownership with success", async function () {
       await bosonVoucher.connect(protocol).transferOwnership(assistant.address);
 
       const ownable = await ethers.getContractAt("OwnableUpgradeable", bosonVoucher.address);
@@ -2045,14 +2045,14 @@ describe("IBosonVoucher", function() {
       expect(owner).eq(assistant.address, "Wrong owner");
     });
 
-    context("💔 Revert Reasons", async function() {
-      it("should revert if caller does not have PROTOCOL role", async function() {
+    context("💔 Revert Reasons", async function () {
+      it("should revert if caller does not have PROTOCOL role", async function () {
         await expect(bosonVoucher.connect(rando).transferOwnership(assistant.address)).to.be.revertedWith(
           RevertReasons.ACCESS_DENIED
         );
       });
 
-      it("Even the current owner cannot transfer the ownership", async function() {
+      it("Even the current owner cannot transfer the ownership", async function () {
         // succesfully transfer to assistant
         await bosonVoucher.connect(protocol).transferOwnership(assistant.address);
 
@@ -2062,7 +2062,7 @@ describe("IBosonVoucher", function() {
         );
       });
 
-      it("Transfering ownership to 0 is not allowed", async function() {
+      it("Transfering ownership to 0 is not allowed", async function () {
         // try to transfer ownership to address 0, should fail
         await expect(bosonVoucher.connect(protocol).transferOwnership(ethers.constants.AddressZero)).to.be.revertedWith(
           RevertReasons.OWNABLE_ZERO_ADDRESS
@@ -2071,21 +2071,21 @@ describe("IBosonVoucher", function() {
     });
   });
 
-  context("setContractURI()", function() {
-    beforeEach(async function() {
+  context("setContractURI()", function () {
+    beforeEach(async function () {
       // give ownership to assistant
       await bosonVoucher.connect(protocol).transferOwnership(assistant.address);
 
       contractURI = "newContractURI";
     });
 
-    it("should emit ContractURIChanged event", async function() {
+    it("should emit ContractURIChanged event", async function () {
       await expect(bosonVoucher.connect(assistant).setContractURI(contractURI))
         .to.emit(bosonVoucher, "ContractURIChanged")
         .withArgs(contractURI);
     });
 
-    it("should set new contract with success", async function() {
+    it("should set new contract with success", async function () {
       await bosonVoucher.connect(assistant).setContractURI(contractURI);
 
       const returnedContractURI = await bosonVoucher.contractURI();
@@ -2093,7 +2093,7 @@ describe("IBosonVoucher", function() {
       expect(returnedContractURI).eq(contractURI, "Wrong contractURI");
     });
 
-    it("should revert if caller is not the owner", async function() {
+    it("should revert if caller is not the owner", async function () {
       // random caller
       await expect(bosonVoucher.connect(rando).setContractURI(contractURI)).to.be.revertedWith(
         RevertReasons.OWNABLE_NOT_OWNER
@@ -2106,8 +2106,8 @@ describe("IBosonVoucher", function() {
     });
   });
 
-  context("ERC2981 NFT Royalty fee", function() {
-    beforeEach(async function() {
+  context("ERC2981 NFT Royalty fee", function () {
+    beforeEach(async function () {
       seller = mockSeller(assistant.address, admin.address, clerk.address, treasury.address);
 
       // prepare the VoucherInitValues
@@ -2157,25 +2157,25 @@ describe("IBosonVoucher", function() {
       offerPrice = offer.price;
     });
 
-    afterEach(async function() {
+    afterEach(async function () {
       // Reset the accountId iterator
       accountId.next(true);
     });
 
-    context("setRoyaltyPercentage()", function() {
-      beforeEach(async function() {
+    context("setRoyaltyPercentage()", function () {
+      beforeEach(async function () {
         // give ownership to assistant
         await bosonVoucher.connect(protocol).transferOwnership(assistant.address);
       });
 
-      it("should emit RoyaltyPercentageChanged event", async function() {
+      it("should emit RoyaltyPercentageChanged event", async function () {
         royaltyPercentage = "0"; //0%
         await expect(bosonVoucher.connect(assistant).setRoyaltyPercentage(royaltyPercentage))
           .to.emit(bosonVoucher, "RoyaltyPercentageChanged")
           .withArgs(royaltyPercentage);
       });
 
-      it("should set a royalty fee percentage", async function() {
+      it("should set a royalty fee percentage", async function () {
         // First, set royalty fee as 0
         royaltyPercentage = "0"; //0%
         await bosonVoucher.connect(assistant).setRoyaltyPercentage(royaltyPercentage);
@@ -2204,8 +2204,8 @@ describe("IBosonVoucher", function() {
         assert.equal(royaltyAmount.toString(), expectedRoyaltyAmount, "Royalty amount is incorrect");
       });
 
-      context("💔 Revert Reasons", async function() {
-        it("should revert if caller is not the owner", async function() {
+      context("💔 Revert Reasons", async function () {
+        it("should revert if caller is not the owner", async function () {
           // random caller
           await expect(bosonVoucher.connect(rando).setRoyaltyPercentage(royaltyPercentage)).to.be.revertedWith(
             RevertReasons.OWNABLE_NOT_OWNER
@@ -2217,7 +2217,7 @@ describe("IBosonVoucher", function() {
           );
         });
 
-        it("should revert if royaltyPercentage is greater than max royalty percentage defined in the protocol", async function() {
+        it("should revert if royaltyPercentage is greater than max royalty percentage defined in the protocol", async function () {
           // Set royalty fee as 15% (protocol limit is 10%)
           royaltyPercentage = "1500"; //15%
 
@@ -2229,8 +2229,8 @@ describe("IBosonVoucher", function() {
       });
     });
 
-    context("getRoyaltyPercentage()", function() {
-      it("should return the royalty fee percentage", async function() {
+    context("getRoyaltyPercentage()", function () {
+      it("should return the royalty fee percentage", async function () {
         // give ownership to assistant
         await bosonVoucher.connect(protocol).transferOwnership(assistant.address);
 
@@ -2244,13 +2244,13 @@ describe("IBosonVoucher", function() {
       });
     });
 
-    context("royaltyInfo()", function() {
-      beforeEach(async function() {
+    context("royaltyInfo()", function () {
+      beforeEach(async function () {
         // give ownership to assistant
         await bosonVoucher.connect(protocol).transferOwnership(assistant.address);
       });
 
-      it("should return a recipient and royalty fee", async function() {
+      it("should return a recipient and royalty fee", async function () {
         // First, set royalty fee as 0
         royaltyPercentage = "0"; //0%
         await bosonVoucher.connect(assistant).setRoyaltyPercentage(royaltyPercentage);
@@ -2293,7 +2293,7 @@ describe("IBosonVoucher", function() {
         assert.equal(royaltyAmount.toString(), expectedRoyaltyAmount, "Royalty amount is incorrect");
       });
 
-      it("if exhanfe doesn't exist it should return 0 values", async function() {
+      it("if exhanfe doesn't exist it should return 0 values", async function () {
         // Set royalty fee as 10%
         royaltyPercentage = "1000"; //10%
         await bosonVoucher.connect(assistant).setRoyaltyPercentage(royaltyPercentage);
@@ -2308,8 +2308,8 @@ describe("IBosonVoucher", function() {
       });
     });
 
-    context("💔 Revert Reasons", async function() {
-      it("should revert during create seller if royaltyPercentage is greater than max royalty percentage defined in the protocol", async function() {
+    context("💔 Revert Reasons", async function () {
+      it("should revert during create seller if royaltyPercentage is greater than max royalty percentage defined in the protocol", async function () {
         // create invalid voucherInitValues
         royaltyPercentage = "2000"; // 20%
         voucherInitValues = new VoucherInitValues("ContractURI", royaltyPercentage);
@@ -2326,8 +2326,8 @@ describe("IBosonVoucher", function() {
     });
   });
 
-  context("getSellerId()", function() {
-    it("should return the seller id", async function() {
+  context("getSellerId()", function () {
+    it("should return the seller id", async function () {
       // prepare the VoucherInitValues
       voucherInitValues = mockVoucherInitValues();
       expect(voucherInitValues.isValid()).is.true;

--- a/test/protocol/clients/BosonVoucherTest.js
+++ b/test/protocol/clients/BosonVoucherTest.js
@@ -1802,7 +1802,7 @@ describe("IBosonVoucher", function () {
   });
 
   context("tokenURI", function () {
-    let metadataUri;
+    let metadataUri, offerId, offerPrice;
 
     beforeEach(async function () {
       seller = mockSeller(assistant.address, admin.address, clerk.address, treasury.address);
@@ -1841,15 +1841,22 @@ describe("IBosonVoucher", function () {
         .createDisputeResolver(disputeResolver, disputeResolverFees, sellerAllowList);
 
       const { offer, offerDates, offerDurations, disputeResolverId } = await mockOffer();
+      offerId = offer.id;
+      offerPrice = offer.price;
+
       await offerHandler
         .connect(assistant)
         .createOffer(offer.toStruct(), offerDates.toStruct(), offerDurations.toStruct(), disputeResolverId, agentId);
-      await fundsHandler
-        .connect(admin)
-        .depositFunds(seller.id, ethers.constants.AddressZero, offer.sellerDeposit, { value: offer.sellerDeposit });
-      await exchangeHandler.connect(buyer).commitToOffer(buyer.address, offer.id, { value: offer.price });
+
+      const pool = ethers.BigNumber.from(offer.sellerDeposit).add(offer.price);
+
+      await fundsHandler.connect(admin).depositFunds(seller.id, ethers.constants.AddressZero, pool, { value: pool });
 
       metadataUri = offer.metadataUri;
+
+      // Update boson voucher address to actual seller's voucher
+      const voucherAddress = calculateContractAddress(accountHandler.address, "1");
+      bosonVoucher = await ethers.getContractAt("BosonVoucher", voucherAddress);
     });
 
     afterEach(async function () {
@@ -1858,8 +1865,34 @@ describe("IBosonVoucher", function () {
     });
 
     it("should return the correct tokenURI", async function () {
+      await exchangeHandler.connect(buyer).commitToOffer(buyer.address, offerId, { value: offerPrice });
+
       const tokenURI = await bosonVoucher.tokenURI(1);
       expect(tokenURI).eq(metadataUri);
+    });
+
+    context("pre-minted", async function () {
+      let start;
+      beforeEach(async function () {
+        // reserve a range
+        start = "10";
+        const length = "1";
+        await bosonVoucher.connect(protocol).reserveRange(offerId, start, length);
+
+        // premint
+        await bosonVoucher.connect(assistant).preMint(offerId, 1);
+      });
+      it("should return the correct tokenURI", async function () {
+        const tokenURI = await bosonVoucher.tokenURI(start);
+        expect(tokenURI).eq(metadataUri);
+      });
+
+      it("should return correct tokenURI when token is preminted and transferred", async function () {
+        await bosonVoucher.connect(assistant).transferFrom(assistant.address, buyer.address, start);
+
+        const tokenURI = await bosonVoucher.tokenURI(start);
+        expect(tokenURI).eq(metadataUri);
+      });
     });
   });
 

--- a/test/upgrade/clients/BosonVoucher-2.1.0-2.2.0.js
+++ b/test/upgrade/clients/BosonVoucher-2.1.0-2.2.0.js
@@ -34,7 +34,7 @@ let snapshot;
 /**
  *  Upgrade test case - After upgrade from 2.1.0 to 2.2.0 everything is still operational
  */
-describe("[@skip-on-coverage] After client upgrade, everything is still operational", function() {
+describe("[@skip-on-coverage] After client upgrade, everything is still operational", function () {
   // Common vars
   let deployer, assistant, rando;
 
@@ -49,7 +49,7 @@ describe("[@skip-on-coverage] After client upgrade, everything is still operatio
   let bosonVoucher;
   let forwarder;
 
-  before(async function() {
+  before(async function () {
     // Make accounts available
     [deployer, assistant, rando] = await ethers.getSigners();
 
@@ -109,7 +109,7 @@ describe("[@skip-on-coverage] After client upgrade, everything is still operatio
     );
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     // Revert to state right after the upgrade.
     // This is used so the lengthly setup (deploy+upgrade) is done only once.
     await ethers.provider.send("evm_revert", [snapshot]);
@@ -121,11 +121,11 @@ describe("[@skip-on-coverage] After client upgrade, everything is still operatio
 
   // Test methods that were added to see that upgrade was succesful
   // Extensive unit tests for this methods are in /test/protocol/clients/BosonVoucherTest.js
-  context("📋 New methods", async function() {
+  context("📋 New methods", async function () {
     let offerId, start, length, amount;
     let sellerId, disputeResolverId;
 
-    beforeEach(async function() {
+    beforeEach(async function () {
       // Create a seller
       sellerId = await accountHandler.getNextAccountId();
       const seller = mockSeller(assistant.address, assistant.address, assistant.address, assistant.address);
@@ -175,7 +175,7 @@ describe("[@skip-on-coverage] After client upgrade, everything is still operatio
       await configHandler.connect(deployer).setMaxPremintedVouchers(1000);
     });
 
-    it("reserveRange()", async function() {
+    it("reserveRange()", async function () {
       // Reserve range, test for event
       await expect(offerHandler.connect(assistant).reserveRange(offerId, length)).to.emit(
         bosonVoucher,
@@ -183,8 +183,8 @@ describe("[@skip-on-coverage] After client upgrade, everything is still operatio
       );
     });
 
-    context("preMint()", async function() {
-      it("seller can pre mint vouchers", async function() {
+    context("preMint()", async function () {
+      it("seller can pre mint vouchers", async function () {
         // Reserve range
         await offerHandler.connect(assistant).reserveRange(offerId, length);
 
@@ -192,7 +192,7 @@ describe("[@skip-on-coverage] After client upgrade, everything is still operatio
         await expect(bosonVoucher.connect(assistant).preMint(offerId, amount)).to.emit(bosonVoucher, "Transfer");
       });
 
-      it("MetaTx: forwarder can pre mint on behalf of seller on old vouchers", async function() {
+      it("MetaTx: forwarder can pre mint on behalf of seller on old vouchers", async function () {
         const sellersLength = preUpgradeEntities.sellers.length;
 
         // Gets last seller created before upgrade
@@ -254,16 +254,19 @@ describe("[@skip-on-coverage] After client upgrade, everything is still operatio
       });
     });
 
-    context("preMintTo()", async function() {
-      it("Assistant can pre mint vouchers for rando address", async function() {
+    context("preMintTo()", async function () {
+      it("Assistant can pre mint vouchers for rando address", async function () {
         // Reserve range
         await offerHandler.connect(assistant).reserveRange(offerId, length);
 
         // Premint tokens, test for event
-        await expect(bosonVoucher.connect(assistant).preMintTo(rando.address, offerId, amount)).to.emit(bosonVoucher, "Transfer");
+        await expect(bosonVoucher.connect(assistant).preMintTo(rando.address, offerId, amount)).to.emit(
+          bosonVoucher,
+          "Transfer"
+        );
       });
 
-      it("MetaTx: forwarder can pre mint on behalf of seller on old vouchers", async function() {
+      it("MetaTx: forwarder can pre mint on behalf of seller on old vouchers", async function () {
         const sellersLength = preUpgradeEntities.sellers.length;
 
         // Gets last seller created before upgrade
@@ -325,8 +328,7 @@ describe("[@skip-on-coverage] After client upgrade, everything is still operatio
       });
     });
 
-
-    it("burnPremintedVouchers()", async function() {
+    it("burnPremintedVouchers()", async function () {
       // Reserve range and premint tokens
       await offerHandler.connect(assistant).reserveRange(offerId, length);
       await bosonVoucher.connect(assistant).preMint(offerId, amount);
@@ -338,7 +340,7 @@ describe("[@skip-on-coverage] After client upgrade, everything is still operatio
       await expect(bosonVoucher.connect(assistant).burnPremintedVouchers(offerId)).to.emit(bosonVoucher, "Transfer");
     });
 
-    it("getRange()", async function() {
+    it("getRange()", async function () {
       // Reserve range
       await offerHandler.connect(assistant).reserveRange(offerId, length);
 
@@ -349,7 +351,7 @@ describe("[@skip-on-coverage] After client upgrade, everything is still operatio
       assert.equal(returnedRange.toString(), range.toString(), "Range mismatch");
     });
 
-    it("getAvailablePreMints()", async function() {
+    it("getAvailablePreMints()", async function () {
       // Reserve range
       await offerHandler.connect(assistant).reserveRange(offerId, length);
 

--- a/test/util/mock.js
+++ b/test/util/mock.js
@@ -1,5 +1,7 @@
 const hre = require("hardhat");
 const ethers = hre.ethers;
+
+const decache = require("decache");
 const Condition = require("../../scripts/domain/Condition");
 const EvaluationMethod = require("../../scripts/domain/EvaluationMethod");
 const Offer = require("../../scripts/domain/Offer");
@@ -12,8 +14,6 @@ const Twin = require("../../scripts/domain/Twin.js");
 const Exchange = require("../../scripts/domain/Exchange.js");
 const TwinReceipt = require("../../scripts/domain/TwinReceipt.js");
 const TokenType = require("../../scripts/domain/TokenType.js");
-const DisputeResolver = require("../../scripts/domain/DisputeResolver");
-const Seller = require("../../scripts/domain/Seller");
 const Buyer = require("../../scripts/domain/Buyer");
 const VoucherInitValues = require("../../scripts/domain/VoucherInitValues");
 const AuthToken = require("../../scripts/domain/AuthToken");
@@ -24,6 +24,8 @@ const Voucher = require("../../scripts/domain/Voucher");
 const Dispute = require("../../scripts/domain/Dispute");
 const { applyPercentage } = require("../../test/util/utils.js");
 const { oneWeek, oneMonth } = require("./constants.js");
+let DisputeResolver = require("../../scripts/domain/DisputeResolver.js");
+let Seller = require("../../scripts/domain/Seller");
 
 function* incrementer() {
   let i = 1;
@@ -110,7 +112,12 @@ function mockTwin(tokenAddress, tokenType) {
   return new Twin(id, sellerId, amount, supplyAvailable, tokenId, tokenAddress, tokenType);
 }
 
-function mockDisputeResolver(assistantAddress, adminAddress, clerkAddress, treasuryAddress, active) {
+function mockDisputeResolver(assistantAddress, adminAddress, clerkAddress, treasuryAddress, active, refreshModule) {
+  if (refreshModule) {
+    decache("../../scripts/domain/DisputeResolver.js");
+    DisputeResolver = require("../../scripts/domain/DisputeResolver.js");
+  }
+
   const metadataUriDR = `https://ipfs.io/ipfs/disputeResolver1`;
   return new DisputeResolver(
     accountId.next().value,
@@ -124,7 +131,11 @@ function mockDisputeResolver(assistantAddress, adminAddress, clerkAddress, treas
   );
 }
 
-function mockSeller(assistantAddress, adminAddress, clerkAddress, treasuryAddress) {
+function mockSeller(assistantAddress, adminAddress, clerkAddress, treasuryAddress, refreshModule) {
+  if (refreshModule) {
+    decache("../../scripts/domain/Seller.js");
+    Seller = require("../../scripts/domain/Seller.js");
+  }
   return new Seller(accountId.next().value, assistantAddress, adminAddress, clerkAddress, treasuryAddress, true);
 }
 

--- a/test/util/upgrade.js
+++ b/test/util/upgrade.js
@@ -256,7 +256,14 @@ async function populateProtocolContract(
     // create entities
     switch (entity) {
       case entityType.DR: {
-        const disputeResolver = mockDisputeResolver(wallet.address, wallet.address, wallet.address, wallet.address);
+        const disputeResolver = mockDisputeResolver(
+          wallet.address,
+          wallet.address,
+          wallet.address,
+          wallet.address,
+          true,
+          true
+        );
         const disputeResolverFees = [
           new DisputeResolverFee(ethers.constants.AddressZero, "Native", "0"),
           new DisputeResolverFee(mockToken.address, "MockToken", "0"),
@@ -272,13 +279,13 @@ async function populateProtocolContract(
           disputeResolverFees,
           sellerAllowList,
         });
-
         //ADMIN role activates Dispute Resolver
         await accountHandler.connect(deployer).activateDisputeResolver(disputeResolver.id);
+
         break;
       }
       case entityType.SELLER: {
-        const seller = mockSeller(wallet.address, wallet.address, wallet.address, wallet.address);
+        const seller = mockSeller(wallet.address, wallet.address, wallet.address, wallet.address, true);
         const id = seller.id;
         let authToken;
         // randomly decide if auth token is used or not
@@ -1392,7 +1399,14 @@ async function populateVoucherContract(
       // create entities
       switch (entity) {
         case entityType.DR: {
-          const disputeResolver = mockDisputeResolver(wallet.address, wallet.address, wallet.address, wallet.address);
+          const disputeResolver = mockDisputeResolver(
+            wallet.address,
+            wallet.address,
+            wallet.address,
+            wallet.address,
+            true,
+            true
+          );
           const disputeResolverFees = [
             new DisputeResolverFee(ethers.constants.AddressZero, "Native", "0"),
             new DisputeResolverFee(mockToken.address, "MockToken", "0"),
@@ -1414,7 +1428,7 @@ async function populateVoucherContract(
           break;
         }
         case entityType.SELLER: {
-          const seller = mockSeller(wallet.address, wallet.address, wallet.address, wallet.address);
+          const seller = mockSeller(wallet.address, wallet.address, wallet.address, wallet.address, true);
           const id = seller.id;
           let authToken = mockAuthToken();
 
@@ -1600,6 +1614,12 @@ async function getVoucherContractState({ bosonVouchers, exchanges, sellers, buye
   return bosonVouchersState;
 }
 
+function revertState() {
+  shell.exec(`rm -rf contracts/* scripts/*`);
+  shell.exec(`git checkout HEAD contracts scripts`);
+  shell.exec(`git reset HEAD contracts scripts`);
+}
+
 exports.deploySuite = deploySuite;
 exports.upgradeSuite = upgradeSuite;
 exports.upgradeClients = upgradeClients;
@@ -1609,3 +1629,4 @@ exports.getStorageLayout = getStorageLayout;
 exports.compareStorageLayouts = compareStorageLayouts;
 exports.populateVoucherContract = populateVoucherContract;
 exports.getVoucherContractState = getVoucherContractState;
+exports.revertState = revertState;


### PR DESCRIPTION
- Vouchers can now be pre-minted for both the contract owner and contract address. 
- A new parameter `_to` has been added to `reserveRange` and must be either the contract owner or contract address. 
-  I have also fixed the pre-commit hook script in this PR.
 
## Notes
 I'll add the upgrade tests checking if OfferHandler has new changes in this [PR](https://github.com/bosonprotocol/boson-protocol-contracts/pull/498) after we merge this one to main, in order to avoid conflicts 