### PR TITLE
exclude examples and solc-version detector

### DIFF
--- a/slither.config.json
+++ b/slither.config.json
@@ -1,4 +1,4 @@
 {
-  "filter_paths": "(contracts/mock/|contracts/ext_libs/|node_modules)",
-  "detectors_to_exclude": "uninitialized-local,timestamp, assembly,naming-convention,similar-names"
+  "filter_paths": "(contracts/mock/|contracts/ext_libs/|contracts/example/|node_modules)",
+  "detectors_to_exclude": "uninitialized-local,timestamp,assembly,naming-convention,similar-names,solc-version"
 }


### PR DESCRIPTION
Change slither config to:
 - Exclude contract examples, since they are not part of the protocol
 - Ignore solc-version detector, since we often use a newer version than recommended by slither