### PR TITLE
[PDB-01M] Arbitrary External Contract Calls

### DIFF
--- a/contracts/domain/BosonErrors.sol
+++ b/contracts/domain/BosonErrors.sol
@@ -340,8 +340,8 @@ interface BosonErrors {
     error InteractionNotAllowed();
 
     // Price discovery related
-    // Price discovery returned a price that is too low
-    error PriceTooLow();
+    // Price discovery returned a price that does not match the expected one
+    error PriceMismatch();
     // Token id is mandatory for bid orders and wrappers
     error TokenIdMandatory();
     // Incoming token id does not match the expected one

--- a/contracts/domain/BosonErrors.sol
+++ b/contracts/domain/BosonErrors.sol
@@ -362,6 +362,8 @@ interface BosonErrors {
     error NegativePriceNotAllowed();
     // Price discovery did not send the voucher to the protocol
     error VoucherNotReceived();
+    // Price discovery did not send the voucher from the protocol
+    error VoucherNotTransferred();
     // Either token with wrong id received or wrong voucher contract made the transfer
     error UnexpectedERC721Received();
     // Royalty fee exceeds the price

--- a/contracts/example/Sudoswap/SudoswapWrapper.sol
+++ b/contracts/example/Sudoswap/SudoswapWrapper.sol
@@ -60,6 +60,7 @@ contract SudoswapWrapper is BosonTypes, Ownable, ERC721 {
     address private poolAddress;
     address private immutable factoryAddress;
     address private immutable protocolAddress;
+    address private immutable unwrapperAddress;
     address private immutable wethAddress;
 
     // Mapping from token ID to price. If pendingTokenId == tokenId, this is not the final price.
@@ -80,12 +81,14 @@ contract SudoswapWrapper is BosonTypes, Ownable, ERC721 {
         address _voucherAddress,
         address _factoryAddress,
         address _protocolAddress,
-        address _wethAddress
+        address _wethAddress,
+        address _unwrapperAddress
     ) ERC721(getVoucherName(_voucherAddress), getVoucherSymbol(_voucherAddress)) {
         voucherAddress = _voucherAddress;
         factoryAddress = _factoryAddress;
         protocolAddress = _protocolAddress;
         wethAddress = _wethAddress;
+        unwrapperAddress = _unwrapperAddress;
 
         // Approve pool to transfer wrapped vouchers
         _setApprovalForAll(address(this), _factoryAddress, true);
@@ -137,7 +140,7 @@ contract SudoswapWrapper is BosonTypes, Ownable, ERC721 {
         // Either contract owner or protocol can unwrap
         // If contract owner is unwrapping, this is equivalent to removing the voucher from the pool
         require(
-            msg.sender == protocolAddress || wrappedVoucherOwner == msg.sender,
+            msg.sender == unwrapperAddress || wrappedVoucherOwner == msg.sender,
             "SudoswapWrapper: Only owner or protocol can unwrap"
         );
 
@@ -152,7 +155,7 @@ contract SudoswapWrapper is BosonTypes, Ownable, ERC721 {
         // Transfer token to protocol
         if (priceToPay > 0) {
             // This example only supports WETH
-            IERC20(cachedExchangeToken[_tokenId]).safeTransfer(protocolAddress, priceToPay);
+            IERC20(cachedExchangeToken[_tokenId]).safeTransfer(unwrapperAddress, priceToPay);
         }
 
         delete cachedExchangeToken[_tokenId]; // gas refund

--- a/contracts/example/ZoraWrapper/ZoraWrapper.sol
+++ b/contracts/example/ZoraWrapper/ZoraWrapper.sol
@@ -50,6 +50,7 @@ contract ZoraWrapper is BosonTypes, ERC721, IERC721Receiver {
     address private immutable voucherAddress;
     address private immutable zoraAuctionHouseAddress;
     address private immutable protocolAddress;
+    address private immutable unwrapperAddress;
     address private immutable wethAddress;
 
     // Token ID for which the price is not yet known
@@ -73,12 +74,14 @@ contract ZoraWrapper is BosonTypes, ERC721, IERC721Receiver {
         address _voucherAddress,
         address _zoraAuctionHouseAddress,
         address _protocolAddress,
-        address _wethAddress
+        address _wethAddress,
+        address _unwrapperAddress
     ) ERC721(getVoucherName(_voucherAddress), getVoucherSymbol(_voucherAddress)) {
         voucherAddress = _voucherAddress;
         zoraAuctionHouseAddress = _zoraAuctionHouseAddress;
         protocolAddress = _protocolAddress;
         wethAddress = _wethAddress;
+        unwrapperAddress = _unwrapperAddress;
 
         // Approve Zora Auction House to transfer wrapped vouchers
         _setApprovalForAll(address(this), _zoraAuctionHouseAddress, true);
@@ -132,7 +135,7 @@ contract ZoraWrapper is BosonTypes, ERC721, IERC721Receiver {
         // Either contract owner or protocol can unwrap
         // If contract owner is unwrapping, this is equivalent to canceled auction
         require(
-            msg.sender == protocolAddress || wrappedVoucherOwner == msg.sender,
+            msg.sender == unwrapperAddress || wrappedVoucherOwner == msg.sender,
             "ZoraWrapper: Only owner or protocol can unwrap"
         );
 
@@ -151,7 +154,7 @@ contract ZoraWrapper is BosonTypes, ERC721, IERC721Receiver {
         // Transfer token to protocol
         if (priceToPay > 0) {
             // No need to handle native separately, since Zora Auction House always sends WETH
-            IERC20(cachedExchangeToken[_tokenId]).safeTransfer(protocolAddress, priceToPay);
+            IERC20(cachedExchangeToken[_tokenId]).safeTransfer(unwrapperAddress, priceToPay);
         }
 
         delete cachedExchangeToken[_tokenId]; // gas refund

--- a/contracts/interfaces/clients/IBosonPriceDiscovery.sol
+++ b/contracts/interfaces/clients/IBosonPriceDiscovery.sol
@@ -10,22 +10,16 @@ import { BosonTypes } from "../../domain/BosonTypes.sol";
  *
  * @notice This is the interface for the Boson Price Discovery contract.
  *
- * The ERC-165 identifier for this interface is: 0x9ec79e15
+ * The ERC-165 identifier for this interface is: 0x8bcce417
  */
 interface IBosonPriceDiscovery is IERC721Receiver {
     /**
      * @notice Fulfils an ask order on external contract.
      *
      * Reverts if:
-     * - Offer price is in native token and caller does not send enough
-     * - Offer price is in some ERC20 token and caller also sends native currency
-     * - Calling transferFrom on token fails for some reason (e.g. the Boson Price Discovery Client is not approved to transfer)
      * - Call to price discovery contract fails
-     * - Received amount is greater from price set in price discovery
-     * - Boson Price Discovery Client does not receive the voucher
-     * - Transfer of voucher to the buyer fails for some reason (e.g. buyer is contract that doesn't accept voucher)
-     * - New voucher owner is not buyer wallet
-     * - Token id sent to buyer and token id set by the caller don't match (if caller has provided token id)
+     * - The implied price is negative
+     * - Any external calls to erc20 contract fail
      *
      * @param _exchangeToken - the address of the exchange contract
      * @param _priceDiscovery - the fully populated BosonTypes.PriceDiscovery struct
@@ -44,15 +38,12 @@ interface IBosonPriceDiscovery is IERC721Receiver {
      * @notice Fulfils a bid order on external contract.
      *
      * Reverts if:
-     * - Token id not set by the caller
-     * - Calling transferFrom on token fails for some reason (e.g. protocol is not approved to transfer)
-     * - Transfer of voucher to the buyer fails for some reason (e.g. buyer is contract that doesn't accept voucher)
-     * - Received ERC20 token amount differs from the expected value
      * - Call to price discovery contract fails
      * - Protocol balance change after price discovery call is lower than the expected price
-     * - Reseller did not approve protocol to transfer exchange token in escrow
-     * - New voucher owner is not buyer wallet
+     * - This contract is still owner of the voucher
      * - Token id sent to buyer and token id set by the caller don't match
+     * - The implied price is negative
+     * - Any external calls to erc20 contract fail
      *
      * @param _tokenId - the id of the token
      * @param _exchangeToken - the address of the exchange token
@@ -69,14 +60,14 @@ interface IBosonPriceDiscovery is IERC721Receiver {
         IBosonVoucher _bosonVoucher
     ) external payable returns (uint256 actualPrice);
 
-    /*
+    /**
      * @notice Call `unwrap` (or equivalent) function on the price discovery contract.
      *
      * Reverts if:
-     * - Token id not set by the caller
      * - Protocol balance doesn't increase by the expected amount.
-     *   Balance change must be equal to the price set by the caller
      * - Token id sent to buyer and token id set by the caller don't match
+     * - The wrapper contract sends back the native currency
+     * - The implied price is negative
      *
      * @param _exchangeToken - the address of the exchange contract
      * @param _priceDiscovery - the fully populated BosonTypes.PriceDiscovery struct

--- a/contracts/interfaces/clients/IBosonPriceDiscovery.sol
+++ b/contracts/interfaces/clients/IBosonPriceDiscovery.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.22;
+
+import { IBosonVoucher } from "./IBosonVoucher.sol";
+import { IERC721Receiver } from "../IERC721Receiver.sol";
+import { BosonTypes } from "../../domain/BosonTypes.sol";
+
+/**
+ * @title BosonPriceDiscovery
+ *
+ * @notice This is the interface for the Boson Price Discovery contract.
+ *
+ * The ERC-165 identifier for this interface is: 0x9ec79e15
+ */
+interface IBosonPriceDiscovery is IERC721Receiver {
+    /**
+     * @notice Fulfils an ask order on external contract.
+     *
+     * Reverts if:
+     * - Offer price is in native token and caller does not send enough
+     * - Offer price is in some ERC20 token and caller also sends native currency
+     * - Calling transferFrom on token fails for some reason (e.g. the Boson Price Discovery Client is not approved to transfer)
+     * - Call to price discovery contract fails
+     * - Received amount is greater from price set in price discovery
+     * - Boson Price Discovery Client does not receive the voucher
+     * - Transfer of voucher to the buyer fails for some reason (e.g. buyer is contract that doesn't accept voucher)
+     * - New voucher owner is not buyer wallet
+     * - Token id sent to buyer and token id set by the caller don't match (if caller has provided token id)
+     *
+     * @param _exchangeToken - the address of the exchange contract
+     * @param _priceDiscovery - the fully populated BosonTypes.PriceDiscovery struct
+     * @param _bosonVoucher - the boson voucher contract
+     * @param _msgSender - the address of the caller, as seen in boson protocol
+     * @return actualPrice - the actual price of the order
+     */
+    function fulfilAskOrder(
+        address _exchangeToken,
+        BosonTypes.PriceDiscovery calldata _priceDiscovery,
+        IBosonVoucher _bosonVoucher,
+        address payable _msgSender
+    ) external returns (uint256 actualPrice);
+
+    /**
+     * @notice Fulfils a bid order on external contract.
+     *
+     * Reverts if:
+     * - Token id not set by the caller
+     * - Calling transferFrom on token fails for some reason (e.g. protocol is not approved to transfer)
+     * - Transfer of voucher to the buyer fails for some reason (e.g. buyer is contract that doesn't accept voucher)
+     * - Received ERC20 token amount differs from the expected value
+     * - Call to price discovery contract fails
+     * - Protocol balance change after price discovery call is lower than the expected price
+     * - Reseller did not approve protocol to transfer exchange token in escrow
+     * - New voucher owner is not buyer wallet
+     * - Token id sent to buyer and token id set by the caller don't match
+     *
+     * @param _tokenId - the id of the token
+     * @param _exchangeToken - the address of the exchange token
+     * @param _priceDiscovery - the fully populated BosonTypes.PriceDiscovery struct
+     * @param _seller - the seller's address
+     * @param _bosonVoucher - the boson voucher contract
+     * @return actualPrice - the actual price of the order
+     */
+    function fulfilBidOrder(
+        uint256 _tokenId,
+        address _exchangeToken,
+        BosonTypes.PriceDiscovery calldata _priceDiscovery,
+        address _seller,
+        IBosonVoucher _bosonVoucher
+    ) external payable returns (uint256 actualPrice);
+
+    /*
+     * @notice Call `unwrap` (or equivalent) function on the price discovery contract.
+     *
+     * Reverts if:
+     * - Token id not set by the caller
+     * - Protocol balance doesn't increase by the expected amount.
+     *   Balance change must be equal to the price set by the caller
+     * - Token id sent to buyer and token id set by the caller don't match
+     *
+     * @param _exchangeToken - the address of the exchange contract
+     * @param _priceDiscovery - the fully populated BosonTypes.PriceDiscovery struct
+     * @return actualPrice - the actual price of the order
+     */
+    function handleWrapper(
+        address _exchangeToken,
+        BosonTypes.PriceDiscovery calldata _priceDiscovery
+    ) external payable returns (uint256 actualPrice);
+}

--- a/contracts/interfaces/events/IBosonConfigEvents.sol
+++ b/contracts/interfaces/events/IBosonConfigEvents.sol
@@ -13,6 +13,7 @@ interface IBosonConfigEvents {
     event TreasuryAddressChanged(address indexed treasuryAddress, address indexed executedBy);
     event VoucherBeaconAddressChanged(address indexed voucherBeaconAddress, address indexed executedBy);
     event BeaconProxyAddressChanged(address indexed beaconProxyAddress, address indexed executedBy);
+    event PriceDiscoveryChanged(address indexed priceDiscoveryAddress, address indexed executedBy);
     event ProtocolFeePercentageChanged(uint256 feePercentage, address indexed executedBy);
     event ProtocolFeeFlatBosonChanged(uint256 feeFlatBoson, address indexed executedBy);
     event MaxEscalationResponsePeriodChanged(uint256 maxEscalationResponsePeriod, address indexed executedBy);

--- a/contracts/interfaces/events/IBosonConfigEvents.sol
+++ b/contracts/interfaces/events/IBosonConfigEvents.sol
@@ -13,7 +13,7 @@ interface IBosonConfigEvents {
     event TreasuryAddressChanged(address indexed treasuryAddress, address indexed executedBy);
     event VoucherBeaconAddressChanged(address indexed voucherBeaconAddress, address indexed executedBy);
     event BeaconProxyAddressChanged(address indexed beaconProxyAddress, address indexed executedBy);
-    event PriceDiscoveryChanged(address indexed priceDiscoveryAddress, address indexed executedBy);
+    event PriceDiscoveryAddressChanged(address indexed priceDiscoveryAddress, address indexed executedBy);
     event ProtocolFeePercentageChanged(uint256 feePercentage, address indexed executedBy);
     event ProtocolFeeFlatBosonChanged(uint256 feeFlatBoson, address indexed executedBy);
     event MaxEscalationResponsePeriodChanged(uint256 maxEscalationResponsePeriod, address indexed executedBy);

--- a/contracts/interfaces/handlers/IBosonConfigHandler.sol
+++ b/contracts/interfaces/handlers/IBosonConfigHandler.sol
@@ -10,7 +10,7 @@ import { IBosonConfigEvents } from "../events/IBosonConfigEvents.sol";
  *
  * @notice Handles management of configuration within the protocol.
  *
- * The ERC-165 identifier for this interface is: 0x7899c7b9
+ * The ERC-165 identifier for this interface is: 0xe27f0773
  */
 interface IBosonConfigHandler is IBosonConfigEvents, BosonErrors {
     /**
@@ -92,6 +92,26 @@ interface IBosonConfigHandler is IBosonConfigEvents, BosonErrors {
      * @return the beaconProxy address
      */
     function getBeaconProxyAddress() external view returns (address);
+
+    /**
+     * @notice Sets the Boson Price Discovery contract address.
+     *
+     * Emits a BosonPriceDiscoveryAddressChanged event if successful.
+     *
+     * Reverts if _priceDiscovery is the zero address
+     *
+     * @dev Caller must have ADMIN role.
+     *
+     * @param _priceDiscovery - the Boson Price Discovery contract address
+     */
+    function setPriceDiscoveryAddress(address _priceDiscovery) external;
+
+    /**
+     * @notice Gets the Boson Price Discovery contract address.
+     *
+     * @return the Boson Price Discovery contract address
+     */
+    function getPriceDiscoveryAddress() external view returns (address);
 
     /**
      * @notice Sets the protocol fee percentage.

--- a/contracts/interfaces/handlers/IBosonConfigHandler.sol
+++ b/contracts/interfaces/handlers/IBosonConfigHandler.sol
@@ -96,7 +96,7 @@ interface IBosonConfigHandler is IBosonConfigEvents, BosonErrors {
     /**
      * @notice Sets the Boson Price Discovery contract address.
      *
-     * Emits a BosonPriceDiscoveryAddressChanged event if successful.
+     * Emits a PriceDiscoveryAddressChanged event if successful.
      *
      * Reverts if _priceDiscovery is the zero address
      *

--- a/contracts/mock/MockExchangeHandlerFacet.sol
+++ b/contracts/mock/MockExchangeHandlerFacet.sol
@@ -546,7 +546,7 @@ contract MockExchangeHandlerFacetWithDefect is MockExchangeHandlerFacet {
  */
 contract TestExchangeHandlerFacet is ExchangeHandlerFacet {
     //solhint-disable-next-line
-    constructor(uint256 _firstExchangeId2_2_0) ExchangeHandlerFacet(_firstExchangeId2_2_0, address(0)) {}
+    constructor(uint256 _firstExchangeId2_2_0) ExchangeHandlerFacet(_firstExchangeId2_2_0) {}
 
     /**
      * @notice Test function to test invalid final exchange state

--- a/contracts/mock/MockExchangeHandlerFacet.sol
+++ b/contracts/mock/MockExchangeHandlerFacet.sol
@@ -546,7 +546,7 @@ contract MockExchangeHandlerFacetWithDefect is MockExchangeHandlerFacet {
  */
 contract TestExchangeHandlerFacet is ExchangeHandlerFacet {
     //solhint-disable-next-line
-    constructor(uint256 _firstExchangeId2_2_0) ExchangeHandlerFacet(_firstExchangeId2_2_0) {}
+    constructor(uint256 _firstExchangeId2_2_0) ExchangeHandlerFacet(_firstExchangeId2_2_0, address(0)) {}
 
     /**
      * @notice Test function to test invalid final exchange state

--- a/contracts/mock/MockWrapper.sol
+++ b/contracts/mock/MockWrapper.sol
@@ -25,6 +25,7 @@ contract MockWrapper is BosonTypes, ERC721, IERC721Receiver {
     address private immutable voucherAddress;
     address private immutable mockAuctionAddress;
     address private immutable protocolAddress;
+    address private immutable unwrapperAddress;
     address private immutable wethAddress;
 
     // Token ID for which the price is not yet known
@@ -48,12 +49,14 @@ contract MockWrapper is BosonTypes, ERC721, IERC721Receiver {
         address _voucherAddress,
         address _mockAuctionAddress,
         address _protocolAddress,
-        address _wethAddress
+        address _wethAddress,
+        address _unwrapperAddress
     ) ERC721(getVoucherName(_voucherAddress), getVoucherSymbol(_voucherAddress)) {
         voucherAddress = _voucherAddress;
         mockAuctionAddress = _mockAuctionAddress;
         protocolAddress = _protocolAddress;
         wethAddress = _wethAddress;
+        unwrapperAddress = _unwrapperAddress;
 
         // Approve Mock Auction to transfer wrapped vouchers
         _setApprovalForAll(address(this), _mockAuctionAddress, true);
@@ -107,7 +110,7 @@ contract MockWrapper is BosonTypes, ERC721, IERC721Receiver {
         // Either contract owner or protocol can unwrap
         // If contract owner is unwrapping, this is equivalent to canceled auction
         require(
-            msg.sender == protocolAddress || wrappedVoucherOwner == msg.sender,
+            msg.sender == unwrapperAddress || wrappedVoucherOwner == msg.sender,
             "MockWrapper: Only owner or protocol can unwrap"
         );
 
@@ -125,7 +128,7 @@ contract MockWrapper is BosonTypes, ERC721, IERC721Receiver {
 
         // Transfer token to protocol
         if (priceToPay > 0) {
-            IERC20(cachedExchangeToken[_tokenId]).safeTransfer(protocolAddress, priceToPay);
+            IERC20(cachedExchangeToken[_tokenId]).safeTransfer(unwrapperAddress, priceToPay);
         }
 
         delete cachedExchangeToken[_tokenId]; // gas refund

--- a/contracts/protocol/bases/PriceDiscoveryBase.sol
+++ b/contracts/protocol/bases/PriceDiscoveryBase.sol
@@ -10,8 +10,6 @@ import { IBosonPriceDiscovery } from "../../interfaces/clients/IBosonPriceDiscov
 import { ProtocolBase } from "./../bases/ProtocolBase.sol";
 import { FundsLib } from "../libs/FundsLib.sol";
 
-// import { BosonPriceDiscovery } from "./../clients/priceDiscovery/BosonPriceDiscovery.sol";
-
 /**
  * @title PriceDiscoveryBase
  *
@@ -22,7 +20,7 @@ contract PriceDiscoveryBase is ProtocolBase {
 
     /**
      * @notice
-     * For offers with native exchange token, it is expected the the price discovery contracts will
+     * For offers with native exchange token, it is expected that the price discovery contracts will
      * operate with wrapped native token. Set the address of the wrapped native token in the constructor.
      *
      * @param _wNative - the address of the wrapped native token

--- a/contracts/protocol/bases/PriceDiscoveryBase.sol
+++ b/contracts/protocol/bases/PriceDiscoveryBase.sol
@@ -29,7 +29,7 @@ contract PriceDiscoveryBase is ProtocolBase {
     //solhint-disable-next-line
     constructor(address _wNative, address _bosonPriceDiscovery) {
         wNative = IWrappedNative(_wNative);
-        bosonPriceDiscovery = BosonPriceDiscovery(_bosonPriceDiscovery);
+        bosonPriceDiscovery = BosonPriceDiscovery(payable(_bosonPriceDiscovery));
     }
 
     /**

--- a/contracts/protocol/bases/PriceDiscoveryBase.sol
+++ b/contracts/protocol/bases/PriceDiscoveryBase.sol
@@ -128,13 +128,11 @@ contract PriceDiscoveryBase is ProtocolBase {
         // Make sure that the exchange is part of the correct offer
         if (_tokenId >> 128 != _offerId) revert TokenIdMismatch();
 
-        {
-            // Make sure that the price discovery contract has transferred the voucher to the protocol
-            if (_bosonVoucher.ownerOf(_tokenId) != bosonPriceDiscovery) revert VoucherNotReceived();
+        // Make sure that the price discovery contract has transferred the voucher to the protocol
+        if (_bosonVoucher.ownerOf(_tokenId) != bosonPriceDiscovery) revert VoucherNotReceived();
 
-            // Transfer voucher to buyer
-            _bosonVoucher.safeTransferFrom(bosonPriceDiscovery, _buyer, _tokenId);
-        }
+        // Transfer voucher to buyer
+        _bosonVoucher.safeTransferFrom(bosonPriceDiscovery, _buyer, _tokenId);
     }
 
     /**

--- a/contracts/protocol/bases/PriceDiscoveryBase.sol
+++ b/contracts/protocol/bases/PriceDiscoveryBase.sol
@@ -162,7 +162,7 @@ contract PriceDiscoveryBase is ProtocolBase {
         address sender = msgSender();
         if (_seller != sender) revert NotVoucherHolder();
 
-        actualPrice = bosonPriceDiscovery.fulfilBidOrder(
+        actualPrice = bosonPriceDiscovery.fulfilBidOrder{ value: msg.value }(
             _tokenId,
             _exchangeToken,
             _priceDiscovery,
@@ -201,7 +201,7 @@ contract PriceDiscoveryBase is ProtocolBase {
         address owner = _bosonVoucher.ownerOf(_tokenId);
         if (owner != _priceDiscovery.priceDiscoveryContract) revert NotVoucherHolder();
 
-        actualPrice = bosonPriceDiscovery.handleWrapper(_exchangeToken, _priceDiscovery);
+        actualPrice = bosonPriceDiscovery.handleWrapper{ value: msg.value }(_exchangeToken, _priceDiscovery);
 
         // Verify that token id provided by caller matches the token id that the price discovery contract has sent to buyer
         getAndVerifyTokenId(_tokenId);

--- a/contracts/protocol/bases/PriceDiscoveryBase.sol
+++ b/contracts/protocol/bases/PriceDiscoveryBase.sol
@@ -126,6 +126,8 @@ contract PriceDiscoveryBase is ProtocolBase {
         );
 
         _tokenId = getAndVerifyTokenId(_tokenId);
+        // todo: if tokenid == 0, make sure that correct offer is used
+
         {
             // Make sure that the price discovery contract has transferred the voucher to the protocol
             if (_bosonVoucher.ownerOf(_tokenId) != address(bosonPriceDiscovery)) revert VoucherNotReceived();
@@ -166,6 +168,10 @@ contract PriceDiscoveryBase is ProtocolBase {
 
         address sender = msgSender();
         if (_seller != sender) revert NotVoucherHolder();
+
+        // Transfer seller's voucher to protocol
+        // Don't need to use safe transfer from, since that protocol can handle the voucher
+        _bosonVoucher.transferFrom(_seller, address(bosonPriceDiscovery), _tokenId);
 
         actualPrice = bosonPriceDiscovery.fulfilBidOrder{ value: msg.value }(
             _tokenId,

--- a/contracts/protocol/clients/priceDiscovery/BosonPriceDiscovery.sol
+++ b/contracts/protocol/clients/priceDiscovery/BosonPriceDiscovery.sol
@@ -69,7 +69,7 @@ contract BosonPriceDiscovery is IERC721Receiver, BosonErrors {
         // Boson protocol (the caller) is trusted, so it can be assumed that all funds were forwarded to this contract
 
         // If token is ERC20, approve price discovery contract to transfer protocol funds
-        if (_exchangeToken != address(0)) {
+        if (_exchangeToken != address(0) && _priceDiscovery.price > 0) {
             IERC20(_exchangeToken).forceApprove(_priceDiscovery.conduit, _priceDiscovery.price);
         }
 
@@ -90,7 +90,7 @@ contract BosonPriceDiscovery is IERC721Receiver, BosonErrors {
         }
 
         // If token is ERC20, reset approval
-        if (_exchangeToken != address(0)) {
+        if (_exchangeToken != address(0) && _priceDiscovery.price > 0) {
             IERC20(_exchangeToken).forceApprove(address(_priceDiscovery.conduit), 0);
         }
 
@@ -138,10 +138,6 @@ contract BosonPriceDiscovery is IERC721Receiver, BosonErrors {
         IBosonVoucher _bosonVoucher
     ) external payable returns (uint256 actualPrice) {
         // ToDo: allow only protocol calls
-
-        // Transfer seller's voucher to protocol
-        // Don't need to use safe transfer from, since that protocol can handle the voucher
-        _bosonVoucher.transferFrom(_seller, address(this), _tokenId);
 
         // Approve conduit to transfer voucher. There is no need to reset approval afterwards, since protocol is not the voucher owner anymore
         _bosonVoucher.approve(_priceDiscovery.conduit, _tokenId);

--- a/contracts/protocol/clients/priceDiscovery/BosonPriceDiscovery.sol
+++ b/contracts/protocol/clients/priceDiscovery/BosonPriceDiscovery.sol
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.22;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IWrappedNative } from "../../../interfaces/IWrappedNative.sol";
+import { IBosonVoucher } from "../../../interfaces/clients/IBosonVoucher.sol";
+import { FundsLib } from "../../libs/FundsLib.sol";
+import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { IERC721Receiver } from "../../../interfaces/IERC721Receiver.sol";
+import { BosonTypes } from "../../../domain/BosonTypes.sol";
+import { BosonErrors } from "../../../domain/BosonErrors.sol";
+
+/**
+ * @title BosonPriceDiscovery
+ *
+ * @dev Boson Price Discovery is a external contract that is used to determine the price of an exchange.
+ */
+contract BosonPriceDiscovery is IERC721Receiver, BosonErrors {
+    using Address for address;
+    using SafeERC20 for IERC20;
+
+    IWrappedNative internal immutable wNative;
+
+    bool private voucherExpected;
+    uint256 private incomingTokenId;
+
+    /**
+     * @notice
+     * For offers with native exchange token, it is expected the the price discovery contracts will
+     * operate with wrapped native token. Set the address of the wrapped native token in the constructor.
+     *
+     * @param _wNative - the address of the wrapped native token
+     */
+    //solhint-disable-next-line
+    constructor(address _wNative) {
+        wNative = IWrappedNative(_wNative);
+    }
+
+    /**
+     * @notice Fulfils an ask order on external contract.
+     *
+     * Reverts if:
+     * - Offer price is in native token and caller does not send enough
+     * - Offer price is in some ERC20 token and caller also sends native currency
+     * - Calling transferFrom on token fails for some reason (e.g. the Boson Price Discovery Client is not approved to transfer)
+     * - Call to price discovery contract fails
+     * - Received amount is greater from price set in price discovery
+     * - Boson Price Discovery Client does not receive the voucher
+     * - Transfer of voucher to the buyer fails for some reason (e.g. buyer is contract that doesn't accept voucher)
+     * - New voucher owner is not buyer wallet
+     * - Token id sent to buyer and token id set by the caller don't match (if caller has provided token id)
+     *
+     * @param _tokenId - the id of the token
+     * @param _exchangeToken - the address of the exchange contract
+     * @param _priceDiscovery - the fully populated BosonTypes.PriceDiscovery struct
+     * @param _buyer - the buyer's address (caller can commit on behalf of a buyer)
+     * @param _bosonVoucher - the boson voucher contract
+     * @param _msgSender - the address of the caller, as seen in boson protocol
+     * @return actualPrice - the actual price of the order
+     */
+    function fulfilAskOrder(
+        uint256 _tokenId,
+        address _exchangeToken,
+        BosonTypes.PriceDiscovery calldata _priceDiscovery,
+        address _buyer,
+        IBosonVoucher _bosonVoucher,
+        address payable _msgSender
+    ) external payable returns (uint256 actualPrice) {
+        // ToDo: allow only protocol calls
+
+        // Boson protocol (the caller) is trusted, so it can be assumed that all funds were forwarded to this contract
+
+        // If token is ERC20, approve price discovery contract to transfer protocol funds
+        if (_exchangeToken != address(0)) {
+            IERC20(_exchangeToken).forceApprove(_priceDiscovery.conduit, _priceDiscovery.price);
+        }
+
+        uint256 thisBalanceBefore = getBalance(_exchangeToken, address(this));
+
+        // Call the price discovery contract
+        voucherExpected = true;
+        _priceDiscovery.priceDiscoveryContract.functionCallWithValue(_priceDiscovery.priceDiscoveryData, msg.value);
+
+        uint256 thisBalanceAfter = getBalance(_exchangeToken, address(this));
+        if (thisBalanceBefore < thisBalanceAfter) revert NegativePriceNotAllowed();
+        actualPrice = thisBalanceBefore - thisBalanceAfter;
+
+        // If token is ERC20, reset approval
+        if (_exchangeToken != address(0)) {
+            IERC20(_exchangeToken).forceApprove(address(_priceDiscovery.conduit), 0);
+        }
+
+        // This is true, assuming the price discvery contract used safeTransferFrom
+        // If it used transferFrom, then this contract might own it, even if the incomingTokenId == 0
+        // Currenltly, we don't support transferFrom. Might be added in the future, but it requires additional call to the Boson protocol
+        if (incomingTokenId == 0) revert VoucherNotReceived();
+
+        // Incoming token id must match the expected token id
+        if (_tokenId != incomingTokenId) revert TokenIdMismatch();
+
+        // Transfer voucher to buyer
+        _bosonVoucher.safeTransferFrom(address(this), _buyer, _tokenId);
+
+        uint256 overchargedAmount = _priceDiscovery.price - actualPrice;
+
+        if (overchargedAmount > 0) {
+            // Return the surplus to caller
+            FundsLib.transferFundsFromProtocol(_exchangeToken, _msgSender, overchargedAmount);
+        }
+
+        delete incomingTokenId;
+        delete voucherExpected;
+    }
+
+    /**
+     * @notice Fulfils a bid order on external contract.
+     *
+     * Reverts if:
+     * - Token id not set by the caller
+     * - Calling transferFrom on token fails for some reason (e.g. protocol is not approved to transfer)
+     * - Transfer of voucher to the buyer fails for some reason (e.g. buyer is contract that doesn't accept voucher)
+     * - Received ERC20 token amount differs from the expected value
+     * - Call to price discovery contract fails
+     * - Protocol balance change after price discovery call is lower than the expected price
+     * - Reseller did not approve protocol to transfer exchange token in escrow
+     * - New voucher owner is not buyer wallet
+     * - Token id sent to buyer and token id set by the caller don't match
+     *
+     * @param _tokenId - the id of the token
+     * @param _exchangeToken - the address of the exchange token
+     * @param _priceDiscovery - the fully populated BosonTypes.PriceDiscovery struct
+     * @param _seller - the seller's address
+     * @param _bosonVoucher - the boson voucher contract
+     * @return actualPrice - the actual price of the order
+     */
+    function fulfilBidOrder(
+        uint256 _tokenId,
+        address _exchangeToken,
+        BosonTypes.PriceDiscovery calldata _priceDiscovery,
+        address _seller,
+        IBosonVoucher _bosonVoucher
+    ) external payable returns (uint256 actualPrice) {
+        // ToDo: allow only protocol calls
+
+        // Transfer seller's voucher to protocol
+        // Don't need to use safe transfer from, since that protocol can handle the voucher
+        _bosonVoucher.transferFrom(_seller, address(this), _tokenId);
+
+        // Approve conduit to transfer voucher. There is no need to reset approval afterwards, since protocol is not the voucher owner anymore
+        _bosonVoucher.approve(_priceDiscovery.conduit, _tokenId);
+        if (_exchangeToken == address(0)) _exchangeToken = address(wNative);
+
+        // Track native balance just in case if seller sends some native currency or price discovery contract does
+        // This is the balance that protocol had, before commit to offer was called
+        uint256 thisNativeBalanceBefore = getBalance(address(0), address(this)) - msg.value;
+
+        // Get protocol balance before calling price discovery contract
+        uint256 thisBalanceBefore = getBalance(_exchangeToken, address(this));
+
+        // Call the price discovery contract
+        _priceDiscovery.priceDiscoveryContract.functionCallWithValue(_priceDiscovery.priceDiscoveryData, msg.value);
+
+        // Get protocol balance after calling price discovery contract
+        uint256 thisBalanceAfter = getBalance(_exchangeToken, address(this));
+
+        // Check the native balance and return the surplus to seller
+        uint256 thisNativeBalanceAfter = getBalance(address(0), address(this));
+        if (thisNativeBalanceAfter > thisNativeBalanceBefore) {
+            // Return the surplus to seller
+            FundsLib.transferFundsFromProtocol(
+                address(0),
+                payable(_seller),
+                thisNativeBalanceAfter - thisNativeBalanceBefore
+            );
+        }
+
+        // Calculate actual price
+        if (thisBalanceAfter < thisBalanceBefore) revert NegativePriceNotAllowed();
+        actualPrice = thisBalanceAfter - thisBalanceBefore;
+
+        // Make sure that balance change is at least the expected price
+        if (actualPrice < _priceDiscovery.price) revert InsufficientValueReceived();
+
+        // Verify that token id provided by caller matches the token id that the price discovery contract has sent to buyer
+
+        // ? what about that
+        // getAndVerifyTokenId(_tokenId);
+        if (_bosonVoucher.ownerOf(_tokenId) == address(this)) {
+            revert VoucherNotTransferred();
+        }
+    }
+
+    /*
+     * @notice Call `unwrap` (or equivalent) function on the price discovery contract.
+     *
+     * Reverts if:
+     * - Token id not set by the caller
+     * - Protocol balance doesn't increase by the expected amount.
+     *   Balance change must be equal to the price set by the caller
+     * - Token id sent to buyer and token id set by the caller don't match
+     *
+     * @param _exchangeToken - the address of the exchange contract
+     * @param _priceDiscovery - the fully populated BosonTypes.PriceDiscovery struct
+     * @return actualPrice - the actual price of the order
+     */
+    function handleWrapper(
+        address _exchangeToken,
+        BosonTypes.PriceDiscovery calldata _priceDiscovery
+    ) external payable returns (uint256 actualPrice) {
+        // ToDo: allow only protocol calls
+
+        // Check balance before calling wrapper
+        bool isNative = _exchangeToken == address(0);
+        if (isNative) _exchangeToken = address(wNative);
+        uint256 thisBalanceBefore = getBalance(_exchangeToken, address(this));
+
+        // Track native balance just in case if seller sends some native currency.
+        // All native currency is forwarded to the wrapper, which should not return any back.
+        // If it does, we revert later in the code.
+        uint256 thisNativeBalanceBefore = getBalance(address(0), address(this)) - msg.value;
+
+        // Call the price discovery contract
+        _priceDiscovery.priceDiscoveryContract.functionCallWithValue(_priceDiscovery.priceDiscoveryData, msg.value);
+
+        // Check the native balance and revert if there is a surplus
+        uint256 thisNativeBalanceAfter = getBalance(address(0), address(this));
+        if (thisNativeBalanceAfter != thisNativeBalanceBefore) revert NativeNotAllowed();
+
+        // Check balance after the price discovery call
+        uint256 thisBalanceAfter = getBalance(_exchangeToken, address(this));
+
+        // Verify that actual price is within the expected range
+        if (thisBalanceAfter < thisBalanceBefore) revert NegativePriceNotAllowed();
+        actualPrice = thisBalanceAfter - thisBalanceBefore;
+
+        // when working with wrappers, price is already known, so the caller should set it exactly
+        // If protocol receive more than expected, it does not return the surplus to the caller
+        if (actualPrice != _priceDiscovery.price) revert PriceTooLow();
+
+        // Verify that token id provided by caller matches the token id that the price discovery contract has sent to buyer
+        // getAndVerifyTokenId(_tokenId);
+    }
+
+    /**
+     * @notice Returns the balance of the protocol for the given token address
+     *
+     * @param _tokenAddress - the address of the token to check the balance for
+     * @return balance - the balance of the protocol for the given token address
+     */
+    function getBalance(address _tokenAddress, address entity) internal view returns (uint256) {
+        return _tokenAddress == address(0) ? entity.balance : IERC20(_tokenAddress).balanceOf(entity);
+    }
+
+    /**
+     * @dev See {IERC721Receiver-onERC721Received}.
+     *
+     * Always returns `IERC721Receiver.onERC721Received.selector`.
+     */
+    function onERC721Received(
+        address,
+        address,
+        uint256 _tokenId,
+        bytes calldata
+    ) external virtual override returns (bytes4) {
+        if (!voucherExpected) revert UnexpectedERC721Received();
+
+        incomingTokenId = _tokenId;
+
+        return this.onERC721Received.selector;
+    }
+}

--- a/contracts/protocol/clients/priceDiscovery/BosonPriceDiscovery.sol
+++ b/contracts/protocol/clients/priceDiscovery/BosonPriceDiscovery.sol
@@ -16,7 +16,7 @@ import { BosonErrors } from "../../../domain/BosonErrors.sol";
 /**
  * @title BosonPriceDiscovery
  *
- * @dev Boson Price Discovery is a external contract that is used to determine the price of an exchange.
+ * @dev Boson Price Discovery is an external contract that is used to determine the price of an exchange.
  */
 contract BosonPriceDiscovery is ERC165, IBosonPriceDiscovery, BosonErrors {
     using Address for address;
@@ -30,7 +30,7 @@ contract BosonPriceDiscovery is ERC165, IBosonPriceDiscovery, BosonErrors {
 
     /**
      * @notice
-     * For offers with native exchange token, it is expected the the price discovery contracts will
+     * For offers with native exchange token, it is expected that the price discovery contracts will
      * operate with wrapped native token. Set the address of the wrapped native token in the constructor.
      *
      * @param _wNative - the address of the wrapped native token

--- a/contracts/protocol/clients/priceDiscovery/BosonPriceDiscovery.sol
+++ b/contracts/protocol/clients/priceDiscovery/BosonPriceDiscovery.sol
@@ -24,6 +24,7 @@ contract BosonPriceDiscovery is IERC721Receiver, BosonErrors {
 
     bool private voucherExpected;
     uint256 private incomingTokenId;
+    address private incomingTokenAddress;
 
     /**
      * @notice
@@ -80,6 +81,7 @@ contract BosonPriceDiscovery is IERC721Receiver, BosonErrors {
 
         // Call the price discovery contract
         voucherExpected = true;
+        incomingTokenAddress = address(_bosonVoucher);
         _priceDiscovery.priceDiscoveryContract.functionCallWithValue(
             _priceDiscovery.priceDiscoveryData,
             _priceDiscovery.price
@@ -117,7 +119,6 @@ contract BosonPriceDiscovery is IERC721Receiver, BosonErrors {
         }
 
         delete incomingTokenId;
-        delete voucherExpected;
 
         // Send the actual price back to the protocol
         // if (actualPrice>0) {
@@ -208,7 +209,6 @@ contract BosonPriceDiscovery is IERC721Receiver, BosonErrors {
         }
 
         delete incomingTokenId;
-        delete voucherExpected;
     }
 
     /*
@@ -266,7 +266,6 @@ contract BosonPriceDiscovery is IERC721Receiver, BosonErrors {
         }
 
         delete incomingTokenId;
-        delete voucherExpected;
     }
 
     /**
@@ -290,9 +289,11 @@ contract BosonPriceDiscovery is IERC721Receiver, BosonErrors {
         uint256 _tokenId,
         bytes calldata
     ) external virtual override returns (bytes4) {
-        if (!voucherExpected) revert UnexpectedERC721Received();
+        if (!voucherExpected || incomingTokenAddress != msg.sender) revert UnexpectedERC721Received();
 
         incomingTokenId = _tokenId;
+        delete voucherExpected;
+        delete incomingTokenAddress;
 
         return this.onERC721Received.selector;
     }

--- a/contracts/protocol/facets/ConfigHandlerFacet.sol
+++ b/contracts/protocol/facets/ConfigHandlerFacet.sol
@@ -37,6 +37,7 @@ contract ConfigHandlerFacet is IBosonConfigHandler, ProtocolBase {
         setTokenAddress(_addresses.token);
         setTreasuryAddress(_addresses.treasury);
         setVoucherBeaconAddress(_addresses.voucherBeacon);
+        setPriceDiscoveryAddress(_addresses.priceDiscovery);
         setProtocolFeePercentage(_fees.percentage);
         setProtocolFeeFlatBoson(_fees.flatBoson);
         setMaxEscalationResponsePeriod(_limits.maxEscalationResponsePeriod);
@@ -171,6 +172,32 @@ contract ConfigHandlerFacet is IBosonConfigHandler, ProtocolBase {
      */
     function getBeaconProxyAddress() external view override returns (address) {
         return protocolAddresses().beaconProxy;
+    }
+
+    /**
+     * @notice Sets the Boson Price Discovery contract address.
+     *
+     * Emits a PriceDiscoveryChanged event if successful.
+     *
+     * Reverts if _priceDiscovery is the zero address
+     *
+     * @dev Caller must have ADMIN role.
+     *
+     * @param _priceDiscovery - the Boson Price Discovery contract address
+     */
+    function setPriceDiscoveryAddress(address _priceDiscovery) public override onlyRole(ADMIN) nonReentrant {
+        checkNonZeroAddress(_priceDiscovery);
+        protocolAddresses().priceDiscovery = _priceDiscovery;
+        emit PriceDiscoveryChanged(_priceDiscovery, msgSender());
+    }
+
+    /**
+     * @notice Gets the Boson Price Discovery contract address.
+     *
+     * @return the Boson Price Discovery contract address
+     */
+    function getPriceDiscoveryAddress() external view override returns (address) {
+        return protocolAddresses().priceDiscovery;
     }
 
     /**

--- a/contracts/protocol/facets/ConfigHandlerFacet.sol
+++ b/contracts/protocol/facets/ConfigHandlerFacet.sol
@@ -177,7 +177,7 @@ contract ConfigHandlerFacet is IBosonConfigHandler, ProtocolBase {
     /**
      * @notice Sets the Boson Price Discovery contract address.
      *
-     * Emits a PriceDiscoveryChanged event if successful.
+     * Emits a PriceDiscoveryAddressChanged event if successful.
      *
      * Reverts if _priceDiscovery is the zero address
      *
@@ -188,7 +188,7 @@ contract ConfigHandlerFacet is IBosonConfigHandler, ProtocolBase {
     function setPriceDiscoveryAddress(address _priceDiscovery) public override onlyRole(ADMIN) nonReentrant {
         checkNonZeroAddress(_priceDiscovery);
         protocolAddresses().priceDiscovery = _priceDiscovery;
-        emit PriceDiscoveryChanged(_priceDiscovery, msgSender());
+        emit PriceDiscoveryAddressChanged(_priceDiscovery, msgSender());
     }
 
     /**

--- a/contracts/protocol/facets/ExchangeHandlerFacet.sol
+++ b/contracts/protocol/facets/ExchangeHandlerFacet.sol
@@ -10,7 +10,6 @@ import { BuyerBase } from "../bases/BuyerBase.sol";
 import { DisputeBase } from "../bases/DisputeBase.sol";
 import { ProtocolLib } from "../libs/ProtocolLib.sol";
 import { FundsLib } from "../libs/FundsLib.sol";
-import { IERC721Receiver } from "../../interfaces/IERC721Receiver.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import { IERC1155 } from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
@@ -21,7 +20,7 @@ import { Address } from "@openzeppelin/contracts/utils/Address.sol";
  *
  * @notice Handles exchanges associated with offers within the protocol.
  */
-contract ExchangeHandlerFacet is DisputeBase, BuyerBase, IBosonExchangeHandler, IERC721Receiver {
+contract ExchangeHandlerFacet is DisputeBase, BuyerBase, IBosonExchangeHandler {
     using Address for address;
     using Address for address payable;
 
@@ -1392,25 +1391,25 @@ contract ExchangeHandlerFacet is DisputeBase, BuyerBase, IBosonExchangeHandler, 
         }
     }
 
-    /**
-     * @dev See {IERC721Receiver-onERC721Received}.
-     *
-     * Always returns `IERC721Receiver.onERC721Received.selector`.
-     */
-    function onERC721Received(
-        address,
-        address,
-        uint256 _tokenId,
-        bytes calldata
-    ) public virtual override returns (bytes4) {
-        ProtocolLib.ProtocolStatus storage ps = protocolStatus();
+    // /**
+    //  * @dev See {IERC721Receiver-onERC721Received}.
+    //  *
+    //  * Always returns `IERC721Receiver.onERC721Received.selector`.
+    //  */
+    // function onERC721Received(
+    //     address,
+    //     address,
+    //     uint256 _tokenId,
+    //     bytes calldata
+    // ) public virtual override returns (bytes4) {
+    //     ProtocolLib.ProtocolStatus storage ps = protocolStatus();
 
-        if (ps.incomingVoucherId != _tokenId || ps.incomingVoucherCloneAddress != msg.sender) {
-            revert UnexpectedERC721Received();
-        }
+    //     if (ps.incomingVoucherId != _tokenId || ps.incomingVoucherCloneAddress != msg.sender) {
+    //         revert UnexpectedERC721Received();
+    //     }
 
-        return this.onERC721Received.selector;
-    }
+    //     return this.onERC721Received.selector;
+    // }
 
     /**
      * @notice Updates NFT ranges, so it's possible to reuse the tokens in other twins and to make

--- a/contracts/protocol/facets/ExchangeHandlerFacet.sol
+++ b/contracts/protocol/facets/ExchangeHandlerFacet.sol
@@ -25,7 +25,6 @@ contract ExchangeHandlerFacet is DisputeBase, BuyerBase, IBosonExchangeHandler {
     using Address for address payable;
 
     uint256 private immutable EXCHANGE_ID_2_2_0; // solhint-disable-line
-    address private immutable bosonPriceDiscovery;
 
     /**
      * @notice After v2.2.0, token ids are derived from offerId and exchangeId.
@@ -35,9 +34,8 @@ contract ExchangeHandlerFacet is DisputeBase, BuyerBase, IBosonExchangeHandler {
      * @param _firstExchangeId2_2_0 - the first exchange id to use for 2.2.0
      */
     //solhint-disable-next-line
-    constructor(uint256 _firstExchangeId2_2_0, address _bosonPriceDiscovery) {
+    constructor(uint256 _firstExchangeId2_2_0) {
         EXCHANGE_ID_2_2_0 = _firstExchangeId2_2_0;
-        bosonPriceDiscovery = _bosonPriceDiscovery;
     }
 
     /**
@@ -678,7 +676,7 @@ contract ExchangeHandlerFacet is DisputeBase, BuyerBase, IBosonExchangeHandler {
                 // During price discovery, the voucher is firs transferred to the protocol, which should
                 // not resulte in a commit yet. The commit should happen when the voucher is transferred
                 // from the protocol to the buyer.
-                if (_to == bosonPriceDiscovery) {
+                if (_to == protocolAddresses().priceDiscovery) {
                     // Avoid reentrancy
                     if (ps.incomingVoucherId != 0) revert IncomingVoucherAlreadySet();
 

--- a/contracts/protocol/facets/ExchangeHandlerFacet.sol
+++ b/contracts/protocol/facets/ExchangeHandlerFacet.sol
@@ -25,6 +25,7 @@ contract ExchangeHandlerFacet is DisputeBase, BuyerBase, IBosonExchangeHandler {
     using Address for address payable;
 
     uint256 private immutable EXCHANGE_ID_2_2_0; // solhint-disable-line
+    address private immutable bosonPriceDiscovery;
 
     /**
      * @notice After v2.2.0, token ids are derived from offerId and exchangeId.
@@ -34,8 +35,9 @@ contract ExchangeHandlerFacet is DisputeBase, BuyerBase, IBosonExchangeHandler {
      * @param _firstExchangeId2_2_0 - the first exchange id to use for 2.2.0
      */
     //solhint-disable-next-line
-    constructor(uint256 _firstExchangeId2_2_0) {
+    constructor(uint256 _firstExchangeId2_2_0, address _bosonPriceDiscovery) {
         EXCHANGE_ID_2_2_0 = _firstExchangeId2_2_0;
+        bosonPriceDiscovery = _bosonPriceDiscovery;
     }
 
     /**
@@ -676,7 +678,7 @@ contract ExchangeHandlerFacet is DisputeBase, BuyerBase, IBosonExchangeHandler {
                 // During price discovery, the voucher is firs transferred to the protocol, which should
                 // not resulte in a commit yet. The commit should happen when the voucher is transferred
                 // from the protocol to the buyer.
-                if (_to == address(this)) {
+                if (_to == bosonPriceDiscovery) {
                     // Avoid reentrancy
                     if (ps.incomingVoucherId != 0) revert IncomingVoucherAlreadySet();
 

--- a/contracts/protocol/facets/ExchangeHandlerFacet.sol
+++ b/contracts/protocol/facets/ExchangeHandlerFacet.sol
@@ -1391,26 +1391,6 @@ contract ExchangeHandlerFacet is DisputeBase, BuyerBase, IBosonExchangeHandler {
         }
     }
 
-    // /**
-    //  * @dev See {IERC721Receiver-onERC721Received}.
-    //  *
-    //  * Always returns `IERC721Receiver.onERC721Received.selector`.
-    //  */
-    // function onERC721Received(
-    //     address,
-    //     address,
-    //     uint256 _tokenId,
-    //     bytes calldata
-    // ) public virtual override returns (bytes4) {
-    //     ProtocolLib.ProtocolStatus storage ps = protocolStatus();
-
-    //     if (ps.incomingVoucherId != _tokenId || ps.incomingVoucherCloneAddress != msg.sender) {
-    //         revert UnexpectedERC721Received();
-    //     }
-
-    //     return this.onERC721Received.selector;
-    // }
-
     /**
      * @notice Updates NFT ranges, so it's possible to reuse the tokens in other twins and to make
      * creation of new ranges viable

--- a/contracts/protocol/facets/PriceDiscoveryHandlerFacet.sol
+++ b/contracts/protocol/facets/PriceDiscoveryHandlerFacet.sol
@@ -32,7 +32,7 @@ contract PriceDiscoveryHandlerFacet is IBosonPriceDiscoveryHandler, PriceDiscove
      * @param _wNative - the address of the wrapped native token
      */
     //solhint-disable-next-line
-    constructor(address _wNative) PriceDiscoveryBase(_wNative) {}
+    constructor(address _wNative, address _pdc) PriceDiscoveryBase(_wNative, _pdc) {}
 
     /**
      * @notice Facet Initializer

--- a/contracts/protocol/facets/PriceDiscoveryHandlerFacet.sol
+++ b/contracts/protocol/facets/PriceDiscoveryHandlerFacet.sol
@@ -32,7 +32,7 @@ contract PriceDiscoveryHandlerFacet is IBosonPriceDiscoveryHandler, PriceDiscove
      * @param _wNative - the address of the wrapped native token
      */
     //solhint-disable-next-line
-    constructor(address _wNative, address _pdc) PriceDiscoveryBase(_wNative, _pdc) {}
+    constructor(address _wNative) PriceDiscoveryBase(_wNative) {}
 
     /**
      * @notice Facet Initializer

--- a/contracts/protocol/facets/PriceDiscoveryHandlerFacet.sol
+++ b/contracts/protocol/facets/PriceDiscoveryHandlerFacet.sol
@@ -26,7 +26,7 @@ import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 contract PriceDiscoveryHandlerFacet is IBosonPriceDiscoveryHandler, PriceDiscoveryBase, BuyerBase {
     /**
      * @notice
-     * For offers with native exchange token, it is expected the the price discovery contracts will
+     * For offers with native exchange token, it is expected that the price discovery contracts will
      * operate with wrapped native token. Set the address of the wrapped native token in the constructor.
      *
      * @param _wNative - the address of the wrapped native token

--- a/contracts/protocol/facets/ProtocolInitializationHandlerFacet.sol
+++ b/contracts/protocol/facets/ProtocolInitializationHandlerFacet.sol
@@ -197,14 +197,18 @@ contract ProtocolInitializationHandlerFacet is IBosonProtocolInitializationHandl
      *  - Length of _sellerIds, _royaltyPercentages and _offerIds arrays do not match
      *  - Any of the offerIds does not exist
      *
-     * @param _initializationData - data representing uint256[] _sellerIds, uint256[] _royaltyPercentages, uint256[][] _offerIds
+     * @param _initializationData - data representing uint256[] _sellerIds, uint256[] _royaltyPercentages, uint256[][] _offerIds, address _priceDiscovery
      */
     function initV2_4_0(bytes calldata _initializationData) internal {
         // Current version must be 2.3.0
         if (protocolStatus().version != bytes32("2.3.0")) revert WrongCurrentVersion();
 
-        (uint256[] memory _royaltyPercentages, uint256[][] memory _sellerIds, uint256[][] memory _offerIds) = abi
-            .decode(_initializationData, (uint256[], uint256[][], uint256[][]));
+        (
+            uint256[] memory _royaltyPercentages,
+            uint256[][] memory _sellerIds,
+            uint256[][] memory _offerIds,
+            address _priceDiscovery
+        ) = abi.decode(_initializationData, (uint256[], uint256[][], uint256[][], address));
 
         if (_royaltyPercentages.length != _sellerIds.length || _royaltyPercentages.length != _offerIds.length)
             revert ArrayLengthMismatch();
@@ -228,6 +232,12 @@ contract ProtocolInitializationHandlerFacet is IBosonProtocolInitializationHandl
                 royaltyInfo.recipients.push(payable(address(0))); // default recipient
                 royaltyInfo.bps.push(_royaltyPercentages[i]);
             }
+        }
+
+        if (_priceDiscovery != address(0)) {
+            // We allow it to be 0, since it can be set later
+            protocolAddresses().priceDiscovery = _priceDiscovery;
+            emit PriceDiscoveryAddressChanged(_priceDiscovery, msgSender());
         }
     }
 

--- a/contracts/protocol/facets/SequentialCommitHandlerFacet.sol
+++ b/contracts/protocol/facets/SequentialCommitHandlerFacet.sol
@@ -21,7 +21,7 @@ contract SequentialCommitHandlerFacet is IBosonSequentialCommitHandler, PriceDis
 
     /**
      * @notice
-     * For offers with native exchange token, it is expected the the price discovery contracts will
+     * For offers with native exchange token, it is expected that the price discovery contracts will
      * operate with wrapped native token. Set the address of the wrapped native token in the constructor.
      *
      * @param _wNative - the address of the wrapped native token

--- a/contracts/protocol/facets/SequentialCommitHandlerFacet.sol
+++ b/contracts/protocol/facets/SequentialCommitHandlerFacet.sol
@@ -27,7 +27,7 @@ contract SequentialCommitHandlerFacet is IBosonSequentialCommitHandler, PriceDis
      * @param _wNative - the address of the wrapped native token
      */
     //solhint-disable-next-line
-    constructor(address _wNative) PriceDiscoveryBase(_wNative) {}
+    constructor(address _wNative, address _pdc) PriceDiscoveryBase(_wNative, _pdc) {}
 
     /**
      * @notice Initializes facet.

--- a/contracts/protocol/facets/SequentialCommitHandlerFacet.sol
+++ b/contracts/protocol/facets/SequentialCommitHandlerFacet.sol
@@ -27,7 +27,7 @@ contract SequentialCommitHandlerFacet is IBosonSequentialCommitHandler, PriceDis
      * @param _wNative - the address of the wrapped native token
      */
     //solhint-disable-next-line
-    constructor(address _wNative, address _pdc) PriceDiscoveryBase(_wNative, _pdc) {}
+    constructor(address _wNative) PriceDiscoveryBase(_wNative) {}
 
     /**
      * @notice Initializes facet.

--- a/contracts/protocol/libs/ProtocolLib.sol
+++ b/contracts/protocol/libs/ProtocolLib.sol
@@ -28,6 +28,8 @@ library ProtocolLib {
         address voucherBeacon;
         // Address of the Boson Beacon proxy implementation
         address beaconProxy;
+        // Address of the Boson Price Discovery
+        address priceDiscovery;
     }
 
     // Protocol limits storage

--- a/scripts/config/facet-deploy.js
+++ b/scripts/config/facet-deploy.js
@@ -2,7 +2,6 @@ const hre = require("hardhat");
 const network = hre.network.name;
 const { getStateModifyingFunctionsHashes } = require("../../scripts/util/diamond-utils.js");
 const protocolConfig = require("./protocol-parameters");
-const { ZeroAddress } = require("ethers");
 
 /**
  * Get the configuration data to be passed to the ConfigHandlerFacet initializer
@@ -81,11 +80,11 @@ async function getFacets(config) {
   facetArgs["ExchangeHandlerFacet"] = { init: [], constructorArgs: [protocolConfig.EXCHANGE_ID_2_2_0[network]] };
   facetArgs["SequentialCommitHandlerFacet"] = {
     init: [],
-    constructorArgs: [protocolConfig.WrappedNative[network], ZeroAddress],
+    constructorArgs: [protocolConfig.WrappedNative[network]],
   };
   facetArgs["PriceDiscoveryHandlerFacet"] = {
     init: [],
-    constructorArgs: [protocolConfig.WrappedNative[network], ZeroAddress],
+    constructorArgs: [protocolConfig.WrappedNative[network]],
   };
 
   // metaTransactionsHandlerFacet initializer arguments.

--- a/scripts/config/facet-deploy.js
+++ b/scripts/config/facet-deploy.js
@@ -2,6 +2,7 @@ const hre = require("hardhat");
 const network = hre.network.name;
 const { getStateModifyingFunctionsHashes } = require("../../scripts/util/diamond-utils.js");
 const protocolConfig = require("./protocol-parameters");
+const { ZeroAddress } = require("ethers");
 
 /**
  * Get the configuration data to be passed to the ConfigHandlerFacet initializer
@@ -80,11 +81,11 @@ async function getFacets(config) {
   facetArgs["ExchangeHandlerFacet"] = { init: [], constructorArgs: [protocolConfig.EXCHANGE_ID_2_2_0[network]] };
   facetArgs["SequentialCommitHandlerFacet"] = {
     init: [],
-    constructorArgs: [protocolConfig.WrappedNative[network]],
+    constructorArgs: [protocolConfig.WrappedNative[network], ZeroAddress],
   };
   facetArgs["PriceDiscoveryHandlerFacet"] = {
     init: [],
-    constructorArgs: [protocolConfig.WrappedNative[network]],
+    constructorArgs: [protocolConfig.WrappedNative[network], ZeroAddress],
   };
 
   // metaTransactionsHandlerFacet initializer arguments.

--- a/scripts/config/facet-deploy.js
+++ b/scripts/config/facet-deploy.js
@@ -14,6 +14,7 @@ function getConfigHandlerInitArgs() {
       treasury: protocolConfig.TREASURY[network],
       voucherBeacon: protocolConfig.BEACON[network],
       beaconProxy: protocolConfig.BEACON_PROXY[network],
+      priceDiscovery: protocolConfig.PRICE_DISCOVERY[network],
     },
     protocolConfig.limits,
     protocolConfig.fees,

--- a/scripts/config/protocol-parameters.js
+++ b/scripts/config/protocol-parameters.js
@@ -93,4 +93,14 @@ module.exports = {
     polygon: "0x17CDD65bebDe68cd8A4045422Fcff825A0740Ef9", //dummy
     goerli: "0x17CDD65bebDe68cd8A4045422Fcff825A0740Ef9", //dummy
   },
+
+  PRICE_DISCOVERY: {
+    mainnet: "0x4102621Ac55e068e148Da09151ce92102c952aab", //dummy
+    hardhat: "0x4102621Ac55e068e148Da09151ce92102c952aab", //dummy
+    localhost: "0x4102621Ac55e068e148Da09151ce92102c952aab", //dummy
+    test: "0x4102621Ac55e068e148Da09151ce92102c952aab", //dummy
+    mumbai: "0x4102621Ac55e068e148Da09151ce92102c952aab", //dummy
+    polygon: "0x17CDD65bebDe68cd8A4045422Fcff825A0740Ef9", //dummy
+    goerli: "0x4102621Ac55e068e148Da09151ce92102c952aab", //dummy
+  },
 };

--- a/scripts/config/revert-reasons.js
+++ b/scripts/config/revert-reasons.js
@@ -220,10 +220,11 @@ exports.RevertReasons = {
   INIT_ADDRESS_WITH_NO_CODE: "LibDiamondCut: _init address has no code",
 
   // Price discovery related
-  PRICE_TOO_LOW: "PriceTooLow",
+  PRICE_MISMATCH: "PriceMismatch",
   TOKEN_ID_MISMATCH: "TokenIdMismatch",
   VOUCHER_TRANSFER_NOT_ALLOWED: "VoucherTransferNotAllowed",
   VOUCHER_NOT_RECEIVED: "VoucherNotReceived",
+  VOUCHER_NOT_TRANSFERRED: "VoucherNotTransferred",
   UNEXPECTED_ERC721_RECEIVED: "UnexpectedERC721Received",
   FEE_AMOUNT_TOO_HIGH: "FeeAmountTooHigh",
   INVALID_PRICE_DISCOVERY: "InvalidPriceDiscovery",

--- a/scripts/config/supported-interfaces.js
+++ b/scripts/config/supported-interfaces.js
@@ -56,6 +56,7 @@ async function getInterfaceIds(useCache = true) {
     "contracts/interfaces/IERC2981.sol:IERC2981",
     "IAccessControl",
     "IBosonSequentialCommitHandler",
+    "IBosonPriceDiscovery",
   ].forEach((iFace) => {
     skipBaseCheck[iFace] = false;
   });

--- a/test/example/SnapshotGateTest.js
+++ b/test/example/SnapshotGateTest.js
@@ -69,6 +69,8 @@ describe("SnapshotGate", function () {
     // Reset the accountId iterator
     accountId.next(true);
 
+    let priceDiscovery;
+
     // Make accounts available
     [
       deployer,
@@ -86,6 +88,7 @@ describe("SnapshotGate", function () {
       holder3,
       holder4,
       holder5,
+      priceDiscovery,
     ] = await getSigners();
 
     // make all account the same
@@ -123,6 +126,7 @@ describe("SnapshotGate", function () {
         token: await bosonToken.getAddress(),
         voucherBeacon: await beacon.getAddress(),
         beaconProxy: ZeroAddress,
+        priceDiscovery: priceDiscovery.address, // dummy address
       },
       // Protocol limits
       {

--- a/test/integration/price-discovery/seaport.js
+++ b/test/integration/price-discovery/seaport.js
@@ -51,27 +51,29 @@ describe("[@skip-on-coverage] seaport integration", function () {
       offerHandler: "IBosonOfferHandler",
       fundsHandler: "IBosonFundsHandler",
       priceDiscoveryHandler: "IBosonPriceDiscoveryHandler",
+      configHandler: "IBosonConfigHandler",
     };
 
     const wethFactory = await getContractFactory("WETH9");
     weth = await wethFactory.deploy();
     await weth.waitForDeployment();
 
-    // Add BosonPriceDiscovery
-    const bpdFactory = await getContractFactory("BosonPriceDiscovery");
-    bpd = await bpdFactory.deploy(await weth.getAddress());
-    await bpd.waitForDeployment();
-
-    let accountHandler, offerHandler;
+    let accountHandler, offerHandler, configHandler;
 
     ({
       signers: [, assistant, buyer, DR],
-      contractInstances: { accountHandler, offerHandler, priceDiscoveryHandler, fundsHandler },
+      contractInstances: { accountHandler, offerHandler, priceDiscoveryHandler, fundsHandler, configHandler },
       extraReturnValues: { bosonVoucher },
     } = await setupTestEnvironment(contracts, {
       wethAddress: await weth.getAddress(),
-      bpdAddress: await bpd.getAddress(),
     }));
+
+    // Add BosonPriceDiscovery
+    const bpdFactory = await getContractFactory("BosonPriceDiscovery");
+    bpd = await bpdFactory.deploy(await weth.getAddress(), await priceDiscoveryHandler.getAddress());
+    await bpd.waitForDeployment();
+
+    await configHandler.setPriceDiscoveryAddress(await bpd.getAddress());
 
     seller = mockSeller(assistant.address, assistant.address, ZeroAddress, assistant.address);
 

--- a/test/integration/price-discovery/seaport.js
+++ b/test/integration/price-discovery/seaport.js
@@ -1,5 +1,5 @@
 const { ethers } = require("hardhat");
-const { ZeroHash, ZeroAddress, getContractAt, getContractFactory } = ethers;
+const { ZeroHash, ZeroAddress, getContractAt, getContractFactory, MaxUint256 } = ethers;
 
 const {
   calculateBosonProxyAddress,
@@ -36,11 +36,12 @@ describe("[@skip-on-coverage] seaport integration", function () {
   let assistant, buyer, DR;
   let fixtures;
   let offer, offerDates;
-  let exchangeHandler, priceDiscoveryHandler;
+  let priceDiscoveryHandler, fundsHandler;
   let weth;
   let seller;
   let seaport;
   let snapshotId;
+  let bpd;
 
   before(async function () {
     accountId.next();
@@ -49,7 +50,6 @@ describe("[@skip-on-coverage] seaport integration", function () {
       accountHandler: "IBosonAccountHandler",
       offerHandler: "IBosonOfferHandler",
       fundsHandler: "IBosonFundsHandler",
-      exchangeHandler: "IBosonExchangeHandler",
       priceDiscoveryHandler: "IBosonPriceDiscoveryHandler",
     };
 
@@ -57,13 +57,21 @@ describe("[@skip-on-coverage] seaport integration", function () {
     weth = await wethFactory.deploy();
     await weth.waitForDeployment();
 
-    let accountHandler, offerHandler, fundsHandler;
+    // Add BosonPriceDiscovery
+    const bpdFactory = await getContractFactory("BosonPriceDiscovery");
+    bpd = await bpdFactory.deploy(await weth.getAddress());
+    await bpd.waitForDeployment();
+
+    let accountHandler, offerHandler;
 
     ({
       signers: [, assistant, buyer, DR],
-      contractInstances: { accountHandler, offerHandler, fundsHandler, exchangeHandler, priceDiscoveryHandler },
+      contractInstances: { accountHandler, offerHandler, priceDiscoveryHandler, fundsHandler },
       extraReturnValues: { bosonVoucher },
-    } = await setupTestEnvironment(contracts, { wethAddress: await weth.getAddress() }));
+    } = await setupTestEnvironment(contracts, {
+      wethAddress: await weth.getAddress(),
+      bpdAddress: await bpd.getAddress(),
+    }));
 
     seller = mockSeller(assistant.address, assistant.address, ZeroAddress, assistant.address);
 
@@ -82,10 +90,18 @@ describe("[@skip-on-coverage] seaport integration", function () {
     ({ offer, offerDates, offerDurations, disputeResolverId } = await mockOffer());
     offer.quantityAvailable = 10;
     offer.priceType = PriceType.Discovery;
+    const offerFeeLimit = MaxUint256; // unlimited offer fee to not affect the tests
 
     await offerHandler
       .connect(assistant)
-      .createOffer(offer.toStruct(), offerDates.toStruct(), offerDurations.toStruct(), disputeResolverId, "0");
+      .createOffer(
+        offer.toStruct(),
+        offerDates.toStruct(),
+        offerDurations.toStruct(),
+        disputeResolverId,
+        "0",
+        offerFeeLimit
+      );
 
     const beaconProxyAddress = await calculateBosonProxyAddress(await accountHandler.getAddress());
     const voucherAddress = calculateCloneAddress(await accountHandler.getAddress(), beaconProxyAddress, seller.admin);
@@ -171,15 +187,14 @@ describe("[@skip-on-coverage] seaport integration", function () {
       ZeroAddress,
     ]);
 
-    const priceDiscovery = new PriceDiscovery(value, seaportAddress, priceDiscoveryData, Side.Ask);
+    const priceDiscovery = new PriceDiscovery(value, Side.Ask, seaportAddress, seaportAddress, priceDiscoveryData);
 
-    // Seller needs to deposit weth in order to fill the escrow at the last step
-    await weth.connect(buyer).deposit({ value });
-    await weth.connect(buyer).approve(await exchangeHandler.getAddress(), value);
+    // Seller needs to deposit in order to fill the escrow at the last step
+    await fundsHandler.connect(assistant).depositFunds(seller.id, ZeroAddress, value, { value: value });
 
     const tx = await priceDiscoveryHandler
       .connect(buyer)
-      .commitToPriceDiscoveryOffer(buyer.address, offer.id, priceDiscovery, {
+      .commitToPriceDiscoveryOffer(buyer.address, identifier, priceDiscovery, {
         value,
       });
 

--- a/test/integration/price-discovery/sudoswap.js
+++ b/test/integration/price-discovery/sudoswap.js
@@ -44,6 +44,7 @@ describe("[@skip-on-coverage] sudoswap integration", function () {
       fundsHandler: "IBosonFundsHandler",
       exchangeHandler: "IBosonExchangeHandler",
       priceDiscoveryHandler: "IBosonPriceDiscoveryHandler",
+      configHandler: "IBosonConfigHandler",
     };
 
     const wethFactory = await getContractFactory("WETH9");
@@ -51,18 +52,27 @@ describe("[@skip-on-coverage] sudoswap integration", function () {
     await weth.waitForDeployment();
     wethAddress = await weth.getAddress();
 
-    // Add BosonPriceDiscovery
-    const bpdFactory = await getContractFactory("BosonPriceDiscovery");
-    bpd = await bpdFactory.deploy(await weth.getAddress());
-    await bpd.waitForDeployment();
-
-    let accountHandler, offerHandler, fundsHandler;
+    let accountHandler, offerHandler, fundsHandler, configHandler;
 
     ({
       signers: [deployer, assistant, buyer, DR],
-      contractInstances: { accountHandler, offerHandler, fundsHandler, exchangeHandler, priceDiscoveryHandler },
+      contractInstances: {
+        accountHandler,
+        offerHandler,
+        fundsHandler,
+        exchangeHandler,
+        priceDiscoveryHandler,
+        configHandler,
+      },
       extraReturnValues: { bosonVoucher },
-    } = await setupTestEnvironment(contracts, { wethAddress, bpdAddress: await bpd.getAddress() }));
+    } = await setupTestEnvironment(contracts, { wethAddress }));
+
+    // Add BosonPriceDiscovery
+    const bpdFactory = await getContractFactory("BosonPriceDiscovery");
+    bpd = await bpdFactory.deploy(await weth.getAddress(), await priceDiscoveryHandler.getAddress());
+    await bpd.waitForDeployment();
+
+    await configHandler.setPriceDiscoveryAddress(await bpd.getAddress());
 
     const LSSVMPairEnumerableETH = await getContractFactory("LSSVMPairEnumerableETH", deployer);
     const lssvmPairEnumerableETH = await LSSVMPairEnumerableETH.deploy();

--- a/test/protocol/FundsHandlerTest.js
+++ b/test/protocol/FundsHandlerTest.js
@@ -176,7 +176,7 @@ describe("IBosonFundsHandler", function () {
     [mockToken] = await deployMockTokens(["Foreign20"]);
 
     // Deploy PriceDiscovery contract
-    const PriceDiscoveryFactory = await ethers.getContractFactory("PriceDiscovery");
+    const PriceDiscoveryFactory = await ethers.getContractFactory("PriceDiscoveryMock");
     priceDiscoveryContract = await PriceDiscoveryFactory.deploy();
     await priceDiscoveryContract.waitForDeployment();
 

--- a/test/protocol/PriceDiscoveryHandlerFacet.js
+++ b/test/protocol/PriceDiscoveryHandlerFacet.js
@@ -136,7 +136,7 @@ describe("IPriceDiscoveryHandlerFacet", function () {
     assistantDR = adminDR;
 
     // Deploy PriceDiscovery contract
-    const PriceDiscoveryFactory = await getContractFactory("PriceDiscovery");
+    const PriceDiscoveryFactory = await getContractFactory("PriceDiscoveryMock");
     priceDiscoveryContract = await PriceDiscoveryFactory.deploy();
     await priceDiscoveryContract.waitForDeployment();
 
@@ -1318,7 +1318,7 @@ describe("IPriceDiscoveryHandlerFacet", function () {
                   priceDiscoveryHandler
                     .connect(assistant)
                     .commitToPriceDiscoveryOffer(buyer.address, tokenId, priceDiscovery)
-                ).to.revertedWithCustomError(bosonErrors, RevertReasons.PRICE_TOO_LOW);
+                ).to.revertedWithCustomError(bosonErrors, RevertReasons.PRICE_MISMATCH);
               });
 
               it("Negative price", async function () {

--- a/test/protocol/PriceDiscoveryHandlerFacet.js
+++ b/test/protocol/PriceDiscoveryHandlerFacet.js
@@ -628,7 +628,7 @@ describe("IPriceDiscoveryHandlerFacet", function () {
               priceDiscoveryHandler
                 .connect(buyer)
                 .commitToPriceDiscoveryOffer(buyer.address, tokenId, priceDiscovery, { value: price })
-            ).to.revertedWithCustomError(bosonErrors, RevertReasons.VOUCHER_NOT_RECEIVED);
+            ).to.revertedWithCustomError(bosonErrors, RevertReasons.TOKEN_ID_MISMATCH);
           });
 
           it("price discovery does not send the voucher to the protocol", async function () {

--- a/test/protocol/PriceDiscoveryHandlerFacet.js
+++ b/test/protocol/PriceDiscoveryHandlerFacet.js
@@ -737,7 +737,7 @@ describe("IPriceDiscoveryHandlerFacet", function () {
 
           // Seller approves protocol to transfer the voucher
           bosonVoucherClone = await getContractAt("IBosonVoucher", expectedCloneAddress);
-          await bosonVoucherClone.connect(assistant).setApprovalForAll(await bpd.getAddress(), true);
+          await bosonVoucherClone.connect(assistant).setApprovalForAll(await priceDiscoveryHandler.getAddress(), true);
 
           newBuyer = mockBuyer(buyer.address);
           exchange.buyerId = newBuyer.id;
@@ -985,7 +985,9 @@ describe("IPriceDiscoveryHandlerFacet", function () {
 
           it("voucher transfer not approved", async function () {
             // revoke approval
-            await bosonVoucherClone.connect(assistant).setApprovalForAll(await bpd.getAddress(), false);
+            await bosonVoucherClone
+              .connect(assistant)
+              .setApprovalForAll(await priceDiscoveryHandler.getAddress(), false);
 
             // Attempt to commit to, expecting revert
             await expect(

--- a/test/protocol/PriceDiscoveryHandlerFacet.js
+++ b/test/protocol/PriceDiscoveryHandlerFacet.js
@@ -92,11 +92,6 @@ describe("IPriceDiscoveryHandlerFacet", function () {
     weth = await wethFactory.deploy();
     await weth.waitForDeployment();
 
-    // Add BosonPriceDiscovery
-    const bpdFactory = await getContractFactory("BosonPriceDiscovery");
-    bpd = await bpdFactory.deploy(await weth.getAddress());
-    await bpd.waitForDeployment();
-
     // Specify contracts needed for this test
     const contracts = {
       erc165: "ERC165Facet",
@@ -125,10 +120,16 @@ describe("IPriceDiscoveryHandlerFacet", function () {
       diamondAddress: protocolDiamondAddress,
     } = await setupTestEnvironment(contracts, {
       wethAddress: await weth.getAddress(),
-      bpdAddress: await bpd.getAddress(),
     }));
 
     bosonErrors = await getContractAt("BosonErrors", await configHandler.getAddress());
+
+    // Add BosonPriceDiscovery
+    const bpdFactory = await getContractFactory("BosonPriceDiscovery");
+    bpd = await bpdFactory.deploy(await weth.getAddress(), protocolDiamondAddress);
+    await bpd.waitForDeployment();
+
+    await configHandler.setPriceDiscoveryAddress(await bpd.getAddress());
 
     // make all account the same
     assistant = admin;

--- a/test/protocol/PriceDiscoveryHandlerFacet.js
+++ b/test/protocol/PriceDiscoveryHandlerFacet.js
@@ -92,7 +92,7 @@ describe("IPriceDiscoveryHandlerFacet", function () {
     weth = await wethFactory.deploy();
     await weth.waitForDeployment();
 
-    // Add PriceDiscoveryBase
+    // Add BosonPriceDiscovery
     const bpdFactory = await getContractFactory("BosonPriceDiscovery");
     bpd = await bpdFactory.deploy(await weth.getAddress());
     await bpd.waitForDeployment();

--- a/test/protocol/SequentialCommitHandlerTest.js
+++ b/test/protocol/SequentialCommitHandlerTest.js
@@ -674,7 +674,7 @@ describe("IBosonSequentialCommitHandler", function () {
                 sequentialCommitHandler
                   .connect(buyer2)
                   .sequentialCommitToOffer(buyer2.address, tokenId, priceDiscovery, { value: price2 })
-              ).to.revertedWithCustomError(bosonErrors, RevertReasons.VOUCHER_NOT_RECEIVED);
+              ).to.revertedWithCustomError(bosonErrors, RevertReasons.TOKEN_ID_MISMATCH);
             });
 
             it("price discovery does not send the voucher to the protocol", async function () {

--- a/test/protocol/SequentialCommitHandlerTest.js
+++ b/test/protocol/SequentialCommitHandlerTest.js
@@ -135,7 +135,7 @@ describe("IBosonSequentialCommitHandler", function () {
     [deployer] = await getSigners();
 
     // Deploy PriceDiscovery contract
-    const PriceDiscoveryFactory = await getContractFactory("PriceDiscovery");
+    const PriceDiscoveryFactory = await getContractFactory("PriceDiscoveryMock");
     priceDiscoveryContract = await PriceDiscoveryFactory.deploy();
     await priceDiscoveryContract.waitForDeployment();
 
@@ -1537,7 +1537,7 @@ describe("IBosonSequentialCommitHandler", function () {
 
       it("should transfer the voucher during sequential commit", async function () {
         // Deploy PriceDiscovery contract
-        const PriceDiscoveryFactory = await getContractFactory("PriceDiscovery");
+        const PriceDiscoveryFactory = await getContractFactory("PriceDiscoveryMock");
         priceDiscoveryContract = await PriceDiscoveryFactory.deploy();
         await priceDiscoveryContract.waitForDeployment();
 

--- a/test/protocol/SequentialCommitHandlerTest.js
+++ b/test/protocol/SequentialCommitHandlerTest.js
@@ -89,11 +89,6 @@ describe("IBosonSequentialCommitHandler", function () {
     weth = await wethFactory.deploy();
     await weth.waitForDeployment();
 
-    // Add BosonPriceDiscovery
-    const bpdFactory = await getContractFactory("BosonPriceDiscovery");
-    bpd = await bpdFactory.deploy(await weth.getAddress());
-    await bpd.waitForDeployment();
-
     // Specify contracts needed for this test
     const contracts = {
       erc165: "ERC165Facet",
@@ -122,10 +117,16 @@ describe("IBosonSequentialCommitHandler", function () {
       diamondAddress: protocolDiamondAddress,
     } = await setupTestEnvironment(contracts, {
       wethAddress: await weth.getAddress(),
-      bpdAddress: await bpd.getAddress(),
     }));
 
     bosonErrors = await getContractAt("BosonErrors", await configHandler.getAddress());
+
+    // Add BosonPriceDiscovery
+    const bpdFactory = await getContractFactory("BosonPriceDiscovery");
+    bpd = await bpdFactory.deploy(await weth.getAddress(), protocolDiamondAddress);
+    await bpd.waitForDeployment();
+
+    await configHandler.setPriceDiscoveryAddress(await bpd.getAddress());
 
     // make all account the same
     assistant = admin;

--- a/test/protocol/SequentialCommitHandlerTest.js
+++ b/test/protocol/SequentialCommitHandlerTest.js
@@ -970,7 +970,9 @@ describe("IBosonSequentialCommitHandler", function () {
 
             // Seller approves protocol to transfer the voucher
             bosonVoucherClone = await getContractAt("IBosonVoucher", expectedCloneAddress);
-            await bosonVoucherClone.connect(reseller).setApprovalForAll(await bpd.getAddress(), true);
+            await bosonVoucherClone
+              .connect(reseller)
+              .setApprovalForAll(await sequentialCommitHandler.getAddress(), true);
 
             mockBuyer(reseller.address); // call only to increment account id counter
             newBuyer = mockBuyer(buyer2.address);
@@ -1269,7 +1271,9 @@ describe("IBosonSequentialCommitHandler", function () {
 
             it("voucher transfer not approved", async function () {
               // revoke approval
-              await bosonVoucherClone.connect(reseller).setApprovalForAll(await bpd.getAddress(), false);
+              await bosonVoucherClone
+                .connect(reseller)
+                .setApprovalForAll(await sequentialCommitHandler.getAddress(), false);
 
               // Attempt to sequentially commit to, expecting revert
               await expect(
@@ -1357,7 +1361,9 @@ describe("IBosonSequentialCommitHandler", function () {
 
                 // Seller approves protocol to transfer the voucher
                 bosonVoucherClone = await getContractAt("IBosonVoucher", expectedCloneAddress);
-                await bosonVoucherClone.connect(reseller).setApprovalForAll(await bpd.getAddress(), true);
+                await bosonVoucherClone
+                  .connect(reseller)
+                  .setApprovalForAll(await sequentialCommitHandler.getAddress(), true);
 
                 mockBuyer(buyer.address); // call only to increment account id counter
                 newBuyer = mockBuyer(buyer2.address);

--- a/test/protocol/clients/PriceDiscoveryTest.js
+++ b/test/protocol/clients/PriceDiscoveryTest.js
@@ -1,0 +1,736 @@
+const { ethers } = require("hardhat");
+const { expect } = require("chai");
+const { ZeroAddress, getSigners, getContractAt, getContractFactory, provider, parseUnits } = ethers;
+
+const PriceDiscovery = require("../../../scripts/domain/PriceDiscovery");
+const Side = require("../../../scripts/domain/Side");
+const { getInterfaceIds } = require("../../../scripts/config/supported-interfaces.js");
+const { RevertReasons } = require("../../../scripts/config/revert-reasons");
+const { getSnapshot, revertToSnapshot } = require("../../util/utils.js");
+const { deployMockTokens } = require("../../../scripts/util/deploy-mock-tokens");
+
+describe("IPriceDiscovery", function () {
+  let interfaceIds;
+  let bosonVoucher;
+  let protocol, buyer, seller, rando, foreign20;
+  let snapshotId;
+  let bosonErrors;
+  let bosonPriceDiscovery;
+  let externalPriceDiscovery;
+  let weth;
+
+  before(async function () {
+    // Get interface id
+    const { IBosonPriceDiscovery, IERC721Receiver } = await getInterfaceIds();
+    interfaceIds = { IBosonPriceDiscovery, IERC721Receiver };
+
+    // Use EOA for tests
+    [protocol, seller, buyer, rando] = await getSigners();
+
+    // Add WETH
+    const wethFactory = await getContractFactory("WETH9");
+    weth = await wethFactory.deploy();
+    await weth.waitForDeployment();
+
+    const bosonPriceDiscoveryFactory = await getContractFactory("BosonPriceDiscovery");
+    bosonPriceDiscovery = await bosonPriceDiscoveryFactory.deploy(await weth.getAddress(), protocol.address);
+    await bosonPriceDiscovery.waitForDeployment();
+
+    bosonErrors = await getContractAt("BosonErrors", await bosonPriceDiscovery.getAddress());
+
+    // Deploy external price discovery
+    const externalPriceDiscoveryFactory = await getContractFactory("PriceDiscoveryMock");
+    externalPriceDiscovery = await externalPriceDiscoveryFactory.deploy();
+    await externalPriceDiscovery.waitForDeployment();
+
+    // Deploy BosonVoucher
+    [bosonVoucher, foreign20] = await deployMockTokens(["Foreign721", "Foreign20"]); // For the purpose of testing, a regular erc721 is ok
+    await foreign20.mint(seller.address, parseUnits("1000", "ether"));
+    await foreign20.mint(buyer.address, parseUnits("1000", "ether"));
+    await foreign20.mint(protocol.address, parseUnits("1000", "ether"));
+
+    // Get snapshot id
+    snapshotId = await getSnapshot();
+  });
+
+  afterEach(async function () {
+    await revertToSnapshot(snapshotId);
+    snapshotId = await getSnapshot();
+  });
+
+  // Interface support
+  context("📋 Interfaces", async function () {
+    context("👉 supportsInterface()", async function () {
+      it("should indicate support for IBosonPriceDiscovery and IERC721Receiver interface", async function () {
+        // IBosonPriceDiscovery interface
+        let support = await bosonPriceDiscovery.supportsInterface(interfaceIds["IBosonPriceDiscovery"]);
+        expect(support, "IBosonPriceDiscovery interface not supported").is.true;
+
+        // IERC721Receiver interface
+        support = await bosonPriceDiscovery.supportsInterface(interfaceIds["IERC721Receiver"]);
+        expect(support, "IERC721Receiver interface not supported").is.true;
+      });
+    });
+  });
+
+  context("📋 Constructor", async function () {
+    it("Deployment fails if wrapped native address is 0", async function () {
+      const bosonPriceDiscoveryFactory = await getContractFactory("BosonPriceDiscovery");
+
+      await expect(bosonPriceDiscoveryFactory.deploy(ZeroAddress, protocol.address)).to.revertedWithCustomError(
+        bosonErrors,
+        RevertReasons.INVALID_ADDRESS
+      );
+    });
+
+    it("Deployment fails if protocol address is 0", async function () {
+      const bosonPriceDiscoveryFactory = await getContractFactory("BosonPriceDiscovery");
+
+      await expect(bosonPriceDiscoveryFactory.deploy(await weth.getAddress(), ZeroAddress)).to.revertedWithCustomError(
+        bosonErrors,
+        RevertReasons.INVALID_ADDRESS
+      );
+    });
+  });
+
+  context("General", async function () {
+    context("👉 fulfilAskOrder()", async function () {
+      let orderType = 0;
+
+      context("Native token", async function () {
+        let order, price, priceDiscovery, exchangeToken;
+
+        beforeEach(async function () {
+          price = 100n;
+
+          order = {
+            seller: seller.address,
+            buyer: buyer.address,
+            voucherContract: await bosonVoucher.getAddress(),
+            tokenId: 0,
+            exchangeToken: ZeroAddress,
+            price: price,
+          };
+
+          await externalPriceDiscovery.setExpectedValues(order, orderType);
+          await protocol.sendTransaction({ to: await bosonPriceDiscovery.getAddress(), value: price });
+
+          const calldata = externalPriceDiscovery.interface.encodeFunctionData("mockFulfil", [0]);
+
+          priceDiscovery = new PriceDiscovery(
+            price,
+            Side.Ask,
+            await externalPriceDiscovery.getAddress(),
+            await externalPriceDiscovery.getAddress(),
+            calldata
+          );
+
+          exchangeToken = ZeroAddress;
+        });
+
+        it("forwards call to priceDiscovery", async function () {
+          await expect(
+            bosonPriceDiscovery
+              .connect(protocol)
+              .fulfilAskOrder(exchangeToken, priceDiscovery, await bosonVoucher.getAddress(), buyer.address)
+          ).to.emit(externalPriceDiscovery, "MockFulfilCalled");
+        });
+
+        it("if priceDiscovery returns some funds, it forwards then to the buyer", async function () {
+          const calldata = externalPriceDiscovery.interface.encodeFunctionData("mockFulfil", [10]);
+          priceDiscovery.priceDiscoveryData = calldata;
+
+          const buyerBalanceBefore = await provider.getBalance(buyer.address);
+
+          await bosonPriceDiscovery
+            .connect(protocol)
+            .fulfilAskOrder(exchangeToken, priceDiscovery, await bosonVoucher.getAddress(), buyer.address);
+
+          const buyerBalanceAfter = await provider.getBalance(buyer.address);
+          expect(buyerBalanceAfter - buyerBalanceBefore).to.eq(price / 10n);
+        });
+
+        context("💔 Revert Reasons", async function () {
+          it("Caller is not the protocol", async function () {
+            await expect(
+              bosonPriceDiscovery
+                .connect(rando)
+                .fulfilAskOrder(order.exchangeToken, priceDiscovery, await bosonVoucher.getAddress(), buyer.address)
+            ).to.revertedWithCustomError(bosonErrors, RevertReasons.ACCESS_DENIED);
+          });
+
+          it("Price discovery reverts", async function () {
+            order.price = 1000n;
+            await externalPriceDiscovery.setExpectedValues(order, orderType);
+
+            await expect(
+              bosonPriceDiscovery
+                .connect(protocol)
+                .fulfilAskOrder(order.exchangeToken, priceDiscovery, await bosonVoucher.getAddress(), buyer.address)
+            ).to.revertedWith("ETH value mismatch");
+          });
+
+          it("Negative price not allowed", async function () {
+            await protocol.sendTransaction({ to: await externalPriceDiscovery.getAddress(), value: 1000 });
+
+            const calldata = externalPriceDiscovery.interface.encodeFunctionData("mockFulfil", [110]);
+            priceDiscovery.priceDiscoveryData = calldata;
+
+            await expect(
+              bosonPriceDiscovery
+                .connect(protocol)
+                .fulfilAskOrder(order.exchangeToken, priceDiscovery, await bosonVoucher.getAddress(), buyer.address)
+            ).to.revertedWithCustomError(bosonErrors, RevertReasons.NEGATIVE_PRICE_NOT_ALLOWED);
+          });
+        });
+      });
+
+      context("ERC20 token", async function () {
+        let order, price, exchangeToken, priceDiscovery;
+
+        beforeEach(async function () {
+          price = 100n;
+
+          order = {
+            seller: seller.address,
+            buyer: buyer.address,
+            voucherContract: await bosonVoucher.getAddress(),
+            tokenId: 0,
+            exchangeToken: await foreign20.getAddress(),
+            price: price,
+          };
+
+          await externalPriceDiscovery.setExpectedValues(order, orderType);
+
+          await foreign20.connect(protocol).transfer(await bosonPriceDiscovery.getAddress(), price);
+
+          const calldata = externalPriceDiscovery.interface.encodeFunctionData("mockFulfil", [25]);
+
+          priceDiscovery = new PriceDiscovery(
+            price,
+            Side.Ask,
+            await externalPriceDiscovery.getAddress(),
+            await externalPriceDiscovery.getAddress(),
+            calldata
+          );
+
+          exchangeToken = await foreign20.getAddress();
+        });
+
+        it("if priceDiscovery returns some funds, it forwards then to the buyer", async function () {
+          const buyerBalanceBefore = await foreign20.balanceOf(buyer.address);
+
+          await bosonPriceDiscovery
+            .connect(protocol)
+            .fulfilAskOrder(exchangeToken, priceDiscovery, await bosonVoucher.getAddress(), buyer.address);
+
+          const buyerBalanceAfter = await foreign20.balanceOf(buyer.address);
+          expect(buyerBalanceAfter - buyerBalanceBefore).to.eq(price / 4n);
+        });
+
+        it("price discovery is not approved after the transaction is finalized", async function () {
+          await bosonPriceDiscovery
+            .connect(protocol)
+            .fulfilAskOrder(exchangeToken, priceDiscovery, await bosonVoucher.getAddress(), buyer.address);
+
+          const allowance = await foreign20.allowance(
+            await bosonPriceDiscovery.getAddress(),
+            await externalPriceDiscovery.getAddress()
+          );
+          expect(allowance).to.eq(0n);
+        });
+
+        context("💔 Revert Reasons", async function () {
+          it("Price discovery reverts", async function () {
+            order.price = 1000n;
+            await externalPriceDiscovery.setExpectedValues(order, orderType);
+
+            await expect(
+              bosonPriceDiscovery
+                .connect(protocol)
+                .fulfilAskOrder(exchangeToken, priceDiscovery, await bosonVoucher.getAddress(), buyer.address)
+            ).to.revertedWith(RevertReasons.ERC20_INSUFFICIENT_ALLOWANCE);
+          });
+
+          it("Negative price not allowed", async function () {
+            await foreign20.connect(protocol).transfer(await externalPriceDiscovery.getAddress(), 1000);
+
+            const calldata = externalPriceDiscovery.interface.encodeFunctionData("mockFulfil", [110]);
+            priceDiscovery.priceDiscoveryData = calldata;
+
+            await expect(
+              bosonPriceDiscovery
+                .connect(protocol)
+                .fulfilAskOrder(exchangeToken, priceDiscovery, await bosonVoucher.getAddress(), buyer.address)
+            ).to.revertedWithCustomError(bosonErrors, RevertReasons.NEGATIVE_PRICE_NOT_ALLOWED);
+          });
+        });
+      });
+    });
+
+    context("👉 fulfilBidOrder()", async function () {
+      let orderType = 1;
+      let tokenId = 1;
+
+      beforeEach(async function () {
+        // mint the voucher
+        // for the test purposes, we mint the voucher directly to the bosonPriceDiscovery contract
+        await bosonVoucher.connect(protocol).mint(tokenId, 1);
+        await bosonVoucher
+          .connect(protocol)
+          .transferFrom(protocol.address, await bosonPriceDiscovery.getAddress(), tokenId);
+      });
+
+      context("Native token", async function () {
+        let order, price, priceDiscovery, exchangeToken;
+
+        beforeEach(async function () {
+          price = 100n;
+
+          order = {
+            seller: seller.address,
+            buyer: buyer.address,
+            voucherContract: await bosonVoucher.getAddress(),
+            tokenId: tokenId,
+            exchangeToken: await weth.getAddress(),
+            price: price,
+          };
+
+          await externalPriceDiscovery.setExpectedValues(order, orderType);
+          await weth.connect(protocol).deposit({ value: 10n * price });
+          await weth.connect(protocol).transfer(await externalPriceDiscovery.getAddress(), 10n * price);
+
+          const calldata = externalPriceDiscovery.interface.encodeFunctionData("mockFulfil", [100]);
+
+          priceDiscovery = new PriceDiscovery(
+            price,
+            Side.Bid,
+            await externalPriceDiscovery.getAddress(),
+            await externalPriceDiscovery.getAddress(),
+            calldata
+          );
+
+          exchangeToken = ZeroAddress;
+        });
+
+        it("forwards call to priceDiscovery", async function () {
+          await expect(
+            bosonPriceDiscovery
+              .connect(protocol)
+              .fulfilBidOrder(tokenId, exchangeToken, priceDiscovery, seller.address, await bosonVoucher.getAddress())
+          ).to.emit(externalPriceDiscovery, "MockFulfilCalled");
+        });
+
+        it("actual price is returned to the protocol", async function () {
+          const calldata = externalPriceDiscovery.interface.encodeFunctionData("mockFulfil", [110]);
+          priceDiscovery.priceDiscoveryData = calldata;
+
+          const protocolBalanceBefore = await weth.balanceOf(protocol.address);
+
+          await bosonPriceDiscovery
+            .connect(protocol)
+            .fulfilBidOrder(tokenId, exchangeToken, priceDiscovery, seller.address, await bosonVoucher.getAddress());
+
+          const protocolBalanceAfter = await weth.balanceOf(protocol.address);
+          expect(protocolBalanceAfter - protocolBalanceBefore).to.eq((price * 11n) / 10n);
+        });
+
+        context("💔 Revert Reasons", async function () {
+          it("Caller is not the protocol", async function () {
+            await expect(
+              bosonPriceDiscovery
+                .connect(rando)
+                .fulfilBidOrder(tokenId, exchangeToken, priceDiscovery, seller.address, await bosonVoucher.getAddress())
+            ).to.revertedWithCustomError(bosonErrors, RevertReasons.ACCESS_DENIED);
+          });
+
+          it("Price discovery reverts", async function () {
+            priceDiscovery.conduit = ZeroAddress;
+
+            await expect(
+              bosonPriceDiscovery
+                .connect(protocol)
+                .fulfilBidOrder(tokenId, exchangeToken, priceDiscovery, seller.address, await bosonVoucher.getAddress())
+            ).to.revertedWith(RevertReasons.ERC721_CALLER_NOT_OWNER_OR_APPROVED);
+          });
+
+          it("Negative price not allowed", async function () {
+            await weth.connect(protocol).deposit({ value: 1000n });
+            await weth.connect(protocol).transfer(await bosonPriceDiscovery.getAddress(), 1000n);
+
+            const calldata = weth.interface.encodeFunctionData("transfer", [rando.address, 110]);
+
+            const priceDiscovery = new PriceDiscovery(
+              price,
+              Side.Bid,
+              await weth.getAddress(),
+              await weth.getAddress(),
+              calldata
+            );
+
+            await expect(
+              bosonPriceDiscovery
+                .connect(protocol)
+                .fulfilBidOrder(tokenId, exchangeToken, priceDiscovery, seller.address, await bosonVoucher.getAddress())
+            ).to.revertedWithCustomError(bosonErrors, RevertReasons.NEGATIVE_PRICE_NOT_ALLOWED);
+          });
+
+          it("Insufficient value received", async function () {
+            const calldata = externalPriceDiscovery.interface.encodeFunctionData("mockFulfil", [90]);
+
+            priceDiscovery.priceDiscoveryData = calldata;
+
+            await expect(
+              bosonPriceDiscovery
+                .connect(protocol)
+                .fulfilBidOrder(tokenId, exchangeToken, priceDiscovery, seller.address, await bosonVoucher.getAddress())
+            ).to.revertedWithCustomError(bosonErrors, RevertReasons.INSUFFICIENT_VALUE_RECEIVED);
+          });
+
+          it("Voucher not transferred", async function () {
+            const calldata = foreign20.interface.encodeFunctionData("transfer", [rando.address, 0]);
+
+            const priceDiscovery = new PriceDiscovery(
+              0,
+              Side.Bid,
+              await foreign20.getAddress(),
+              await foreign20.getAddress(),
+              calldata
+            );
+
+            await expect(
+              bosonPriceDiscovery
+                .connect(protocol)
+                .fulfilBidOrder(tokenId, exchangeToken, priceDiscovery, seller.address, await bosonVoucher.getAddress())
+            ).to.revertedWithCustomError(bosonErrors, RevertReasons.VOUCHER_NOT_TRANSFERRED);
+          });
+        });
+      });
+
+      context("ERC20 token", async function () {
+        let order, price, exchangeToken, priceDiscovery;
+
+        beforeEach(async function () {
+          price = 100n;
+
+          order = {
+            seller: seller.address,
+            buyer: buyer.address,
+            voucherContract: await bosonVoucher.getAddress(),
+            tokenId: tokenId,
+            exchangeToken: await foreign20.getAddress(),
+            price: price,
+          };
+
+          await externalPriceDiscovery.setExpectedValues(order, orderType);
+
+          await foreign20.connect(protocol).transfer(await externalPriceDiscovery.getAddress(), 2n * price);
+
+          const calldata = externalPriceDiscovery.interface.encodeFunctionData("mockFulfil", [100]);
+
+          priceDiscovery = new PriceDiscovery(
+            price,
+            Side.Bid,
+            await externalPriceDiscovery.getAddress(),
+            await externalPriceDiscovery.getAddress(),
+            calldata
+          );
+
+          exchangeToken = await foreign20.getAddress();
+        });
+
+        it("forwards call to priceDiscovery", async function () {
+          await expect(
+            bosonPriceDiscovery
+              .connect(protocol)
+              .fulfilBidOrder(tokenId, exchangeToken, priceDiscovery, seller.address, await bosonVoucher.getAddress())
+          ).to.emit(externalPriceDiscovery, "MockFulfilCalled");
+        });
+
+        it("actual price is returned to the protocol", async function () {
+          const calldata = externalPriceDiscovery.interface.encodeFunctionData("mockFulfil", [110]);
+          priceDiscovery.priceDiscoveryData = calldata;
+
+          const protocolBalanceBefore = await foreign20.balanceOf(protocol.address);
+
+          await bosonPriceDiscovery
+            .connect(protocol)
+            .fulfilBidOrder(tokenId, exchangeToken, priceDiscovery, seller.address, await bosonVoucher.getAddress());
+
+          const protocolBalanceAfter = await foreign20.balanceOf(protocol.address);
+          expect(protocolBalanceAfter - protocolBalanceBefore).to.eq((price * 11n) / 10n);
+        });
+
+        it("price discovery is not approved after the transaction is finalized", async function () {
+          await bosonPriceDiscovery
+            .connect(protocol)
+            .fulfilBidOrder(tokenId, exchangeToken, priceDiscovery, seller.address, await bosonVoucher.getAddress());
+
+          const approved = await bosonVoucher.getApproved(tokenId);
+          expect(approved).to.eq(ZeroAddress);
+        });
+
+        context("💔 Revert Reasons", async function () {
+          it("Price discovery reverts", async function () {
+            order.price = 1000n;
+            await externalPriceDiscovery.setExpectedValues(order, orderType);
+
+            await expect(
+              bosonPriceDiscovery
+                .connect(protocol)
+                .fulfilBidOrder(tokenId, exchangeToken, priceDiscovery, seller.address, await bosonVoucher.getAddress())
+            ).to.revertedWith(RevertReasons.ERC20_EXCEEDS_BALANCE);
+          });
+
+          it("Negative price not allowed", async function () {
+            await foreign20.connect(protocol).transfer(await bosonPriceDiscovery.getAddress(), 1000);
+
+            const calldata = foreign20.interface.encodeFunctionData("transfer", [rando.address, 110]);
+
+            const priceDiscovery = new PriceDiscovery(
+              price,
+              Side.Bid,
+              await foreign20.getAddress(),
+              await foreign20.getAddress(),
+              calldata
+            );
+
+            await expect(
+              bosonPriceDiscovery
+                .connect(protocol)
+                .fulfilBidOrder(tokenId, exchangeToken, priceDiscovery, seller.address, await bosonVoucher.getAddress())
+            ).to.revertedWithCustomError(bosonErrors, RevertReasons.NEGATIVE_PRICE_NOT_ALLOWED);
+          });
+
+          it("Insufficient value received", async function () {
+            const calldata = externalPriceDiscovery.interface.encodeFunctionData("mockFulfil", [90]);
+
+            priceDiscovery.priceDiscoveryData = calldata;
+
+            await expect(
+              bosonPriceDiscovery
+                .connect(protocol)
+                .fulfilBidOrder(tokenId, exchangeToken, priceDiscovery, seller.address, await bosonVoucher.getAddress())
+            ).to.revertedWithCustomError(bosonErrors, RevertReasons.INSUFFICIENT_VALUE_RECEIVED);
+          });
+        });
+      });
+    });
+
+    context("👉 handleWrapper()", async function () {
+      let orderType = 2;
+      let tokenId = 1;
+
+      // beforeEach(async function () {
+      //   // mint the voucher
+      //   // for the test purposes, we mint the voucher directly to the bosonPriceDiscovery contract
+      //   await bosonVoucher.connect(protocol).mint(tokenId, 1);
+      //   await bosonVoucher
+      //     .connect(protocol)
+      //     .transferFrom(protocol.address, await bosonPriceDiscovery.getAddress(), tokenId);
+      // });
+
+      context("Native token", async function () {
+        let order, price, priceDiscovery, exchangeToken;
+
+        beforeEach(async function () {
+          price = 100n;
+
+          order = {
+            seller: seller.address,
+            buyer: buyer.address,
+            voucherContract: await bosonVoucher.getAddress(),
+            tokenId: tokenId,
+            exchangeToken: await weth.getAddress(),
+            price: price,
+          };
+
+          await externalPriceDiscovery.setExpectedValues(order, orderType);
+          await weth.connect(protocol).deposit({ value: 10n * price });
+          await weth.connect(protocol).transfer(await externalPriceDiscovery.getAddress(), 10n * price);
+
+          const calldata = externalPriceDiscovery.interface.encodeFunctionData("mockFulfil", [100]);
+
+          priceDiscovery = new PriceDiscovery(
+            price,
+            Side.Wrapper,
+            await externalPriceDiscovery.getAddress(),
+            await externalPriceDiscovery.getAddress(),
+            calldata
+          );
+
+          exchangeToken = ZeroAddress;
+        });
+
+        it("forwards call to priceDiscovery", async function () {
+          await expect(bosonPriceDiscovery.connect(protocol).handleWrapper(exchangeToken, priceDiscovery)).to.emit(
+            externalPriceDiscovery,
+            "MockFulfilCalled"
+          );
+        });
+
+        it("actual price is returned to the protocol", async function () {
+          const protocolBalanceBefore = await weth.balanceOf(protocol.address);
+
+          await bosonPriceDiscovery.connect(protocol).handleWrapper(exchangeToken, priceDiscovery);
+
+          const protocolBalanceAfter = await weth.balanceOf(protocol.address);
+          expect(protocolBalanceAfter - protocolBalanceBefore).to.eq(price);
+        });
+
+        context("💔 Revert Reasons", async function () {
+          it("Caller is not the protocol", async function () {
+            await expect(
+              bosonPriceDiscovery.connect(rando).handleWrapper(exchangeToken, priceDiscovery)
+            ).to.revertedWithCustomError(bosonErrors, RevertReasons.ACCESS_DENIED);
+          });
+
+          it("Price discovery reverts", async function () {
+            await externalPriceDiscovery.setExpectedValues(order, 1);
+
+            await expect(
+              bosonPriceDiscovery.connect(protocol).handleWrapper(exchangeToken, priceDiscovery)
+            ).to.revertedWith(RevertReasons.ERC721_INVALID_TOKEN_ID);
+          });
+
+          it("Negative price not allowed", async function () {
+            await weth.connect(protocol).deposit({ value: 1000n });
+            await weth.connect(protocol).transfer(await bosonPriceDiscovery.getAddress(), 1000n);
+
+            const calldata = weth.interface.encodeFunctionData("transfer", [rando.address, 110]);
+
+            const priceDiscovery = new PriceDiscovery(
+              price,
+              Side.Bid,
+              await weth.getAddress(),
+              await weth.getAddress(),
+              calldata
+            );
+
+            await expect(
+              bosonPriceDiscovery.connect(protocol).handleWrapper(exchangeToken, priceDiscovery)
+            ).to.revertedWithCustomError(bosonErrors, RevertReasons.NEGATIVE_PRICE_NOT_ALLOWED);
+          });
+
+          it("Insufficient value received", async function () {
+            const calldata = externalPriceDiscovery.interface.encodeFunctionData("mockFulfil", [90]);
+
+            priceDiscovery.priceDiscoveryData = calldata;
+
+            await expect(
+              bosonPriceDiscovery.connect(protocol).handleWrapper(exchangeToken, priceDiscovery)
+            ).to.revertedWithCustomError(bosonErrors, RevertReasons.PRICE_MISMATCH);
+          });
+
+          it("Returned too much", async function () {
+            const calldata = externalPriceDiscovery.interface.encodeFunctionData("mockFulfil", [110]);
+
+            priceDiscovery.priceDiscoveryData = calldata;
+
+            await expect(
+              bosonPriceDiscovery.connect(protocol).handleWrapper(exchangeToken, priceDiscovery)
+            ).to.revertedWithCustomError(bosonErrors, RevertReasons.PRICE_MISMATCH);
+          });
+        });
+      });
+
+      context("ERC20 token", async function () {
+        let order, price, exchangeToken, priceDiscovery;
+
+        beforeEach(async function () {
+          price = 100n;
+
+          order = {
+            seller: seller.address,
+            buyer: buyer.address,
+            voucherContract: await bosonVoucher.getAddress(),
+            tokenId: tokenId,
+            exchangeToken: await foreign20.getAddress(),
+            price: price,
+          };
+
+          await externalPriceDiscovery.setExpectedValues(order, orderType);
+
+          await foreign20.connect(protocol).transfer(await externalPriceDiscovery.getAddress(), 2n * price);
+
+          const calldata = externalPriceDiscovery.interface.encodeFunctionData("mockFulfil", [100]);
+
+          priceDiscovery = new PriceDiscovery(
+            price,
+            Side.Wrapper,
+            await externalPriceDiscovery.getAddress(),
+            await externalPriceDiscovery.getAddress(),
+            calldata
+          );
+
+          exchangeToken = await foreign20.getAddress();
+        });
+
+        it("forwards call to priceDiscovery", async function () {
+          await expect(bosonPriceDiscovery.connect(protocol).handleWrapper(exchangeToken, priceDiscovery)).to.emit(
+            externalPriceDiscovery,
+            "MockFulfilCalled"
+          );
+        });
+
+        it("actual price is returned to the protocol", async function () {
+          const protocolBalanceBefore = await foreign20.balanceOf(protocol.address);
+
+          await bosonPriceDiscovery.connect(protocol).handleWrapper(exchangeToken, priceDiscovery);
+
+          const protocolBalanceAfter = await foreign20.balanceOf(protocol.address);
+          expect(protocolBalanceAfter - protocolBalanceBefore).to.eq(price);
+        });
+
+        context("💔 Revert Reasons", async function () {
+          it("Price discovery reverts", async function () {
+            order.price = 1000n;
+            await externalPriceDiscovery.setExpectedValues(order, orderType);
+
+            await expect(
+              bosonPriceDiscovery.connect(protocol).handleWrapper(exchangeToken, priceDiscovery)
+            ).to.revertedWith(RevertReasons.ERC20_EXCEEDS_BALANCE);
+          });
+
+          it("Negative price not allowed", async function () {
+            await foreign20.connect(protocol).transfer(await bosonPriceDiscovery.getAddress(), 1000);
+
+            const calldata = foreign20.interface.encodeFunctionData("transfer", [rando.address, 110]);
+
+            const priceDiscovery = new PriceDiscovery(
+              price,
+              Side.Bid,
+              await foreign20.getAddress(),
+              await foreign20.getAddress(),
+              calldata
+            );
+
+            await expect(
+              bosonPriceDiscovery.connect(protocol).handleWrapper(exchangeToken, priceDiscovery)
+            ).to.revertedWithCustomError(bosonErrors, RevertReasons.NEGATIVE_PRICE_NOT_ALLOWED);
+          });
+
+          it("Insufficient value received", async function () {
+            const calldata = externalPriceDiscovery.interface.encodeFunctionData("mockFulfil", [90]);
+
+            priceDiscovery.priceDiscoveryData = calldata;
+
+            await expect(
+              bosonPriceDiscovery.connect(protocol).handleWrapper(exchangeToken, priceDiscovery)
+            ).to.revertedWithCustomError(bosonErrors, RevertReasons.PRICE_MISMATCH);
+          });
+
+          it("Returned too much", async function () {
+            const calldata = externalPriceDiscovery.interface.encodeFunctionData("mockFulfil", [110]);
+
+            priceDiscovery.priceDiscoveryData = calldata;
+
+            await expect(
+              bosonPriceDiscovery.connect(protocol).handleWrapper(exchangeToken, priceDiscovery)
+            ).to.revertedWithCustomError(bosonErrors, RevertReasons.PRICE_MISMATCH);
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/protocol/clients/PriceDiscoveryTest.js
+++ b/test/protocol/clients/PriceDiscoveryTest.js
@@ -733,4 +733,21 @@ describe("IPriceDiscovery", function () {
       });
     });
   });
+
+  context("📋 onERC721Received", async function () {
+    it("Can receive voucher only during price discovery", async function () {
+      const tokenId = 1;
+      await bosonVoucher.connect(protocol).mint(tokenId, 1);
+
+      await expect(
+        bosonVoucher
+          .connect(protocol)
+          ["safeTransferFrom(address,address,uint256)"](
+            protocol.address,
+            await bosonPriceDiscovery.getAddress(),
+            tokenId
+          )
+      ).to.revertedWithCustomError(bosonErrors, RevertReasons.UNEXPECTED_ERC721_RECEIVED);
+    });
+  });
 });

--- a/test/util/utils.js
+++ b/test/util/utils.js
@@ -167,6 +167,20 @@ function compareRoyaltyInfo(returnedRoyaltyInfo) {
   return true;
 }
 
+/** Predicate to compare protocol version in emitted events
+ * Bind expected protocol version to this function and pass it to .withArgs() instead of the expected protocol version
+ * If trimmed returned and expected versions are equal, the test will pass, otherwise it raises an error
+ *
+ * @param {*} returnedRoyaltyInfo
+ * @returns equality of expected and returned protocol versions
+ */
+function compareProtocolVersions(returnedVersion) {
+  // trim returned version
+  const trimmedReturnedVersion = returnedVersion.replace(/\0/g, "");
+
+  return trimmedReturnedVersion == this;
+}
+
 async function setNextBlockTimestamp(timestamp, mine = false) {
   if (typeof timestamp == "string" && timestamp.startsWith("0x0") && timestamp.length > 3)
     timestamp = "0x" + timestamp.substring(3);
@@ -563,3 +577,4 @@ exports.getSnapshot = getSnapshot;
 exports.revertToSnapshot = revertToSnapshot;
 exports.getSellerSalt = getSellerSalt;
 exports.compareRoyaltyInfo = compareRoyaltyInfo;
+exports.compareProtocolVersions = compareProtocolVersions;

--- a/test/util/utils.js
+++ b/test/util/utils.js
@@ -398,7 +398,7 @@ function objectToArray(input) {
   return result;
 }
 
-async function setupTestEnvironment(contracts, { bosonTokenAddress, forwarderAddress, wethAddress } = {}) {
+async function setupTestEnvironment(contracts, { bosonTokenAddress, forwarderAddress, wethAddress, bpdAddress } = {}) {
   // Load modules only here to avoid the caching issues in upgrade tests
   const { deployProtocolDiamond } = require("../../scripts/util/deploy-protocol-diamond.js");
   const { deployProtocolClients } = require("../../scripts/util/deploy-protocol-clients");
@@ -496,6 +496,10 @@ async function setupTestEnvironment(contracts, { bosonTokenAddress, forwarderAdd
   const facetsToDeploy = await getFacetsWithArgs(facetNames, protocolConfig);
   facetsToDeploy["SequentialCommitHandlerFacet"].constructorArgs[0] = wethAddress || ZeroAddress; // update only weth address
   facetsToDeploy["PriceDiscoveryHandlerFacet"].constructorArgs[0] = wethAddress || ZeroAddress; // update only weth address
+
+  facetsToDeploy["SequentialCommitHandlerFacet"].constructorArgs[1] = bpdAddress || ZeroAddress; // update only weth address
+  facetsToDeploy["PriceDiscoveryHandlerFacet"].constructorArgs[1] = bpdAddress || ZeroAddress; // update only weth address
+  facetsToDeploy["ExchangeHandlerFacet"].constructorArgs[1] = bpdAddress || ZeroAddress; // update only weth address
 
   // Cut the protocol handler facets into the Diamond
   await deployAndCutFacets(await protocolDiamond.getAddress(), facetsToDeploy, maxPriorityFeePerGas);

--- a/test/util/utils.js
+++ b/test/util/utils.js
@@ -398,7 +398,7 @@ function objectToArray(input) {
   return result;
 }
 
-async function setupTestEnvironment(contracts, { bosonTokenAddress, forwarderAddress, wethAddress, bpdAddress } = {}) {
+async function setupTestEnvironment(contracts, { bosonTokenAddress, forwarderAddress, wethAddress } = {}) {
   // Load modules only here to avoid the caching issues in upgrade tests
   const { deployProtocolDiamond } = require("../../scripts/util/deploy-protocol-diamond.js");
   const { deployProtocolClients } = require("../../scripts/util/deploy-protocol-clients");
@@ -465,6 +465,7 @@ async function setupTestEnvironment(contracts, { bosonTokenAddress, forwarderAdd
       token: bosonTokenAddress || (await bosonToken.getAddress()),
       voucherBeacon: await beacon.getAddress(),
       beaconProxy: ZeroAddress,
+      priceDiscovery: await beacon.getAddress(), // dummy address, changed later
     },
     // Protocol limits
     {
@@ -496,10 +497,6 @@ async function setupTestEnvironment(contracts, { bosonTokenAddress, forwarderAdd
   const facetsToDeploy = await getFacetsWithArgs(facetNames, protocolConfig);
   facetsToDeploy["SequentialCommitHandlerFacet"].constructorArgs[0] = wethAddress || ZeroAddress; // update only weth address
   facetsToDeploy["PriceDiscoveryHandlerFacet"].constructorArgs[0] = wethAddress || ZeroAddress; // update only weth address
-
-  facetsToDeploy["SequentialCommitHandlerFacet"].constructorArgs[1] = bpdAddress || ZeroAddress; // update only weth address
-  facetsToDeploy["PriceDiscoveryHandlerFacet"].constructorArgs[1] = bpdAddress || ZeroAddress; // update only weth address
-  facetsToDeploy["ExchangeHandlerFacet"].constructorArgs[1] = bpdAddress || ZeroAddress; // update only weth address
 
   // Cut the protocol handler facets into the Diamond
   await deployAndCutFacets(await protocolDiamond.getAddress(), facetsToDeploy, maxPriorityFeePerGas);


### PR DESCRIPTION
Fix #861 

This change moves a part of price discovery logic outside the diamond, effectively creating another boson protocol client.

Since this client does not own any assets, they cannot be stolen from it. The user will always approve only Boson Protocol or external price discovery contract to transfer the vouchers and/or erc20 tokens.

Users can still make arbitrary calls through this client, but since it's outside the boson protocol address, any calls that the client makes will not be directly associated with the boson protocol.