### PR TITLE
Tight pack Offer struct

### DIFF
--- a/contracts/domain/BosonTypes.sol
+++ b/contracts/domain/BosonTypes.sol
@@ -153,11 +153,11 @@ contract BosonTypes {
         uint256 buyerCancelPenalty;
         uint256 quantityAvailable;
         address exchangeToken;
+        PriceType priceType;
         string metadataUri;
         string metadataHash;
         bool voided;
         uint256 collectionIndex;
-        PriceType priceType;
         RoyaltyInfo[] royaltyInfo;
     }
 

--- a/contracts/interfaces/handlers/IBosonOfferHandler.sol
+++ b/contracts/interfaces/handlers/IBosonOfferHandler.sol
@@ -10,7 +10,7 @@ import { IBosonOfferEvents } from "../events/IBosonOfferEvents.sol";
  *
  * @notice Handles creation, voiding, and querying of offers within the protocol.
  *
- * The ERC-165 identifier for this interface is: 0xfe4be526
+ * The ERC-165 identifier for this interface is: 0x91b54fdc
  */
 interface IBosonOfferHandler is BosonErrors, IBosonOfferEvents {
     /**

--- a/contracts/interfaces/handlers/IBosonOrchestrationHandler.sol
+++ b/contracts/interfaces/handlers/IBosonOrchestrationHandler.sol
@@ -14,7 +14,7 @@ import { IBosonBundleEvents } from "../events/IBosonBundleEvents.sol";
  *
  * @notice Combines creation of multiple entities (accounts, offers, groups, twins, bundles) in a single transaction
  *
- * The ERC-165 identifier for this interface is: 0xb0f85bb8
+ * The ERC-165 identifier for this interface is: 0x44eb95ca
  */
 interface IBosonOrchestrationHandler is
     IBosonAccountEvents,

--- a/scripts/domain/Offer.js
+++ b/scripts/domain/Offer.js
@@ -23,11 +23,11 @@ class Offer {
             uint256 buyerCancelPenalty;
             uint256 quantityAvailable;
             address exchangeToken;
+            PriceType priceType;
             string metadataUri;
             string metadataHash;
             bool voided;
             uint256 collectionIndex;            
-            PriceType priceType;
             RoyaltyInfo[] royaltyInfo;
         }
     */
@@ -40,11 +40,11 @@ class Offer {
     buyerCancelPenalty,
     quantityAvailable,
     exchangeToken,
+    priceType,
     metadataUri,
     metadataHash,
     voided,
     collectionIndex,
-    priceType,
     royaltyInfo
   ) {
     this.id = id;
@@ -54,11 +54,11 @@ class Offer {
     this.buyerCancelPenalty = buyerCancelPenalty;
     this.quantityAvailable = quantityAvailable;
     this.exchangeToken = exchangeToken;
+    this.priceType = priceType;
     this.metadataUri = metadataUri;
     this.metadataHash = metadataHash;
     this.voided = voided;
     this.collectionIndex = collectionIndex;
-    this.priceType = priceType;
     this.royaltyInfo = royaltyInfo;
   }
 
@@ -76,11 +76,11 @@ class Offer {
       buyerCancelPenalty,
       quantityAvailable,
       exchangeToken,
+      priceType,
       metadataUri,
       metadataHash,
       voided,
       collectionIndex,
-      priceType,
       royaltyInfo,
     } = o;
 
@@ -92,11 +92,11 @@ class Offer {
       buyerCancelPenalty,
       quantityAvailable,
       exchangeToken,
+      priceType,
       metadataUri,
       metadataHash,
       voided,
       collectionIndex,
-      priceType,
       royaltyInfo.map((ri) => RoyaltyInfo.fromObject(ri))
     );
   }
@@ -114,11 +114,11 @@ class Offer {
       buyerCancelPenalty,
       quantityAvailable,
       exchangeToken,
+      priceType,
       metadataUri,
       metadataHash,
       voided,
       collectionIndex,
-      priceType,
       royaltyInfo;
 
     // destructure struct
@@ -130,11 +130,11 @@ class Offer {
       buyerCancelPenalty,
       quantityAvailable,
       exchangeToken,
+      priceType,
       metadataUri,
       metadataHash,
       voided,
       collectionIndex,
-      priceType,
       royaltyInfo,
     ] = struct;
     if (!collectionIndex) {
@@ -149,11 +149,11 @@ class Offer {
       buyerCancelPenalty: buyerCancelPenalty.toString(),
       quantityAvailable: quantityAvailable.toString(),
       exchangeToken,
+      priceType: Number(priceType),
       metadataUri,
       metadataHash,
       voided,
       collectionIndex: collectionIndex.toString(),
-      priceType: Number(priceType),
       royaltyInfo: royaltyInfo.map((ri) => RoyaltyInfo.fromStruct(ri)),
     });
   }
@@ -187,11 +187,11 @@ class Offer {
       this.buyerCancelPenalty,
       this.quantityAvailable,
       this.exchangeToken,
+      this.priceType,
       this.metadataUri,
       this.metadataHash,
       this.voided,
       this.collectionIndex,
-      this.priceType,
       new RoyaltyInfoList(this.royaltyInfo).toStruct(),
     ];
   }
@@ -270,6 +270,14 @@ class Offer {
   }
 
   /**
+   * Is this Offer instance's priceType field valid?
+   * @returns {boolean}
+   */
+  priceTypeIsValid() {
+    return enumIsValid(this.priceType, PriceType.Types);
+  }
+
+  /**
    * Is this Offer instance's metadataUri field valid?
    * Always present, must be a string
    *
@@ -307,14 +315,6 @@ class Offer {
   }
 
   /**
-   * Is this Offer instance's priceType field valid?
-   * @returns {boolean}
-   */
-  priceTypeIsValid() {
-    return enumIsValid(this.priceType, PriceType.Types);
-  }
-
-  /**
    * Is this Offer instance's royaltyInfo field valid?
    * Must be a valid RoyaltyInfo instance
    * @returns {boolean}
@@ -342,11 +342,11 @@ class Offer {
       this.buyerCancelPenaltyIsValid() &&
       this.quantityAvailableIsValid() &&
       this.exchangeTokenIsValid() &&
+      this.priceTypeIsValid() &&
       this.metadataUriIsValid() &&
       this.metadataHashIsValid() &&
       this.voidedIsValid() &&
       this.collectionIndexIsValid() &&
-      this.priceTypeIsValid() &&
       this.royaltyInfoIsValid()
     );
   }

--- a/test/domain/OfferTest.js
+++ b/test/domain/OfferTest.js
@@ -19,11 +19,11 @@ describe("Offer", function () {
     buyerCancelPenalty,
     quantityAvailable,
     exchangeToken,
+    priceType,
     metadataUri,
     metadataHash,
     voided,
     collectionIndex,
-    priceType,
     royaltyInfo;
 
   beforeEach(async function () {
@@ -37,11 +37,11 @@ describe("Offer", function () {
     buyerCancelPenalty = parseUnits("0.05", "ether").toString();
     quantityAvailable = "1";
     exchangeToken = ZeroAddress.toString(); // Zero addy ~ chain base currency
+    priceType = PriceType.Static;
     metadataHash = "QmYXc12ov6F2MZVZwPs5XeCBbf61cW3wKRk8h3D5NTYj4T"; // not an actual metadataHash, just some data for tests
     metadataUri = `https://ipfs.io/ipfs/${metadataHash}`;
     voided = false;
     collectionIndex = "2";
-    priceType = PriceType.Static;
     royaltyInfo = [
       new RoyaltyInfo(
         accounts.slice(0, 3).map((a) => a.address),
@@ -61,11 +61,11 @@ describe("Offer", function () {
         buyerCancelPenalty,
         quantityAvailable,
         exchangeToken,
+        priceType,
         metadataUri,
         metadataHash,
         voided,
         collectionIndex,
-        priceType,
         royaltyInfo
       );
       expect(offer.idIsValid()).is.true;
@@ -75,11 +75,11 @@ describe("Offer", function () {
       expect(offer.buyerCancelPenaltyIsValid()).is.true;
       expect(offer.quantityAvailableIsValid()).is.true;
       expect(offer.exchangeTokenIsValid()).is.true;
+      expect(offer.priceTypeIsValid()).is.true;
       expect(offer.metadataUriIsValid()).is.true;
       expect(offer.metadataHashIsValid()).is.true;
       expect(offer.voidedIsValid()).is.true;
       expect(offer.collectionIndexIsValid()).is.true;
-      expect(offer.priceTypeIsValid()).is.true;
       expect(offer.royaltyInfoIsValid()).is.true;
       expect(offer.isValid()).is.true;
     });
@@ -96,11 +96,11 @@ describe("Offer", function () {
         buyerCancelPenalty,
         quantityAvailable,
         exchangeToken,
+        priceType,
         metadataUri,
         metadataHash,
         voided,
         collectionIndex,
-        priceType,
         royaltyInfo
       );
       expect(offer.isValid()).is.true;
@@ -260,6 +260,43 @@ describe("Offer", function () {
       expect(offer.isValid()).is.true;
     });
 
+    it("Always present, priceType must be a valid PriceType", async function () {
+      // Invalid field value
+      offer.priceType = "zedzdeadbaby";
+      expect(offer.priceTypeIsValid()).is.false;
+      expect(offer.isValid()).is.false;
+
+      // Invalid field value
+      offer.priceType = new Date();
+      expect(offer.priceTypeIsValid()).is.false;
+      expect(offer.isValid()).is.false;
+
+      // Invalid field value
+      offer.priceType = 12;
+      expect(offer.priceTypeIsValid()).is.false;
+      expect(offer.isValid()).is.false;
+
+      // Invalid field value
+      offer.priceType = "0";
+      expect(offer.priceTypeIsValid()).is.false;
+      expect(offer.isValid()).is.false;
+
+      // Invalid field value
+      offer.priceType = "126";
+      expect(offer.priceTypeIsValid()).is.false;
+      expect(offer.isValid()).is.false;
+
+      // Valid field value
+      offer.priceType = PriceType.Static;
+      expect(offer.priceTypeIsValid()).is.true;
+      expect(offer.isValid()).is.true;
+
+      // Valid field value
+      offer.priceType = PriceType.Discovery;
+      expect(offer.priceTypeIsValid()).is.true;
+      expect(offer.isValid()).is.true;
+    });
+
     it("Always present, metadataUri must be a non-empty string", async function () {
       // Invalid field value
       offer.metadataUri = 12;
@@ -343,43 +380,6 @@ describe("Offer", function () {
       expect(offer.isValid()).is.true;
     });
 
-    it("Always present, priceType must be a valid PriceType", async function () {
-      // Invalid field value
-      offer.priceType = "zedzdeadbaby";
-      expect(offer.priceTypeIsValid()).is.false;
-      expect(offer.isValid()).is.false;
-
-      // Invalid field value
-      offer.priceType = new Date();
-      expect(offer.priceTypeIsValid()).is.false;
-      expect(offer.isValid()).is.false;
-
-      // Invalid field value
-      offer.priceType = 12;
-      expect(offer.priceTypeIsValid()).is.false;
-      expect(offer.isValid()).is.false;
-
-      // Invalid field value
-      offer.priceType = "0";
-      expect(offer.priceTypeIsValid()).is.false;
-      expect(offer.isValid()).is.false;
-
-      // Invalid field value
-      offer.priceType = "126";
-      expect(offer.priceTypeIsValid()).is.false;
-      expect(offer.isValid()).is.false;
-
-      // Valid field value
-      offer.priceType = PriceType.Static;
-      expect(offer.priceTypeIsValid()).is.true;
-      expect(offer.isValid()).is.true;
-
-      // Valid field value
-      offer.priceType = PriceType.Discovery;
-      expect(offer.priceTypeIsValid()).is.true;
-      expect(offer.isValid()).is.true;
-    });
-
     it("Always present, royaltyInfo must be a RoyaltyInfo instance", async function () {
       // Invalid field value
       offer.royaltyInfo = 12;
@@ -421,11 +421,11 @@ describe("Offer", function () {
         buyerCancelPenalty,
         quantityAvailable,
         exchangeToken,
+        priceType,
         metadataUri,
         metadataHash,
         voided,
         collectionIndex,
-        priceType,
         royaltyInfo
       );
       expect(offer.isValid()).is.true;
@@ -439,11 +439,11 @@ describe("Offer", function () {
         buyerCancelPenalty,
         quantityAvailable,
         exchangeToken,
+        priceType,
         metadataUri,
         metadataHash,
         voided,
         collectionIndex,
-        priceType,
         royaltyInfo,
       };
     });
@@ -471,11 +471,11 @@ describe("Offer", function () {
           offer.buyerCancelPenalty,
           offer.quantityAvailable,
           offer.exchangeToken,
+          offer.priceType,
           offer.metadataUri,
           offer.metadataHash,
           offer.voided,
           offer.collectionIndex,
-          offer.priceType,
           royaltyInfo.map((ri) => ri.toStruct()),
         ];
 

--- a/test/protocol/MetaTransactionsHandlerTest.js
+++ b/test/protocol/MetaTransactionsHandlerTest.js
@@ -3476,7 +3476,7 @@ describe("IBosonMetaTransactionsHandler", function () {
           message.from = await assistant.getAddress();
           message.contractAddress = await offerHandler.getAddress();
           message.functionName =
-            "createOffer((uint256,uint256,uint256,uint256,uint256,uint256,address,string,string,bool,uint256,uint8,(address[],uint256[])[]),(uint256,uint256,uint256,uint256),(uint256,uint256,uint256),uint256,uint256,uint256)";
+            "createOffer((uint256,uint256,uint256,uint256,uint256,uint256,address,uint8,string,string,bool,uint256,(address[],uint256[])[]),(uint256,uint256,uint256,uint256),(uint256,uint256,uint256),uint256,uint256,uint256)";
           message.functionSignature = functionSignature;
         });
 

--- a/test/protocol/ProtocolInitializationHandlerTest.js
+++ b/test/protocol/ProtocolInitializationHandlerTest.js
@@ -1017,9 +1017,9 @@ describe("ProtocolInitializationHandler", async function () {
           const offerSlot = BigInt(
             getMappingStoragePosition(protocolEntitiesSlotNumber + 0n, Number(offerId), paddingType.START)
           );
-          const royaltyInfoLength = offerSlot + 12n;
+          const royaltyInfoLength = offerSlot + 11n;
           await setStorageAt(protocolAddress, royaltyInfoLength, "0x"); // royaltyInfo length set to zero
-          const royaltyInfoSlot = BigInt(keccak256(Buffer.from((offerSlot + 12n).toString(16), "hex")));
+          const royaltyInfoSlot = BigInt(keccak256(Buffer.from((offerSlot + 11n).toString(16), "hex")));
           await setStorageAt(protocolAddress, royaltyInfoSlot + 0n, "0x"); // set royaltyInfo.recipients length to zero
           await setStorageAt(protocolAddress, royaltyInfoSlot + 1n, "0x"); // set royaltyInfo.bps length to zero
 

--- a/test/util/mock.js
+++ b/test/util/mock.js
@@ -72,11 +72,11 @@ async function mockOffer({ refreshModule } = {}) {
   const buyerCancelPenalty = parseUnits("0.05", "ether").toString();
   const quantityAvailable = "1";
   const exchangeToken = ZeroAddress.toString(); // Zero addy ~ chain base currency
+  const priceType = PriceType.Static;
   const metadataHash = "QmYXc12ov6F2MZVZwPs5XeCBbf61cW3wKRk8h3D5NTYj4T"; // not an actual metadataHash, just some data for tests
   const metadataUri = `https://ipfs.io/ipfs/${metadataHash}`;
   const voided = false;
   const collectionIndex = "0";
-  const priceType = PriceType.Static;
   const royaltyInfo = [new RoyaltyInfo([ZeroAddress], ["0"])];
 
   // Create a valid offer, then set fields in tests directly
@@ -88,11 +88,11 @@ async function mockOffer({ refreshModule } = {}) {
     buyerCancelPenalty,
     quantityAvailable,
     exchangeToken,
+    priceType,
     metadataUri,
     metadataHash,
     voided,
     collectionIndex,
-    priceType,
     royaltyInfo
   );
 


### PR DESCRIPTION
From v2.3.0 to v2.4.0 a PriceType field was added to the Offers struct.
Given that it is of type `Enum`, it can be tightly packed in the same slot with exchange token address.