### PR TITLE
Add get getSellersCollectionsPaginated method

### DIFF
--- a/contracts/interfaces/handlers/IBosonAccountHandler.sol
+++ b/contracts/interfaces/handlers/IBosonAccountHandler.sol
@@ -9,7 +9,7 @@ import { IBosonAccountEvents } from "../events/IBosonAccountEvents.sol";
  *
  * @notice Handles creation, update, retrieval of accounts within the protocol.
  *
- * The ERC-165 identifier for this interface is: 0xbc1d7461
+ * The ERC-165 identifier for this interface is: 0x8946080b
  */
 interface IBosonAccountHandler is IBosonAccountEvents {
     /**
@@ -383,7 +383,8 @@ interface IBosonAccountHandler is IBosonAccountEvents {
     ) external view returns (bool exists, BosonTypes.Seller memory seller, BosonTypes.AuthToken memory authToken);
 
     /**
-     * @notice Gets the details about a seller's collections.
+     * @notice Gets the details about all seller's collections.
+     * In case seller has too many collections and this runs out of gas, pleas use getSellersCollectionsPaginated.
      *
      * @param _sellerId - the id of the seller to check
      * @return defaultVoucherAddress - the address of the default voucher contract for the seller
@@ -391,6 +392,22 @@ interface IBosonAccountHandler is IBosonAccountEvents {
      */
     function getSellersCollections(
         uint256 _sellerId
+    ) external view returns (address defaultVoucherAddress, BosonTypes.Collection[] memory additionalCollections);
+
+    /**
+     * @notice Gets the details about all seller's collections.
+     * In case seller has too many collections and this runs out of gas, pleas use getSellersCollectionsPaginated.
+     *
+     * @param _sellerId - the id of the seller to check
+     * @param _limit - the maximum number of Collections that should be returned starting from the index defined by `_offset`. If `_offset` + `_limit` exceeds total number of collections, `_limit` is adjusted to return all remaining collections.
+     * @param _offset - the starting index from which to return collections. If `_offset` is greater than or equal to total number of collections, an empty list is returned.
+     * @return defaultVoucherAddress - the address of the default voucher contract for the seller
+     * @return additionalCollections - an array of additional collections that the seller has created
+     */
+    function getSellersCollectionsPaginated(
+        uint256 _sellerId,
+        uint256 _limit,
+        uint256 _offset
     ) external view returns (address defaultVoucherAddress, BosonTypes.Collection[] memory additionalCollections);
 
     /**

--- a/contracts/protocol/facets/FundsHandlerFacet.sol
+++ b/contracts/protocol/facets/FundsHandlerFacet.sol
@@ -174,16 +174,17 @@ contract FundsHandlerFacet is IBosonFundsHandler, ProtocolBase {
         uint256 _offset
     ) external view override returns (address[] memory tokenList) {
         address[] storage tokens = protocolLookups().tokenList[_entityId];
+        uint256 tokenCount = tokens.length;
 
-        if (_offset >= tokens.length) {
+        if (_offset >= tokenCount) {
             return new address[](0);
-        } else if (_offset + _limit > tokens.length) {
-            _limit = tokens.length - _offset;
+        } else if (_offset + _limit > tokenCount) {
+            _limit = tokenCount - _offset;
         }
 
         tokenList = new address[](_limit);
 
-        for (uint i = 0; i < _limit; ) {
+        for (uint256 i = 0; i < _limit; ) {
             tokenList[i] = tokens[_offset++];
 
             unchecked {

--- a/contracts/protocol/facets/SellerHandlerFacet.sol
+++ b/contracts/protocol/facets/SellerHandlerFacet.sol
@@ -501,7 +501,8 @@ contract SellerHandlerFacet is SellerBase {
     }
 
     /**
-     * @notice Gets the details about a seller's collections.
+     * @notice Gets the details about all seller's collections.
+     * In case seller has too many collections and this runs out of gas, pleas use getSellersCollectionsPaginated.
      *
      * @param _sellerId - the id of the seller to check
      * @return defaultVoucherAddress - the address of the default voucher contract for the seller
@@ -512,6 +513,43 @@ contract SellerHandlerFacet is SellerBase {
     ) external view returns (address defaultVoucherAddress, Collection[] memory additionalCollections) {
         ProtocolLib.ProtocolLookups storage pl = protocolLookups();
         return (pl.cloneAddress[_sellerId], pl.additionalCollections[_sellerId]);
+    }
+
+    /**
+     * @notice Gets the details about all seller's collections.
+     * In case seller has too many collections and this runs out of gas, pleas use getSellersCollectionsPaginated.
+     *
+     * @param _sellerId - the id of the seller to check
+     * @param _limit - the maximum number of Collections that should be returned starting from the index defined by `_offset`. If `_offset` + `_limit` exceeds total number of collections, `_limit` is adjusted to return all remaining collections.
+     * @param _offset - the starting index from which to return collections. If `_offset` is greater than or equal to total number of collections, an empty list is returned.
+     * @return defaultVoucherAddress - the address of the default voucher contract for the seller
+     * @return additionalCollections - an array of additional collections that the seller has created
+     */
+    function getSellersCollectionsPaginated(
+        uint256 _sellerId,
+        uint256 _limit,
+        uint256 _offset
+    ) external view returns (address defaultVoucherAddress, Collection[] memory additionalCollections) {
+        ProtocolLib.ProtocolLookups storage pl = protocolLookups();
+        Collection[] storage sellersAdditionalCollections = pl.additionalCollections[_sellerId];
+        uint256 collectionCount = sellersAdditionalCollections.length;
+
+        if (_offset >= collectionCount) {
+            return (pl.cloneAddress[_sellerId], new Collection[](0));
+        } else if (_offset + _limit > collectionCount) {
+            _limit = collectionCount - _offset;
+        }
+
+        additionalCollections = new Collection[](_limit);
+
+        for (uint256 i = 0; i < _limit; ) {
+            additionalCollections[i] = sellersAdditionalCollections[_offset++];
+            unchecked {
+                i++;
+            }
+        }
+
+        return (pl.cloneAddress[_sellerId], additionalCollections);
     }
 
     /**


### PR DESCRIPTION
Closes #709 

Implementation is slightly different than proposed in the issue. It matches the pattern in the existing `getTokenListPaginated`.
This allows to retrieval of multiple collections with a single call, but with more granular control.

Changes:
- add `getSellersCollectionsPaginated` to `SellerHandlerFacet`
- add corresponding unit tests