### PR TITLE
Upgrade voucher contracts - fix

### DIFF
--- a/addresses/80001-mumbai-test.json
+++ b/addresses/80001-mumbai-test.json
@@ -168,12 +168,6 @@
       "interfaceId": "0x60b30e70"
     },
     {
-      "name": "BosonVoucher Logic",
-      "address": "0x945a419a988921A758A94D6bB88A264aaD2fa646",
-      "args": [],
-      "interfaceId": ""
-    },
-    {
       "name": "OfferHandlerFacet",
       "address": "0x4b94267Aa5Ca691429D4da3d29C36C9e8888487D",
       "args": [],
@@ -184,6 +178,14 @@
       "address": "0x2354D6CBC8Ff222898ea1D22eF3d28043A6d710b",
       "args": [],
       "interfaceId": "0xa38bc2e7"
+    },
+    {
+      "name": "BosonVoucher Logic",
+      "address": "0x2e784BeA2e2AEC0eefF14Fe0D9dC9219DD74B167",
+      "args": [
+        "0x69015912AA33720b842dCD6aC059Ed623F28d9f7"
+      ],
+      "interfaceId": ""
     }
   ]
 }

--- a/logs/mumbai-test.upgrade.contracts.txt
+++ b/logs/mumbai-test.upgrade.contracts.txt
@@ -276,3 +276,22 @@ Boson Protocol Contract Suite Upgrader
 📋 Diamond upgraded.
 
 
+--------------------------------------------------------------------------------
+Boson Protocol Client Upgrader
+--------------------------------------------------------------------------------
+⛓  Network: mumbai
+📅 Thu Mar 16 2023 16:24:43 GMT+0100 (Srednjeevropski standardni čas)
+🔱 Admin account:  0x2a91A0148EE62fA638bE38C7eE05c29a3e568dD8
+--------------------------------------------------------------------------------
+
+📋 Deploying new logic contract
+
+📋 Updating implementation address on beacon
+✅ BosonVoucher Logic deployed to: 0x2e784BeA2e2AEC0eefF14Fe0D9dC9219DD74B167
+--------------------------------------------------------------------------------
+✅ Contracts written to /home/klemen/boson/clean/boson-protocol-contracts/scripts/util/../../addresses/80001-mumbai-test.json
+--------------------------------------------------------------------------------
+
+📋 Client upgraded.
+
+

--- a/scripts/config/client-upgrade.js
+++ b/scripts/config/client-upgrade.js
@@ -5,7 +5,7 @@ module.exports = {
     localhost: "0x494f5238b40119e707582Ce87E0ca3627dB23Bcb", //dummy
     test: "0x69015912AA33720b842dCD6aC059Ed623F28d9f7",
     staging: "0x69015912AA33720b842dCD6aC059Ed623F28d9f7",
-    mumbai: "0x494f5238b40119e707582Ce87E0ca3627dB23Bcb", //dummy
+    mumbai: "0x69015912AA33720b842dCD6aC059Ed623F28d9f7",
     polygon: "0x17CDD65bebDe68cd8A4045422Fcff825A0740Ef9", //dummy
   },
 };

--- a/scripts/upgrade-clients.js
+++ b/scripts/upgrade-clients.js
@@ -88,7 +88,7 @@ async function main(env, clientConfig) {
 
   // Remove old entry from contracts
   contracts = contracts.filter((i) => i.name !== "BosonVoucher Logic");
-  deploymentComplete("BosonVoucher Logic", bosonVoucherImplementation.address, [], "", contracts);
+  deploymentComplete("BosonVoucher Logic", bosonVoucherImplementation.address, clientImplementationArgs, "", contracts);
 
   const contractsPath = await writeContracts(contracts, env);
   console.log(divider);

--- a/scripts/util/report-verify-deployments.js
+++ b/scripts/util/report-verify-deployments.js
@@ -11,6 +11,7 @@ async function verifyOnBlockExplorer(contract) {
 
   console.log("contract object in verify function ", contract);
   try {
+    if (contract.name == "BosonVoucher Logic") contract.name == "BosonVoucher";
     if (contract.name == "BosonVoucher Beacon") {
       await hre.run("verify:verify", {
         contract: "contracts/protocol/clients/proxy/BosonClientBeacon.sol:BosonClientBeacon",


### PR DESCRIPTION
Boson voucher contract was redeployed, since previous deployment used wrong `forwarderAddress`. This PR updates addrresses file.

Other changes:
- `scripts/config/client-upgrade.js` uses correct address for mumbai network
- `scripts/upgrade-clients.js` now correctly stores constructor argument (needed for verification)
- `scripts/util/report-verify-deployments.js` correctly handles "BosonVoucher Logic" verification