### PR TITLE
New pausable regions

### DIFF
--- a/contracts/domain/BosonErrors.sol
+++ b/contracts/domain/BosonErrors.sol
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.22;
 
+import { BosonTypes } from "./BosonTypes.sol";
+
 interface BosonErrors {
     // Pause related
     // Trying to unpause a protocol when it's not paused
     error NotPaused();
     // Whenever a region is paused, and a method from that region is called
-    error RegionPaused(); //ToDo consider adding the region to the error message
+    error RegionPaused(BosonTypes.PausableRegion region);
 
     // General
     // Input parameter of type address is zero address

--- a/contracts/domain/BosonTypes.sol
+++ b/contracts/domain/BosonTypes.sol
@@ -21,7 +21,9 @@ contract BosonTypes {
         Disputes,
         Funds,
         Orchestration,
-        MetaTransaction
+        MetaTransaction,
+        PriceDiscovery,
+        SequentialCommit
     }
 
     enum EvaluationMethod {

--- a/contracts/protocol/bases/PausableBase.sol
+++ b/contracts/protocol/bases/PausableBase.sol
@@ -169,6 +169,30 @@ contract PausableBase is BosonTypes {
     }
 
     /**
+     * @notice Modifier that checks the PriceDiscovery region is not paused
+     *
+     * Reverts if region is paused
+     *
+     * See: {BosonTypes.PausableRegion}
+     */
+    modifier priceDiscoveryNotPaused() {
+        revertIfPaused(PausableRegion.PriceDiscovery);
+        _;
+    }
+
+    /**
+     * @notice Modifier that checks the SequentialCommit region is not paused
+     *
+     * Reverts if region is paused
+     *
+     * See: {BosonTypes.PausableRegion}
+     */
+    modifier sequentialCommitNotPaused() {
+        revertIfPaused(PausableRegion.SequentialCommit);
+        _;
+    }
+
+    /**
      * @notice Checks if a region of the protocol is paused.
      *
      * Reverts if region is paused
@@ -178,6 +202,7 @@ contract PausableBase is BosonTypes {
     function revertIfPaused(PausableRegion _region) internal view {
         // Region enum value must be used as the exponent in a power of 2
         uint256 powerOfTwo = 1 << uint256(_region);
-        if ((ProtocolLib.protocolStatus().pauseScenario & powerOfTwo) == powerOfTwo) revert BosonErrors.RegionPaused();
+        if ((ProtocolLib.protocolStatus().pauseScenario & powerOfTwo) == powerOfTwo)
+            revert BosonErrors.RegionPaused(_region);
     }
 }

--- a/contracts/protocol/bases/PriceDiscoveryBase.sol
+++ b/contracts/protocol/bases/PriceDiscoveryBase.sol
@@ -52,7 +52,7 @@ contract PriceDiscoveryBase is ProtocolBase {
         PriceDiscovery calldata _priceDiscovery,
         address _seller,
         address _buyer
-    ) internal returns (uint256 actualPrice) {
+    ) internal priceDiscoveryNotPaused returns (uint256 actualPrice) {
         // Make sure caller provided price discovery data
         if (_priceDiscovery.priceDiscoveryContract == address(0) || _priceDiscovery.priceDiscoveryData.length == 0) {
             revert InvalidPriceDiscovery();

--- a/contracts/protocol/facets/PriceDiscoveryHandlerFacet.sol
+++ b/contracts/protocol/facets/PriceDiscoveryHandlerFacet.sol
@@ -3,20 +3,11 @@ pragma solidity 0.8.22;
 
 import { BuyerBase } from "../bases/BuyerBase.sol";
 import { IBosonPriceDiscoveryHandler } from "../../interfaces/handlers/IBosonPriceDiscoveryHandler.sol";
-import { IBosonVoucher } from "../../interfaces/clients/IBosonVoucher.sol";
-import { ITwinToken } from "../../interfaces/ITwinToken.sol";
 import { DiamondLib } from "../../diamond/DiamondLib.sol";
 import { BuyerBase } from "../bases/BuyerBase.sol";
-import { DisputeBase } from "../bases/DisputeBase.sol";
-import { ProtocolLib } from "../libs/ProtocolLib.sol";
 import { FundsLib } from "../libs/FundsLib.sol";
 import "../../domain/BosonConstants.sol";
-import { IERC1155 } from "../../interfaces/IERC1155.sol";
-import { IERC721 } from "../../interfaces/IERC721.sol";
-import { IERC20 } from "../../interfaces/IERC20.sol";
-import { IERC721Receiver } from "../../interfaces/IERC721Receiver.sol";
 import { PriceDiscoveryBase } from "../bases/PriceDiscoveryBase.sol";
-import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 
 /**
  * @title PriceDiscoveryHandlerFacet

--- a/contracts/protocol/facets/SequentialCommitHandlerFacet.sol
+++ b/contracts/protocol/facets/SequentialCommitHandlerFacet.sol
@@ -74,7 +74,7 @@ contract SequentialCommitHandlerFacet is IBosonSequentialCommitHandler, PriceDis
         address payable _buyer,
         uint256 _tokenId,
         PriceDiscovery calldata _priceDiscovery
-    ) external payable exchangesNotPaused buyersNotPaused nonReentrant {
+    ) external payable exchangesNotPaused buyersNotPaused sequentialCommitNotPaused nonReentrant {
         // Make sure buyer address is not zero address
         if (_buyer == address(0)) revert InvalidAddress();
 

--- a/scripts/domain/PausableRegion.js
+++ b/scripts/domain/PausableRegion.js
@@ -16,6 +16,8 @@ PausableRegion.Disputes = 9;
 PausableRegion.Funds = 10;
 PausableRegion.Orchestration = 11;
 PausableRegion.MetaTransaction = 12;
+PausableRegion.PriceDiscovery = 13;
+PausableRegion.SequentialCommit = 14;
 
 PausableRegion.Regions = [
   PausableRegion.Offers,
@@ -31,6 +33,8 @@ PausableRegion.Regions = [
   PausableRegion.Funds,
   PausableRegion.Orchestration,
   PausableRegion.MetaTransaction,
+  PausableRegion.PriceDiscovery,
+  PausableRegion.SequentialCommit,
 ];
 
 // Export

--- a/test/protocol/AgentHandlerTest.js
+++ b/test/protocol/AgentHandlerTest.js
@@ -164,10 +164,9 @@ describe("AgentHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.Agents]);
 
           // Attempt to create an agent, expecting revert
-          await expect(accountHandler.connect(rando).createAgent(agent)).to.revertedWithCustomError(
-            bosonErrors,
-            RevertReasons.REGION_PAUSED
-          );
+          await expect(accountHandler.connect(rando).createAgent(agent))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Agents);
         });
 
         it("active is false", async function () {
@@ -455,10 +454,9 @@ describe("AgentHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.Agents]);
 
           // Attempt to update an agent, expecting revert
-          await expect(accountHandler.connect(other1).updateAgent(agent)).to.revertedWithCustomError(
-            bosonErrors,
-            RevertReasons.REGION_PAUSED
-          );
+          await expect(accountHandler.connect(other1).updateAgent(agent))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Agents);
         });
 
         it("Agent does not exist", async function () {

--- a/test/protocol/BundleHandlerTest.js
+++ b/test/protocol/BundleHandlerTest.js
@@ -357,10 +357,9 @@ describe("IBosonBundleHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.Bundles]);
 
           // Attempt to create a bundle, expecting revert
-          await expect(bundleHandler.connect(assistant).createBundle(bundle)).to.revertedWithCustomError(
-            bosonErrors,
-            RevertReasons.REGION_PAUSED
-          );
+          await expect(bundleHandler.connect(assistant).createBundle(bundle))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Bundles);
         });
 
         it("Caller not assistant of any seller", async function () {

--- a/test/protocol/BuyerHandlerTest.js
+++ b/test/protocol/BuyerHandlerTest.js
@@ -139,10 +139,9 @@ describe("BuyerHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.Buyers]);
 
           // Attempt to create a buyer, expecting revert
-          await expect(accountHandler.connect(rando).createBuyer(buyer)).to.revertedWithCustomError(
-            bosonErrors,
-            RevertReasons.REGION_PAUSED
-          );
+          await expect(accountHandler.connect(rando).createBuyer(buyer))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Buyers);
         });
 
         it("active is false", async function () {
@@ -444,10 +443,9 @@ describe("BuyerHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.Buyers]);
 
           // Attempt to update a buyer, expecting revert
-          await expect(accountHandler.connect(other1).updateBuyer(buyer)).to.revertedWithCustomError(
-            bosonErrors,
-            RevertReasons.REGION_PAUSED
-          );
+          await expect(accountHandler.connect(other1).updateBuyer(buyer))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Buyers);
         });
 
         it("Buyer does not exist", async function () {

--- a/test/protocol/DisputeHandlerTest.js
+++ b/test/protocol/DisputeHandlerTest.js
@@ -297,10 +297,9 @@ describe("IBosonDisputeHandler", function () {
             await pauseHandler.connect(pauser).pause([PausableRegion.Disputes]);
 
             // Attempt to raise a dispute, expecting revert
-            await expect(disputeHandler.connect(buyer).raiseDispute(exchangeId)).to.revertedWithCustomError(
-              bosonErrors,
-              RevertReasons.REGION_PAUSED
-            );
+            await expect(disputeHandler.connect(buyer).raiseDispute(exchangeId))
+              .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+              .withArgs(PausableRegion.Disputes);
           });
 
           it("Caller does not hold a voucher for the given exchange id", async function () {
@@ -453,10 +452,9 @@ describe("IBosonDisputeHandler", function () {
             await pauseHandler.connect(pauser).pause([PausableRegion.Disputes]);
 
             // Attempt to retract a dispute, expecting revert
-            await expect(disputeHandler.connect(buyer).retractDispute(exchangeId)).to.revertedWithCustomError(
-              bosonErrors,
-              RevertReasons.REGION_PAUSED
-            );
+            await expect(disputeHandler.connect(buyer).retractDispute(exchangeId))
+              .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+              .withArgs(PausableRegion.Disputes);
           });
 
           it("Exchange does not exist", async function () {
@@ -595,9 +593,9 @@ describe("IBosonDisputeHandler", function () {
             await pauseHandler.connect(pauser).pause([PausableRegion.Disputes]);
 
             // Attempt to extend a dispute timeout, expecting revert
-            await expect(
-              disputeHandler.connect(assistant).extendDisputeTimeout(exchangeId, newDisputeTimeout)
-            ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+            await expect(disputeHandler.connect(assistant).extendDisputeTimeout(exchangeId, newDisputeTimeout))
+              .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+              .withArgs(PausableRegion.Disputes);
           });
 
           it("Exchange does not exist", async function () {
@@ -738,10 +736,9 @@ describe("IBosonDisputeHandler", function () {
             await pauseHandler.connect(pauser).pause([PausableRegion.Disputes]);
 
             // Attempt to expire a dispute, expecting revert
-            await expect(disputeHandler.connect(rando).expireDispute(exchangeId)).to.revertedWithCustomError(
-              bosonErrors,
-              RevertReasons.REGION_PAUSED
-            );
+            await expect(disputeHandler.connect(rando).expireDispute(exchangeId))
+              .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+              .withArgs(PausableRegion.Disputes);
           });
 
           it("Exchange does not exist", async function () {
@@ -1091,9 +1088,9 @@ describe("IBosonDisputeHandler", function () {
             await pauseHandler.connect(pauser).pause([PausableRegion.Disputes]);
 
             // Attempt to resolve a dispute, expecting revert
-            await expect(
-              disputeHandler.connect(assistant).resolveDispute(exchangeId, buyerPercentBasisPoints, r, s, v)
-            ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+            await expect(disputeHandler.connect(assistant).resolveDispute(exchangeId, buyerPercentBasisPoints, r, s, v))
+              .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+              .withArgs(PausableRegion.Disputes);
           });
 
           it("Specified buyer percent exceeds 100%", async function () {
@@ -1378,7 +1375,9 @@ describe("IBosonDisputeHandler", function () {
             // Attempt to escalate a dispute, expecting revert
             await expect(
               disputeHandler.connect(buyer).escalateDispute(exchangeId, { value: buyerEscalationDepositNative })
-            ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+            )
+              .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+              .withArgs(PausableRegion.Disputes);
           });
 
           it("Exchange does not exist", async function () {
@@ -1626,9 +1625,9 @@ describe("IBosonDisputeHandler", function () {
             await pauseHandler.connect(pauser).pause([PausableRegion.Disputes]);
 
             // Attempt to decide a dispute, expecting revert
-            await expect(
-              disputeHandler.connect(assistantDR).decideDispute(exchangeId, buyerPercentBasisPoints)
-            ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+            await expect(disputeHandler.connect(assistantDR).decideDispute(exchangeId, buyerPercentBasisPoints))
+              .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+              .withArgs(PausableRegion.Disputes);
           });
 
           it("Specified buyer percent exceeds 100%", async function () {
@@ -1786,10 +1785,9 @@ describe("IBosonDisputeHandler", function () {
             await pauseHandler.connect(pauser).pause([PausableRegion.Disputes]);
 
             // Attempt to expire an escalated dispute, expecting revert
-            await expect(disputeHandler.connect(rando).expireEscalatedDispute(exchangeId)).to.revertedWithCustomError(
-              bosonErrors,
-              RevertReasons.REGION_PAUSED
-            );
+            await expect(disputeHandler.connect(rando).expireEscalatedDispute(exchangeId))
+              .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+              .withArgs(PausableRegion.Disputes);
           });
 
           it("Exchange does not exist", async function () {
@@ -1932,9 +1930,9 @@ describe("IBosonDisputeHandler", function () {
             await pauseHandler.connect(pauser).pause([PausableRegion.Disputes]);
 
             // Attempt to refuse an escalated dispute, expecting revert
-            await expect(
-              disputeHandler.connect(assistantDR).refuseEscalatedDispute(exchangeId)
-            ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+            await expect(disputeHandler.connect(assistantDR).refuseEscalatedDispute(exchangeId))
+              .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+              .withArgs(PausableRegion.Disputes);
           });
 
           it("Exchange does not exist", async function () {
@@ -2525,10 +2523,9 @@ describe("IBosonDisputeHandler", function () {
             await pauseHandler.connect(pauser).pause([PausableRegion.Disputes]);
 
             // Attempt to expire a dispute batch, expecting revert
-            await expect(disputeHandler.connect(rando).expireDisputeBatch(disputesToExpire)).to.revertedWithCustomError(
-              bosonErrors,
-              RevertReasons.REGION_PAUSED
-            );
+            await expect(disputeHandler.connect(rando).expireDisputeBatch(disputesToExpire))
+              .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+              .withArgs(PausableRegion.Disputes);
           });
 
           it("Exchange does not exist", async function () {

--- a/test/protocol/DisputeResolverHandlerTest.js
+++ b/test/protocol/DisputeResolverHandlerTest.js
@@ -469,7 +469,9 @@ describe("DisputeResolverHandler", function () {
           // Attempt to create a dispute resolver, expecting revert
           await expect(
             accountHandler.connect(admin).createDisputeResolver(disputeResolver, disputeResolverFees, sellerAllowList)
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.DisputeResolvers);
         });
 
         it("Any address is the zero address", async function () {
@@ -1213,10 +1215,9 @@ describe("DisputeResolverHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.DisputeResolvers]);
 
           // Attempt to update a dispute resolver, expecting revert
-          await expect(accountHandler.connect(admin).updateDisputeResolver(disputeResolver)).to.revertedWithCustomError(
-            bosonErrors,
-            RevertReasons.REGION_PAUSED
-          );
+          await expect(accountHandler.connect(admin).updateDisputeResolver(disputeResolver))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.DisputeResolvers);
         });
 
         it("Dispute resolver does not exist", async function () {
@@ -1469,7 +1470,9 @@ describe("DisputeResolverHandler", function () {
           // Attempt to add dispute resolver fees, expecting revert
           await expect(
             accountHandler.connect(admin).addFeesToDisputeResolver(disputeResolver.id, disputeResolverFeesToAdd)
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.DisputeResolvers);
         });
 
         it("Dispute resolver does not exist", async function () {
@@ -1714,7 +1717,9 @@ describe("DisputeResolverHandler", function () {
           // Attempt to remove dispute resolver fees, expecting revert
           await expect(
             accountHandler.connect(admin).removeFeesFromDisputeResolver(disputeResolver.id, feeTokenAddressesToRemove)
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.DisputeResolvers);
         });
 
         it("Dispute resolver does not exist", async function () {
@@ -1843,9 +1848,9 @@ describe("DisputeResolverHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.DisputeResolvers]);
 
           // Attempt to add sellers to a dispute resolver allow list, expecting revert
-          await expect(
-            accountHandler.connect(admin).addSellersToAllowList(disputeResolver.id, allowedSellersToAdd)
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          await expect(accountHandler.connect(admin).addSellersToAllowList(disputeResolver.id, allowedSellersToAdd))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.DisputeResolvers);
         });
 
         it("Dispute resolver does not exist", async function () {
@@ -2050,7 +2055,9 @@ describe("DisputeResolverHandler", function () {
           // Attempt to remove sellers from a dispute resolver allow list, expecting revert
           await expect(
             accountHandler.connect(admin).removeSellersFromAllowList(disputeResolver.id, allowedSellersToRemove)
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.DisputeResolvers);
         });
 
         it("Dispute resolver does not exist", async function () {
@@ -2325,9 +2332,9 @@ describe("DisputeResolverHandler", function () {
           // Pause the disputeResolvers region of the protocol
           await pauseHandler.connect(pauser).pause([PausableRegion.DisputeResolvers]);
 
-          await expect(
-            accountHandler.connect(rando).optInToDisputeResolverUpdate(disputeResolver.id, [])
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          await expect(accountHandler.connect(rando).optInToDisputeResolverUpdate(disputeResolver.id, []))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.DisputeResolvers);
         });
 
         it("Admin is not unique to this disputeResolver", async function () {

--- a/test/protocol/ExchangeHandlerTest.js
+++ b/test/protocol/ExchangeHandlerTest.js
@@ -805,7 +805,9 @@ describe("IBosonExchangeHandler", function () {
           // Attempt to create an exchange, expecting revert
           await expect(
             exchangeHandler.connect(buyer).commitToOffer(await buyer.getAddress(), offerId, { value: price })
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Exchanges);
         });
 
         it("The buyers region of protocol is paused", async function () {
@@ -815,7 +817,9 @@ describe("IBosonExchangeHandler", function () {
           // Attempt to create a buyer, expecting revert
           await expect(
             exchangeHandler.connect(buyer).commitToOffer(await buyer.getAddress(), offerId, { value: price })
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Buyers);
         });
 
         it("buyer.address is the zero address", async function () {
@@ -1620,7 +1624,9 @@ describe("IBosonExchangeHandler", function () {
             exchangeHandler
               .connect(buyer)
               .commitToConditionalOffer(await buyer.getAddress(), offerId, tokenId, { value: price })
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Exchanges);
         });
 
         it("The buyers region of protocol is paused", async function () {
@@ -1632,7 +1638,9 @@ describe("IBosonExchangeHandler", function () {
             exchangeHandler
               .connect(buyer)
               .commitToConditionalOffer(await buyer.getAddress(), offerId, tokenId, { value: price })
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Buyers);
         });
 
         it("await buyer.getAddress() is the zero address", async function () {
@@ -1865,10 +1873,9 @@ describe("IBosonExchangeHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.Exchanges]);
 
           // Attempt to complete an exchange, expecting revert
-          await expect(exchangeHandler.connect(assistant).completeExchange(exchangeId)).to.revertedWithCustomError(
-            bosonErrors,
-            RevertReasons.REGION_PAUSED
-          );
+          await expect(exchangeHandler.connect(assistant).completeExchange(exchangeId))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Exchanges);
         });
 
         it("exchange id is invalid", async function () {
@@ -2077,9 +2084,9 @@ describe("IBosonExchangeHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.Exchanges]);
 
           // Attempt to complete an exchange, expecting revert
-          await expect(
-            exchangeHandler.connect(buyer).completeExchangeBatch(exchangesToComplete)
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          await expect(exchangeHandler.connect(buyer).completeExchangeBatch(exchangesToComplete))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Exchanges);
         });
 
         it("exchange id is invalid", async function () {
@@ -2211,10 +2218,9 @@ describe("IBosonExchangeHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.Exchanges]);
 
           // Attempt to complete an exchange, expecting revert
-          await expect(exchangeHandler.connect(assistant).revokeVoucher(exchange.id)).to.revertedWithCustomError(
-            bosonErrors,
-            RevertReasons.REGION_PAUSED
-          );
+          await expect(exchangeHandler.connect(assistant).revokeVoucher(exchange.id))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Exchanges);
         });
 
         it("exchange id is invalid", async function () {
@@ -2330,10 +2336,9 @@ describe("IBosonExchangeHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.Exchanges]);
 
           // Attempt to complete an exchange, expecting revert
-          await expect(exchangeHandler.connect(buyer).cancelVoucher(exchange.id)).to.revertedWithCustomError(
-            bosonErrors,
-            RevertReasons.REGION_PAUSED
-          );
+          await expect(exchangeHandler.connect(buyer).cancelVoucher(exchange.id))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Exchanges);
         });
 
         it("exchange id is invalid", async function () {
@@ -2454,10 +2459,9 @@ describe("IBosonExchangeHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.Exchanges]);
 
           // Attempt to complete an exchange, expecting revert
-          await expect(exchangeHandler.connect(buyer).expireVoucher(exchangeId)).to.revertedWithCustomError(
-            bosonErrors,
-            RevertReasons.REGION_PAUSED
-          );
+          await expect(exchangeHandler.connect(buyer).expireVoucher(exchangeId))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Exchanges);
         });
 
         it("exchange id is invalid", async function () {
@@ -2611,10 +2615,9 @@ describe("IBosonExchangeHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.Exchanges]);
 
           // Attempt to complete an exchange, expecting revert
-          await expect(exchangeHandler.connect(buyer).redeemVoucher(exchangeId)).to.revertedWithCustomError(
-            bosonErrors,
-            RevertReasons.REGION_PAUSED
-          );
+          await expect(exchangeHandler.connect(buyer).redeemVoucher(exchangeId))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Exchanges);
         });
 
         it("exchange id is invalid", async function () {
@@ -5054,9 +5057,9 @@ describe("IBosonExchangeHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.Exchanges]);
 
           // Attempt to complete an exchange, expecting revert
-          await expect(
-            exchangeHandler.connect(assistant).extendVoucher(exchange.id, validUntilDate)
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          await expect(exchangeHandler.connect(assistant).extendVoucher(exchange.id, validUntilDate))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Exchanges);
         });
 
         it("exchange id is invalid", async function () {
@@ -5265,7 +5268,9 @@ describe("IBosonExchangeHandler", function () {
             bosonVoucherClone
               .connect(buyer)
               .transferFrom(await buyer.getAddress(), await newOwner.getAddress(), tokenId)
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Buyers);
         });
 
         it("Caller is not a clone address", async function () {
@@ -5798,7 +5803,9 @@ describe("IBosonExchangeHandler", function () {
             bosonVoucher
               .connect(assistant)
               .transferFrom(await assistant.getAddress(), await buyer.getAddress(), tokenId)
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Exchanges);
         });
 
         it("The buyers region of protocol is paused", async function () {
@@ -5810,7 +5817,9 @@ describe("IBosonExchangeHandler", function () {
             bosonVoucher
               .connect(assistant)
               .transferFrom(await assistant.getAddress(), await buyer.getAddress(), tokenId)
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Buyers);
         });
 
         it("Caller is not the voucher contract, owned by the seller", async function () {

--- a/test/protocol/ExchangeHandlerTest.js
+++ b/test/protocol/ExchangeHandlerTest.js
@@ -797,6 +797,26 @@ describe("IBosonExchangeHandler", function () {
         expect(await additionalCollection.ownerOf(tokenId)).to.equal(buyer.address, "Wrong buyer address");
       });
 
+      it("It is possible to commit to fixed offer if price discovery region is paused", async function () {
+        // Pause the price discovery region of the protocol
+        await pauseHandler.connect(pauser).pause([PausableRegion.PriceDiscovery]);
+
+        // Commit to offer, retrieving the event
+        await expect(
+          exchangeHandler.connect(buyer).commitToOffer(await buyer.getAddress(), offerId, { value: price })
+        ).to.emit(exchangeHandler, "BuyerCommitted");
+      });
+
+      it("It is possible to commit to fixed offer if sequential commit region is paused", async function () {
+        // Pause the sequential commit region of the protocol
+        await pauseHandler.connect(pauser).pause([PausableRegion.SequentialCommit]);
+
+        // Commit to offer, retrieving the event
+        await expect(
+          exchangeHandler.connect(buyer).commitToOffer(await buyer.getAddress(), offerId, { value: price })
+        ).to.emit(exchangeHandler, "BuyerCommitted");
+      });
+
       context("💔 Revert Reasons", async function () {
         it("The exchanges region of protocol is paused", async function () {
           // Pause the exchanges region of the protocol

--- a/test/protocol/FundsHandlerTest.js
+++ b/test/protocol/FundsHandlerTest.js
@@ -339,7 +339,9 @@ describe("IBosonFundsHandler", function () {
           // Attempt to deposit funds, expecting revert
           await expect(
             fundsHandler.connect(assistant).depositFunds(seller.id, await mockToken.getAddress(), depositAmount)
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Funds);
         });
 
         it("Amount to deposit is zero", async function () {
@@ -885,9 +887,9 @@ describe("IBosonFundsHandler", function () {
               await pauseHandler.connect(pauser).pause([PausableRegion.Funds]);
 
               // Attempt to withdraw funds, expecting revert
-              await expect(
-                fundsHandler.connect(buyer).withdrawFunds(buyerId, tokenListBuyer, tokenAmountsBuyer)
-              ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+              await expect(fundsHandler.connect(buyer).withdrawFunds(buyerId, tokenListBuyer, tokenAmountsBuyer))
+                .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+                .withArgs(PausableRegion.Funds);
             });
 
             it("Caller is not authorized to withdraw", async function () {
@@ -1481,9 +1483,9 @@ describe("IBosonFundsHandler", function () {
             await pauseHandler.connect(pauser).pause([PausableRegion.Funds]);
 
             // Attempt to withdraw funds, expecting revert
-            await expect(
-              fundsHandler.connect(feeCollector).withdrawProtocolFees(tokenList, tokenAmounts)
-            ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+            await expect(fundsHandler.connect(feeCollector).withdrawProtocolFees(tokenList, tokenAmounts))
+              .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+              .withArgs(PausableRegion.Funds);
           });
 
           it("Caller is not authorized to withdraw", async function () {

--- a/test/protocol/GroupHandlerTest.js
+++ b/test/protocol/GroupHandlerTest.js
@@ -302,10 +302,9 @@ describe("IBosonGroupHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.Groups]);
 
           // Attempt to create a group expecting revert
-          await expect(groupHandler.connect(assistant).createGroup(group, condition)).to.revertedWithCustomError(
-            bosonErrors,
-            RevertReasons.REGION_PAUSED
-          );
+          await expect(groupHandler.connect(assistant).createGroup(group, condition))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Groups);
         });
 
         it("Caller not assistant of any seller", async function () {
@@ -689,9 +688,9 @@ describe("IBosonGroupHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.Groups]);
 
           // Attempt to add offers to a group, expecting revert
-          await expect(
-            groupHandler.connect(assistant).addOffersToGroup(group.id, offerIdsToAdd)
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          await expect(groupHandler.connect(assistant).addOffersToGroup(group.id, offerIdsToAdd))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Groups);
         });
 
         it("Group does not exist", async function () {
@@ -885,9 +884,9 @@ describe("IBosonGroupHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.Groups]);
 
           // Attempt to remove offers to a group, expecting revert
-          await expect(
-            groupHandler.connect(assistant).removeOffersFromGroup(group.id, offerIdsToRemove)
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          await expect(groupHandler.connect(assistant).removeOffersFromGroup(group.id, offerIdsToRemove))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Groups);
         });
 
         it("Group does not exist", async function () {
@@ -1004,9 +1003,9 @@ describe("IBosonGroupHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.Groups]);
 
           // Attempt to set group condition, expecting revert
-          await expect(
-            groupHandler.connect(assistant).setGroupCondition(group.id, condition)
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          await expect(groupHandler.connect(assistant).setGroupCondition(group.id, condition))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Groups);
         });
 
         it("Group does not exist", async function () {

--- a/test/protocol/MetaTransactionsHandlerTest.js
+++ b/test/protocol/MetaTransactionsHandlerTest.js
@@ -811,7 +811,9 @@ describe("IBosonMetaTransactionsHandler", function () {
                   s,
                   v
                 )
-            ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+            )
+              .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+              .withArgs(PausableRegion.MetaTransaction);
           });
 
           it("Should fail when function name is not allowlisted", async function () {

--- a/test/protocol/OfferHandlerTest.js
+++ b/test/protocol/OfferHandlerTest.js
@@ -697,7 +697,9 @@ describe("IBosonOfferHandler", function () {
             offerHandler
               .connect(assistant)
               .createOffer(offer, offerDates, offerDurations, disputeResolver.id, agentId, offerFeeLimit)
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Offers);
         });
 
         it("Caller not assistant of any seller", async function () {
@@ -1296,10 +1298,9 @@ describe("IBosonOfferHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.Offers]);
 
           // Attempt to void an offer expecting revert
-          await expect(offerHandler.connect(assistant).voidOffer(id)).to.revertedWithCustomError(
-            bosonErrors,
-            RevertReasons.REGION_PAUSED
-          );
+          await expect(offerHandler.connect(assistant).voidOffer(id))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Offers);
         });
 
         it("Offer does not exist", async function () {
@@ -1409,9 +1410,9 @@ describe("IBosonOfferHandler", function () {
             await pauseHandler.connect(pauser).pause([PausableRegion.Offers]);
 
             // Attempt to extend an offer expecting revert
-            await expect(
-              offerHandler.connect(assistant).extendOffer(offer.id, offerDates.validUntil)
-            ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+            await expect(offerHandler.connect(assistant).extendOffer(offer.id, offerDates.validUntil))
+              .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+              .withArgs(PausableRegion.Offers);
           });
 
           it("Offer does not exist", async function () {
@@ -1615,9 +1616,9 @@ describe("IBosonOfferHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.Offers]);
 
           // Attempt to update the offer expecting revert
-          await expect(
-            offerHandler.connect(assistant).updateOfferRoyaltyRecipients(offer.id, newRoyaltyInfo)
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          await expect(offerHandler.connect(assistant).updateOfferRoyaltyRecipients(offer.id, newRoyaltyInfo))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Offers);
         });
 
         it("Offer does not exist", async function () {
@@ -1898,9 +1899,9 @@ describe("IBosonOfferHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.Offers]);
 
           // Attempt to reserve a range, expecting revert
-          await expect(
-            offerHandler.connect(assistant).reserveRange(id, length, await assistant.getAddress())
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          await expect(offerHandler.connect(assistant).reserveRange(id, length, await assistant.getAddress()))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Offers);
         });
 
         it("The exchanges region of protocol is paused", async function () {
@@ -1908,9 +1909,9 @@ describe("IBosonOfferHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.Exchanges]);
 
           // Attempt to reserve a range, expecting revert
-          await expect(
-            offerHandler.connect(assistant).reserveRange(id, length, await assistant.getAddress())
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          await expect(offerHandler.connect(assistant).reserveRange(id, length, await assistant.getAddress()))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Exchanges);
         });
 
         it("Offer does not exist", async function () {
@@ -2689,7 +2690,9 @@ describe("IBosonOfferHandler", function () {
                 agentIds,
                 offerFeeLimits
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Offers);
         });
 
         it("Caller not assistant of any seller", async function () {
@@ -3684,10 +3687,9 @@ describe("IBosonOfferHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.Offers]);
 
           // Attempt to void offer batch, expecting revert
-          await expect(offerHandler.connect(assistant).voidOfferBatch(offersToVoid)).to.revertedWithCustomError(
-            bosonErrors,
-            RevertReasons.REGION_PAUSED
-          );
+          await expect(offerHandler.connect(assistant).voidOfferBatch(offersToVoid))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Offers);
         });
 
         it("Offer does not exist", async function () {
@@ -3817,9 +3819,9 @@ describe("IBosonOfferHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.Offers]);
 
           // Attempt to extend offer batch, expecting revert
-          await expect(
-            offerHandler.connect(assistant).extendOfferBatch(offersToExtend, newValidUntilDate)
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          await expect(offerHandler.connect(assistant).extendOfferBatch(offersToExtend, newValidUntilDate))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Offers);
         });
 
         it("Offer does not exist", async function () {
@@ -3991,7 +3993,9 @@ describe("IBosonOfferHandler", function () {
           // Attempt to update offer batch, expecting revert
           await expect(
             offerHandler.connect(assistant).updateOfferRoyaltyRecipientsBatch(offersToUpdate, newRoyaltyInfo)
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Offers);
         });
 
         it("Offer does not exist", async function () {

--- a/test/protocol/OrchestrationHandlerTest.js
+++ b/test/protocol/OrchestrationHandlerTest.js
@@ -513,7 +513,9 @@ describe("IBosonOrchestrationHandler", function () {
             orchestrationHandler
               .connect(buyer)
               .raiseAndEscalateDispute(exchangeId, { value: buyerEscalationDepositNative })
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Orchestration);
         });
 
         it("The disputes region of protocol is paused", async function () {
@@ -525,7 +527,9 @@ describe("IBosonOrchestrationHandler", function () {
             orchestrationHandler
               .connect(buyer)
               .raiseAndEscalateDispute(exchangeId, { value: buyerEscalationDepositNative })
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Disputes);
         });
 
         it("Caller is not the buyer for the given exchange id", async function () {
@@ -1529,7 +1533,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Orchestration);
         });
 
         it("The sellers region of protocol is paused", async function () {
@@ -1551,7 +1557,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Sellers);
         });
 
         it("The offers region of protocol is paused", async function () {
@@ -1573,7 +1581,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Offers);
         });
 
         it("The exchanges region of protocol is paused [preminted offers]", async function () {
@@ -1598,7 +1608,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Exchanges);
         });
 
         it("active is false", async function () {
@@ -3190,7 +3202,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Orchestration);
         });
 
         it("The offers region of protocol is paused", async function () {
@@ -3210,7 +3224,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Offers);
         });
 
         it("The exchanges region of protocol is paused [preminted offers]", async function () {
@@ -3238,7 +3254,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Exchanges);
         });
 
         it("The groups region of protocol is paused", async function () {
@@ -3258,7 +3276,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Offers);
         });
 
         it("Caller not assistant of any seller", async function () {
@@ -4150,7 +4170,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Orchestration);
         });
 
         it("The offers region of protocol is paused", async function () {
@@ -4170,7 +4192,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Offers);
         });
 
         it("The exchanges region of protocol is paused [preminted offers]", async function () {
@@ -4193,7 +4217,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Exchanges);
         });
 
         it("The groups region of protocol is paused", async function () {
@@ -4213,7 +4239,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Groups);
         });
 
         it("Group does not exist", async function () {
@@ -5035,7 +5063,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Orchestration);
         });
 
         it("The offers region of protocol is paused", async function () {
@@ -5055,7 +5085,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Offers);
         });
 
         it("The bundles region of protocol is paused", async function () {
@@ -5075,7 +5107,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Bundles);
         });
 
         it("The twins region of protocol is paused", async function () {
@@ -5095,7 +5129,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Twins);
         });
 
         it("The exchanges region of protocol is paused [preminted offers]", async function () {
@@ -5123,7 +5159,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Exchanges);
         });
 
         it("should revert if protocol is not approved to transfer the ERC20 token", async function () {
@@ -6134,7 +6172,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Orchestration);
         });
 
         it("The offers region of protocol is paused", async function () {
@@ -6155,7 +6195,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Offers);
         });
 
         it("The groups region of protocol is paused", async function () {
@@ -6176,7 +6218,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Groups);
         });
 
         it("The bundles region of protocol is paused", async function () {
@@ -6197,7 +6241,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Bundles);
         });
 
         it("The twins region of protocol is paused", async function () {
@@ -6218,7 +6264,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Twins);
         });
 
         it("The exchanges region of protocol is paused [preminted offers]", async function () {
@@ -6242,7 +6290,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Exchanges);
         });
       });
     });
@@ -6988,7 +7038,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Orchestration);
         });
 
         it("The sellers region of protocol is paused", async function () {
@@ -7011,7 +7063,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Sellers);
         });
 
         it("The offers region of protocol is paused", async function () {
@@ -7034,7 +7088,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Offers);
         });
 
         it("The groups region of protocol is paused", async function () {
@@ -7057,7 +7113,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Groups);
         });
 
         it("The exchanges region of protocol is paused [preminted offers]", async function () {
@@ -7083,7 +7141,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Exchanges);
         });
       });
     });
@@ -7933,7 +7993,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Orchestration);
         });
 
         it("The sellers region of protocol is paused", async function () {
@@ -7956,7 +8018,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Sellers);
         });
 
         it("The offers region of protocol is paused", async function () {
@@ -7979,7 +8043,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Offers);
         });
 
         it("The bundles region of protocol is paused", async function () {
@@ -8002,7 +8068,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Bundles);
         });
 
         it("The twins region of protocol is paused", async function () {
@@ -8025,7 +8093,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Twins);
         });
 
         it("The exchanges region of protocol is paused [preminted offers]", async function () {
@@ -8054,7 +8124,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Exchanges);
         });
       });
     });
@@ -9015,7 +9087,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Orchestration);
         });
 
         it("The sellers region of protocol is paused", async function () {
@@ -9039,7 +9113,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Sellers);
         });
 
         it("The offers region of protocol is paused", async function () {
@@ -9063,7 +9139,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Offers);
         });
 
         it("The groups region of protocol is paused", async function () {
@@ -9087,7 +9165,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Groups);
         });
 
         it("The twins region of protocol is paused", async function () {
@@ -9111,7 +9191,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Twins);
         });
 
         it("The bundles region of protocol is paused", async function () {
@@ -9135,7 +9217,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Bundles);
         });
 
         it("The exchanges region of protocol is paused [preminted offers]", async function () {
@@ -9165,7 +9249,9 @@ describe("IBosonOrchestrationHandler", function () {
                 agentId,
                 offerFeeLimit
               )
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          )
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Exchanges);
         });
       });
     });

--- a/test/protocol/PriceDiscoveryHandlerFacet.js
+++ b/test/protocol/PriceDiscoveryHandlerFacet.js
@@ -482,6 +482,18 @@ describe("IPriceDiscoveryHandlerFacet", function () {
             .withArgs(offerId, newBuyer.id, exchangeId, exchange.toStruct(), voucher.toStruct(), expectedCloneAddress);
         });
 
+        it("It is possible to commit to price discovery offer if sequential commit region is paused", async function () {
+          // Pause the sequential commit region of the protocol
+          await pauseHandler.connect(pauser).pause([PausableRegion.SequentialCommit]);
+
+          // Commit to offer
+          await expect(
+            priceDiscoveryHandler
+              .connect(buyer)
+              .commitToPriceDiscoveryOffer(buyer.address, tokenId, priceDiscovery, { value: price })
+          ).to.emit(priceDiscoveryHandler, "BuyerCommitted");
+        });
+
         context("💔 Revert Reasons", async function () {
           it("The exchanges region of protocol is paused", async function () {
             // Pause the exchanges region of the protocol
@@ -915,6 +927,16 @@ describe("IPriceDiscoveryHandlerFacet", function () {
           const [, { quantityAvailable: quantityAvailableAfter }] = await offerHandler.connect(rando).getOffer(offerId);
 
           expect(quantityAvailableAfter).to.equal(quantityAvailableBefore, "Quantity available should be the same");
+        });
+
+        it("It is possible to commit to price discovery offer if sequential commit region is paused", async function () {
+          // Pause the sequential commit region of the protocol
+          await pauseHandler.connect(pauser).pause([PausableRegion.SequentialCommit]);
+
+          // Commit to offer
+          await expect(
+            priceDiscoveryHandler.connect(assistant).commitToPriceDiscoveryOffer(buyer.address, tokenId, priceDiscovery)
+          ).to.emit(priceDiscoveryHandler, "BuyerCommitted");
         });
 
         context("💔 Revert Reasons", async function () {

--- a/test/protocol/PriceDiscoveryHandlerFacet.js
+++ b/test/protocol/PriceDiscoveryHandlerFacet.js
@@ -492,7 +492,9 @@ describe("IPriceDiscoveryHandlerFacet", function () {
               priceDiscoveryHandler
                 .connect(buyer)
                 .commitToPriceDiscoveryOffer(buyer.address, tokenId, priceDiscovery, { value: price })
-            ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+            )
+              .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+              .withArgs(PausableRegion.Exchanges);
           });
 
           it("The buyers region of protocol is paused", async function () {
@@ -504,7 +506,9 @@ describe("IPriceDiscoveryHandlerFacet", function () {
               priceDiscoveryHandler
                 .connect(buyer)
                 .commitToPriceDiscoveryOffer(buyer.address, tokenId, priceDiscovery, { value: price })
-            ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+            )
+              .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+              .withArgs(PausableRegion.Buyers);
           });
 
           it("The price discovery region of protocol is paused", async function () {
@@ -923,7 +927,9 @@ describe("IPriceDiscoveryHandlerFacet", function () {
               priceDiscoveryHandler
                 .connect(assistant)
                 .commitToPriceDiscoveryOffer(buyer.address, tokenId, priceDiscovery)
-            ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+            )
+              .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+              .withArgs(PausableRegion.Exchanges);
           });
 
           it("The buyers region of protocol is paused", async function () {
@@ -935,7 +941,9 @@ describe("IPriceDiscoveryHandlerFacet", function () {
               priceDiscoveryHandler
                 .connect(assistant)
                 .commitToPriceDiscoveryOffer(buyer.address, tokenId, priceDiscovery)
-            ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+            )
+              .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+              .withArgs(PausableRegion.Buyers);
           });
 
           it("The price discovery region of protocol is paused", async function () {

--- a/test/protocol/PriceDiscoveryHandlerFacet.js
+++ b/test/protocol/PriceDiscoveryHandlerFacet.js
@@ -507,6 +507,20 @@ describe("IPriceDiscoveryHandlerFacet", function () {
             ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
           });
 
+          it("The price discovery region of protocol is paused", async function () {
+            // Pause the price discovery region of the protocol
+            await pauseHandler.connect(pauser).pause([PausableRegion.PriceDiscovery]);
+
+            // Attempt to sequentially commit, expecting revert
+            await expect(
+              priceDiscoveryHandler
+                .connect(buyer)
+                .commitToPriceDiscoveryOffer(buyer.address, tokenId, priceDiscovery, { value: price })
+            )
+              .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+              .withArgs(PausableRegion.PriceDiscovery);
+          });
+
           it("buyer address is the zero address", async function () {
             // Attempt to commit, expecting revert
             await expect(
@@ -922,6 +936,20 @@ describe("IPriceDiscoveryHandlerFacet", function () {
                 .connect(assistant)
                 .commitToPriceDiscoveryOffer(buyer.address, tokenId, priceDiscovery)
             ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          });
+
+          it("The price discovery region of protocol is paused", async function () {
+            // Pause the price discovery region of the protocol
+            await pauseHandler.connect(pauser).pause([PausableRegion.PriceDiscovery]);
+
+            // Attempt to sequentially commit, expecting revert
+            await expect(
+              priceDiscoveryHandler
+                .connect(assistant)
+                .commitToPriceDiscoveryOffer(buyer.address, tokenId, priceDiscovery)
+            )
+              .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+              .withArgs(PausableRegion.PriceDiscovery);
           });
 
           it("buyer address is the zero address", async function () {

--- a/test/protocol/SellerHandlerTest.js
+++ b/test/protocol/SellerHandlerTest.js
@@ -728,9 +728,9 @@ describe("SellerHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.Sellers]);
 
           // Attempt to create a seller expecting revert
-          await expect(
-            accountHandler.connect(assistant).createSeller(seller, emptyAuthToken, voucherInitValues)
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          await expect(accountHandler.connect(assistant).createSeller(seller, emptyAuthToken, voucherInitValues))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Sellers);
         });
 
         it("active is false", async function () {
@@ -2302,10 +2302,9 @@ describe("SellerHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.Sellers]);
 
           // Attempt to update a seller expecting revert
-          await expect(accountHandler.connect(admin).updateSeller(seller, emptyAuthToken)).to.revertedWithCustomError(
-            bosonErrors,
-            RevertReasons.REGION_PAUSED
-          );
+          await expect(accountHandler.connect(admin).updateSeller(seller, emptyAuthToken))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Sellers);
         });
 
         it("Seller does not exist", async function () {
@@ -2980,10 +2979,9 @@ describe("SellerHandler", function () {
           // Pause the sellers region of the protocol
           await pauseHandler.connect(pauser).pause([PausableRegion.Sellers]);
 
-          await expect(accountHandler.connect(rando).optInToSellerUpdate(seller.id, [])).to.revertedWithCustomError(
-            bosonErrors,
-            RevertReasons.REGION_PAUSED
-          );
+          await expect(accountHandler.connect(rando).optInToSellerUpdate(seller.id, []))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Sellers);
         });
 
         it("Admin is not unique to this seller", async function () {
@@ -3265,9 +3263,9 @@ describe("SellerHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.Sellers]);
 
           // Attempt to create a new collection expecting revert
-          await expect(
-            accountHandler.connect(assistant).createNewCollection(externalId, voucherInitValues)
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          await expect(accountHandler.connect(assistant).createNewCollection(externalId, voucherInitValues))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Sellers);
         });
 
         it("Caller is not anyone's assistant", async function () {
@@ -3600,9 +3598,9 @@ describe("SellerHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.Sellers]);
 
           // Attempt to update the salt, expecting revert
-          await expect(
-            accountHandler.connect(admin).updateSellerSalt(seller.id, newSellerSalt)
-          ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+          await expect(accountHandler.connect(admin).updateSellerSalt(seller.id, newSellerSalt))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Sellers);
         });
 
         it("Caller is not anyone's admin", async function () {
@@ -3988,9 +3986,9 @@ describe("SellerHandler", function () {
             await pauseHandler.connect(pauser).pause([PausableRegion.Sellers]);
 
             // Attempt to add royalty recipients expecting revert
-            await expect(
-              accountHandler.connect(admin).addRoyaltyRecipients(seller.id, royaltyRecipientInfoListStruct)
-            ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+            await expect(accountHandler.connect(admin).addRoyaltyRecipients(seller.id, royaltyRecipientInfoListStruct))
+              .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+              .withArgs(PausableRegion.Sellers);
           });
 
           it("seller does not exist", async function () {
@@ -4135,7 +4133,9 @@ describe("SellerHandler", function () {
               accountHandler
                 .connect(admin)
                 .updateRoyaltyRecipients(seller.id, royaltyRecipientInfoIds, royaltyRecipientInfoListUpdates.toStruct())
-            ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+            )
+              .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+              .withArgs(PausableRegion.Sellers);
           });
 
           it("seller does not exist", async function () {
@@ -4334,9 +4334,9 @@ describe("SellerHandler", function () {
             await pauseHandler.connect(pauser).pause([PausableRegion.Sellers]);
 
             // Attempt to remove royalty recipients expecting revert
-            await expect(
-              accountHandler.connect(admin).removeRoyaltyRecipients(seller.id, royaltyRecipientInfoIds)
-            ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+            await expect(accountHandler.connect(admin).removeRoyaltyRecipients(seller.id, royaltyRecipientInfoIds))
+              .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+              .withArgs(PausableRegion.Sellers);
           });
 
           it("seller does not exist", async function () {

--- a/test/protocol/SequentialCommitHandlerTest.js
+++ b/test/protocol/SequentialCommitHandlerTest.js
@@ -580,7 +580,9 @@ describe("IBosonSequentialCommitHandler", function () {
                 sequentialCommitHandler
                   .connect(buyer2)
                   .sequentialCommitToOffer(buyer2.address, tokenId, priceDiscovery, { value: price2 })
-              ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+              )
+                .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+                .withArgs(PausableRegion.Exchanges);
             });
 
             it("The buyers region of protocol is paused", async function () {
@@ -592,7 +594,9 @@ describe("IBosonSequentialCommitHandler", function () {
                 sequentialCommitHandler
                   .connect(buyer2)
                   .sequentialCommitToOffer(buyer2.address, tokenId, priceDiscovery, { value: price2 })
-              ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+              )
+                .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+                .withArgs(PausableRegion.Buyers);
             });
 
             it("The sequential region of protocol is paused", async function () {
@@ -1244,7 +1248,9 @@ describe("IBosonSequentialCommitHandler", function () {
                 sequentialCommitHandler
                   .connect(reseller)
                   .sequentialCommitToOffer(buyer2.address, tokenId, priceDiscovery)
-              ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+              )
+                .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+                .withArgs(PausableRegion.Exchanges);
             });
 
             it("The buyers region of protocol is paused", async function () {
@@ -1256,7 +1262,9 @@ describe("IBosonSequentialCommitHandler", function () {
                 sequentialCommitHandler
                   .connect(reseller)
                   .sequentialCommitToOffer(buyer2.address, tokenId, priceDiscovery)
-              ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+              )
+                .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+                .withArgs(PausableRegion.Buyers);
             });
 
             it("The sequential region of protocol is paused", async function () {

--- a/test/protocol/SequentialCommitHandlerTest.js
+++ b/test/protocol/SequentialCommitHandlerTest.js
@@ -595,6 +595,34 @@ describe("IBosonSequentialCommitHandler", function () {
               ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
             });
 
+            it("The sequential region of protocol is paused", async function () {
+              // Pause the sequential commit region of the protocol
+              await pauseHandler.connect(pauser).pause([PausableRegion.SequentialCommit]);
+
+              // Attempt to sequentially commit, expecting revert
+              await expect(
+                sequentialCommitHandler
+                  .connect(buyer2)
+                  .sequentialCommitToOffer(buyer2.address, tokenId, priceDiscovery, { value: price2 })
+              )
+                .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+                .withArgs(PausableRegion.SequentialCommit);
+            });
+
+            it("The price discovery region of protocol is paused", async function () {
+              // Pause the price discovery region of the protocol
+              await pauseHandler.connect(pauser).pause([PausableRegion.PriceDiscovery]);
+
+              // Attempt to sequentially commit, expecting revert
+              await expect(
+                sequentialCommitHandler
+                  .connect(buyer2)
+                  .sequentialCommitToOffer(buyer2.address, tokenId, priceDiscovery, { value: price2 })
+              )
+                .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+                .withArgs(PausableRegion.PriceDiscovery);
+            });
+
             it("buyer address is the zero address", async function () {
               // Attempt to sequentially commit, expecting revert
               await expect(
@@ -1229,6 +1257,34 @@ describe("IBosonSequentialCommitHandler", function () {
                   .connect(reseller)
                   .sequentialCommitToOffer(buyer2.address, tokenId, priceDiscovery)
               ).to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED);
+            });
+
+            it("The sequential region of protocol is paused", async function () {
+              // Pause the sequential commit region of the protocol
+              await pauseHandler.connect(pauser).pause([PausableRegion.SequentialCommit]);
+
+              // Attempt to sequentially commit, expecting revert
+              await expect(
+                sequentialCommitHandler
+                  .connect(buyer2)
+                  .sequentialCommitToOffer(buyer2.address, tokenId, priceDiscovery, { value: price2 })
+              )
+                .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+                .withArgs(PausableRegion.SequentialCommit);
+            });
+
+            it("The price discovery region of protocol is paused", async function () {
+              // Pause the price discovery region of the protocol
+              await pauseHandler.connect(pauser).pause([PausableRegion.PriceDiscovery]);
+
+              // Attempt to sequentially commit, expecting revert
+              await expect(
+                sequentialCommitHandler
+                  .connect(reseller)
+                  .sequentialCommitToOffer(buyer2.address, tokenId, priceDiscovery)
+              )
+                .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+                .withArgs(PausableRegion.PriceDiscovery);
             });
 
             it("buyer address is the zero address", async function () {

--- a/test/protocol/TwinHandlerTest.js
+++ b/test/protocol/TwinHandlerTest.js
@@ -346,10 +346,9 @@ describe("IBosonTwinHandler", function () {
           await pauseHandler.connect(pauser).pause([PausableRegion.Twins]);
 
           // Attempt to Remove a twin, expecting revert
-          await expect(twinHandler.connect(assistant).createTwin(twin)).to.revertedWithCustomError(
-            bosonErrors,
-            RevertReasons.REGION_PAUSED
-          );
+          await expect(twinHandler.connect(assistant).createTwin(twin))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Twins);
         });
 
         it("Caller not assistant of any seller", async function () {
@@ -746,15 +745,12 @@ describe("IBosonTwinHandler", function () {
       context("💔 Revert Reasons", async function () {
         it("The twins region of protocol is paused", async function () {
           // Pause the twins region of the protocol
-          await pauseHandler
-            .connect(pauser)
-            .pause([PausableRegion.Offers, PausableRegion.Twins, PausableRegion.Bundles]);
+          await pauseHandler.connect(pauser).pause([PausableRegion.Twins]);
 
           // Attempt to Remove a twin, expecting revert
-          await expect(twinHandler.connect(assistant).removeTwin(twin.id)).to.revertedWithCustomError(
-            bosonErrors,
-            RevertReasons.REGION_PAUSED
-          );
+          await expect(twinHandler.connect(assistant).removeTwin(twin.id))
+            .to.revertedWithCustomError(bosonErrors, RevertReasons.REGION_PAUSED)
+            .withArgs(PausableRegion.Twins);
         });
 
         it("Twin does not exist", async function () {


### PR DESCRIPTION
Fix #903 

Adds two new pausable regions and changes the `RegionPaused()` error to include the region that reverted.