### PR TITLE
V2.4.0. protocol initialization

### DIFF
--- a/contracts/protocol/facets/ProtocolInitializationHandlerFacet.sol
+++ b/contracts/protocol/facets/ProtocolInitializationHandlerFacet.sol
@@ -35,12 +35,6 @@ contract ProtocolInitializationHandlerFacet is IBosonProtocolInitializationHandl
      */
     constructor() {
         thisAddress = address(this);
-
-        mapping(bytes32 => function(bytes calldata) internal) storage initFunctions = initFunctionsPtr();
-        initFunctions[bytes32("2.2.0")] = initV2_2_0;
-        initFunctions[bytes32("2.2.1")] = initV2_2_1;
-        initFunctions[bytes32("2.3.0")] = initV2_3_0;
-        initFunctions[bytes32("2.4.0")] = initV2_4_0;
     }
 
     /**
@@ -103,7 +97,15 @@ contract ProtocolInitializationHandlerFacet is IBosonProtocolInitializationHandl
 
         // ProtocolLib.ProtocolStatus storage status = protocolStatus();
         if (_isUpgrade) {
-            initVersion(_version, _initializationData);
+            if (_version == bytes32("2.2.0")) {
+                initV2_2_0(_initializationData);
+            } else if (_version == bytes32("2.2.1")) {
+                initV2_2_1();
+            } else if (_version == bytes32("2.3.0")) {
+                initV2_3_0(_initializationData);
+            } else if (_version == bytes32("2.4.0")) {
+                initV2_4_0(_initializationData);
+            }
         }
 
         removeInterfaces(_interfacesToRemove);
@@ -112,22 +114,6 @@ contract ProtocolInitializationHandlerFacet is IBosonProtocolInitializationHandl
         protocolStatus().version = _version;
 
         emit ProtocolInitialized(string(abi.encodePacked(_version)));
-    }
-
-    /**
-     * @notice Retrieves correct initialization function based on the version and passes the _initializationData to it.
-     *
-     *
-     * @param _initializationData - data representing uint256 _maxPremintedVouchers
-     */
-    function initVersion(bytes32 _version, bytes calldata _initializationData) internal {
-        mapping(bytes32 => function(bytes calldata) internal) storage initFunctions = initFunctionsPtr();
-        function(bytes calldata) internal initFunction = initFunctions[_version];
-
-        // If _version is not on the list, skip initialization
-        if (initFunction != initFunctions[0x0]) {
-            initFunction(_initializationData);
-        }
     }
 
     /**
@@ -151,7 +137,7 @@ contract ProtocolInitializationHandlerFacet is IBosonProtocolInitializationHandl
     /**
      * @notice Initializes the version 2.2.0.
      */
-    function initV2_2_1(bytes calldata) internal view {
+    function initV2_2_1() internal view {
         // Current version must be 2.2.0
         if (protocolStatus().version != bytes32("2.2.0")) revert WrongCurrentVersion();
     }
@@ -196,13 +182,69 @@ contract ProtocolInitializationHandlerFacet is IBosonProtocolInitializationHandl
     /**
      * @notice Initializes the version 2.4.0.
      *
+     * Initliaziation data is used to back-fill the royalty recipients for existing offers and sellers.
+     * The data is grouped by royalty percentage, so if more sellers and/or have the same royalty percentage, they can be grouped together.
+     * Supplied royalty percentage should match the current percentage set in seller's boson voucher contract.
+     * If seller has multiple collections with different royalty precentages:
+     *  - the sellerId should be included in the group, corresponding to the minimal royalty percentage
+     *  - the _offerIds array should should be included in the group, corresponding to the royalty percentage that matches the royalty of the collection to which offer belongs
+     * If some offer is voided, or has no active vouchers, it can be omitted.
+     *
+     * If the amount of data is too large, it can be split into multiple `initV2_4_0Public` calls, that should be made before calling initialize.
+     *
+     * N.B. this method does not validate that the seller exists, or that it's unique.
+     *
      * Reverts if:
      *  - Current version is not 2.3.0
+     *  - Length of _sellerIds, _royaltyPercentages and _offerIds arrays do not match
+     *  - Any of the offerIds does not exist
      *
+     * @param _initializationData - data representing uint256[] _sellerIds, uint256[] _royaltyPercentages, uint256[][] _offerIds
      */
-    function initV2_4_0(bytes calldata) internal view {
+    function initV2_4_0(bytes calldata _initializationData) internal {
         // Current version must be 2.3.0
         if (protocolStatus().version != bytes32("2.3.0")) revert WrongCurrentVersion();
+
+        (uint256[] memory _royaltyPercentages, uint256[][] memory _sellerIds, uint256[][] memory _offerIds) = abi
+            .decode(_initializationData, (uint256[], uint256[][], uint256[][]));
+
+        if (_royaltyPercentages.length != _sellerIds.length || _royaltyPercentages.length != _offerIds.length)
+            revert ArrayLengthMismatch();
+        ProtocolLib.ProtocolLookups storage lookups = protocolLookups();
+
+        for (uint256 i = 0; i < _royaltyPercentages.length; i++) {
+            // Populate sellers' Royalty Recipients
+            for (uint256 j = 0; j < _sellerIds[i].length; j++) {
+                RoyaltyRecipient storage defaultRoyaltyRecipient = lookups
+                    .royaltyRecipientsBySeller[_sellerIds[i][j]]
+                    .push();
+                defaultRoyaltyRecipient.minRoyaltyPercentage = _royaltyPercentages[i];
+            }
+
+            // Populate offers' Royalty Info
+            for (uint256 j = 0; j < _offerIds[i].length; j++) {
+                (bool exist, Offer storage offer) = fetchOffer(_offerIds[i][j]);
+                if (!exist) revert NoSuchOffer();
+
+                RoyaltyInfo storage royaltyInfo = offer.royaltyInfo.push();
+                royaltyInfo.recipients.push(payable(address(0))); // default recipient
+                royaltyInfo.bps.push(_royaltyPercentages[i]);
+            }
+        }
+    }
+
+    /**
+     * @notice Method to initialize the protocol if it cannot be done in a single transaction.
+     *
+     * This shuld be used only if the amount of data is too large, and it cannot be done in a single `initialize` transaction.
+     * This method should be called before `initialize` method.
+     * This method should not be registered as a diamond public method.
+     * Refer to initV2_4_0 for more details about the data structure.
+     *
+     * @param _initializationData - data representing uint256[] _sellerIds, uint256[] _royaltyPercentages, uint256[][] _offerIds
+     */
+    function initV2_4_0External(bytes calldata _initializationData) external onlyRole(UPGRADER) {
+        initV2_4_0(_initializationData);
     }
 
     /**
@@ -231,21 +273,6 @@ contract ProtocolInitializationHandlerFacet is IBosonProtocolInitializationHandl
             unchecked {
                 i++;
             }
-        }
-    }
-
-    /**
-     * @notice Returns the pointer to initialization functions mappings.
-     *
-     */
-    function initFunctionsPtr()
-        internal
-        pure
-        returns (mapping(bytes32 => function(bytes calldata) internal) storage initFunctions)
-    {
-        bytes32 position = PROTOCOL_INIT_TX_POSITION;
-        assembly {
-            initFunctions.slot := position
         }
     }
 }

--- a/contracts/protocol/facets/SellerHandlerFacet.sol
+++ b/contracts/protocol/facets/SellerHandlerFacet.sol
@@ -159,8 +159,9 @@ contract SellerHandlerFacet is SellerBase {
                     .royaltyRecipientIndexBySellerAndRecipient[_seller.id];
                 uint256 royaltyRecipientId = royaltyRecipientIndexBySellerAndRecipient[_seller.treasury];
 
-                RoyaltyRecipient[] storage royaltyRecipients = lookups.royaltyRecipientsBySeller[_seller.id];
                 if (royaltyRecipientId != 0) {
+                    RoyaltyRecipient[] storage royaltyRecipients = lookups.royaltyRecipientsBySeller[_seller.id];
+
                     // If the new treasury is already a royalty recipient, remove it
                     royaltyRecipientId--; // royaltyRecipientId is 1-based, so we need to decrement it to get the index
                     uint256 lastRoyaltyRecipientsId = royaltyRecipients.length - 1;
@@ -178,7 +179,7 @@ contract SellerHandlerFacet is SellerBase {
 
                 updateApplied = true;
 
-                emit RoyaltyRecipientsChanged(_seller.id, royaltyRecipients, msgSender());
+                emit RoyaltyRecipientsChanged(_seller.id, fetchRoyaltyRecipients(_seller.id), msgSender());
             }
 
             if (keccak256(bytes(_seller.metadataUri)) != keccak256(bytes(seller.metadataUri))) {
@@ -505,7 +506,7 @@ contract SellerHandlerFacet is SellerBase {
             }
         }
 
-        emit RoyaltyRecipientsChanged(_sellerId, royaltyRecipients, sender);
+        emit RoyaltyRecipientsChanged(_sellerId, fetchRoyaltyRecipients(_sellerId), sender);
     }
 
     /**
@@ -584,7 +585,7 @@ contract SellerHandlerFacet is SellerBase {
             }
         }
 
-        emit RoyaltyRecipientsChanged(_sellerId, royaltyRecipients, msgSender());
+        emit RoyaltyRecipientsChanged(_sellerId, fetchRoyaltyRecipients(_sellerId), msgSender());
     }
 
     /**
@@ -648,7 +649,7 @@ contract SellerHandlerFacet is SellerBase {
             }
         }
 
-        emit RoyaltyRecipientsChanged(_sellerId, royaltyRecipients, sender);
+        emit RoyaltyRecipientsChanged(_sellerId, fetchRoyaltyRecipients(_sellerId), sender);
     }
 
     /**
@@ -845,7 +846,7 @@ contract SellerHandlerFacet is SellerBase {
     function getRoyaltyRecipients(
         uint256 _sellerId
     ) external view returns (RoyaltyRecipient[] memory royaltyRecipients) {
-        return protocolLookups().royaltyRecipientsBySeller[_sellerId];
+        return fetchRoyaltyRecipients(_sellerId);
     }
 
     /**


### PR DESCRIPTION
Due to recent changes, existing sellers are missing `royaltyRecipients` and offers are missing `royaltyInfo`.

This data should be filled in during the initialization of the next version.

This PR adds `initV2_4_0` which is used to populate missing data.