### PR TITLE
fix verifyOnTestEnv() in deploy-suite script

### DIFF
--- a/scripts/util/report-verify-deployments.js
+++ b/scripts/util/report-verify-deployments.js
@@ -33,7 +33,7 @@ async function verifyOnTestEnv(contracts) {
   for (const contract of contracts) {
     console.log(`\n📋 Verifying on test env ${contract.name}`);
     try {
-      const code = await hre.provider.getCode(await contract.getAddress());
+      const code = await hre.ethers.provider.getCode(contract.address);
       if (code === "0x0" || code === "0x") {
         console.log(`❌ Failed to verify ${contract.name} on test env.`);
       }


### PR DESCRIPTION
integrating the pre v2.3.0 version of the protocol in the core-components,  I've detected the following issue with the verifyOnTestEnv() used in the deployment script (only called when network is "test" or "localhost")

- `hre.provider.getCode(...)` is replaced with `hre.ethers.provider.getCode(...`)
  ![image](https://github.com/bosonprotocol/boson-protocol-contracts/assets/7184124/96885a1a-bb09-411b-8071-5d7095da59c4)
- `await contract.getAddress()` is replaced with `contract.address`, as `contract`'s type here is not ethers.Contract, but a structured object with 'name', 'address', ... properties
  ![image](https://github.com/bosonprotocol/boson-protocol-contracts/assets/7184124/1c890dcc-4a10-4930-8a76-ebf9d66bf49e)
