### PR TITLE
Price discovery ask flow update

### DIFF
--- a/contracts/interfaces/clients/IBosonPriceDiscovery.sol
+++ b/contracts/interfaces/clients/IBosonPriceDiscovery.sol
@@ -32,7 +32,7 @@ interface IBosonPriceDiscovery is IERC721Receiver {
         BosonTypes.PriceDiscovery calldata _priceDiscovery,
         IBosonVoucher _bosonVoucher,
         address payable _msgSender
-    ) external payable returns (uint256 actualPrice);
+    ) external returns (uint256 actualPrice);
 
     /**
      * @notice Fulfils a bid order on external contract.

--- a/contracts/interfaces/clients/IBosonPriceDiscovery.sol
+++ b/contracts/interfaces/clients/IBosonPriceDiscovery.sol
@@ -32,7 +32,7 @@ interface IBosonPriceDiscovery is IERC721Receiver {
         BosonTypes.PriceDiscovery calldata _priceDiscovery,
         IBosonVoucher _bosonVoucher,
         address payable _msgSender
-    ) external returns (uint256 actualPrice);
+    ) external payable returns (uint256 actualPrice);
 
     /**
      * @notice Fulfils a bid order on external contract.

--- a/contracts/mock/PriceDiscovery.sol
+++ b/contracts/mock/PriceDiscovery.sol
@@ -217,6 +217,9 @@ contract PriceDiscoveryTransferElsewhere is PriceDiscoveryMock, IERC721Receiver 
      * @dev invoke fulfilBuyOrder on itself, making it the msg.sender
      */
     function fulfilBuyOrderElsewhere(Order memory _order) public payable {
+        if (_order.exchangeToken != address(0)) {
+            IERC20(_order.exchangeToken).transferFrom(msg.sender, address(this), _order.price);
+        }
         this.fulfilBuyOrder(_order);
     }
 

--- a/contracts/protocol/bases/PriceDiscoveryBase.sol
+++ b/contracts/protocol/bases/PriceDiscoveryBase.sol
@@ -126,7 +126,7 @@ contract PriceDiscoveryBase is ProtocolBase {
         FundsLib.validateIncomingPayment(_exchangeToken, _priceDiscovery.price);
         FundsLib.transferFundsFromProtocol(_exchangeToken, payable(bosonPriceDiscovery), _priceDiscovery.price);
 
-        actualPrice = IBosonPriceDiscovery(bosonPriceDiscovery).fulfilAskOrder{ value: msg.value }(
+        actualPrice = IBosonPriceDiscovery(bosonPriceDiscovery).fulfilAskOrder(
             _exchangeToken,
             _priceDiscovery,
             _bosonVoucher,

--- a/contracts/protocol/clients/priceDiscovery/BosonPriceDiscovery.sol
+++ b/contracts/protocol/clients/priceDiscovery/BosonPriceDiscovery.sol
@@ -61,23 +61,23 @@ contract BosonPriceDiscovery is ERC165, IBosonPriceDiscovery, BosonErrors {
         BosonTypes.PriceDiscovery calldata _priceDiscovery,
         IBosonVoucher _bosonVoucher,
         address payable _msgSender
-    ) external payable onlyProtocol returns (uint256 actualPrice) {
+    ) external onlyProtocol returns (uint256 actualPrice) {
         // Boson protocol (the caller) is trusted, so it can be assumed that all funds were forwarded to this contract
         // If token is ERC20, approve price discovery contract to transfer the funds
         if (_exchangeToken != address(0) && _priceDiscovery.price > 0) {
             IERC20(_exchangeToken).forceApprove(_priceDiscovery.conduit, _priceDiscovery.price);
         }
 
-        // Track native balance just in case if the buyer sends some native currency or price discovery contract does
+        // Track native balance just in case if the price discovery sends some native currency
         // This is the balance that protocol had, before commit to offer was called
-        uint256 thisNativeBalanceBefore = getBalance(address(0)) - msg.value;
+        uint256 thisNativeBalanceBefore = getBalance(address(0));
 
         // Get protocol balance before calling price discovery contract
         uint256 thisBalanceBefore = getBalance(_exchangeToken);
 
         // Call the price discovery contract
         incomingTokenAddress = address(_bosonVoucher);
-        _priceDiscovery.priceDiscoveryContract.functionCallWithValue(_priceDiscovery.priceDiscoveryData, msg.value);
+        _priceDiscovery.priceDiscoveryContract.functionCallWithValue(_priceDiscovery.priceDiscoveryData, 0);
 
         // Check the native balance and return the surplus to seller
         uint256 thisNativeBalanceAfter = getBalance(address(0));

--- a/contracts/protocol/facets/PriceDiscoveryHandlerFacet.sol
+++ b/contracts/protocol/facets/PriceDiscoveryHandlerFacet.sol
@@ -143,21 +143,12 @@ contract PriceDiscoveryHandlerFacet is IBosonPriceDiscoveryHandler, PriceDiscove
 
         (, uint256 buyerId) = getBuyerIdByWallet(_buyer);
         if (actualPrice > 0) {
-            if (_priceDiscovery.side == Side.Ask) {
-                // Price discovery should send funds to the seller
-                // Nothing in escrow, take it from the seller's pool
-                FundsLib.decreaseAvailableFunds(sellerId, exchangeToken, actualPrice);
-
-                emit FundsEncumbered(sellerId, exchangeToken, actualPrice, msgSender());
-            } else {
-                // when bid side or wrapper, we have full proceeds in escrow.
-                // If exchange token is 0, we need to unwrap it
-                if (exchangeToken == address(0)) {
-                    wNative.withdraw(actualPrice);
-                }
-                emit FundsEncumbered(buyerId, exchangeToken, actualPrice, msgSender());
+            // If exchange token is 0, we need to unwrap it
+            if (exchangeToken == address(0)) {
+                wNative.withdraw(actualPrice);
             }
 
+            emit FundsEncumbered(buyerId, exchangeToken, actualPrice, msgSender());
             // Not emitting BuyerCommitted since it's emitted in commitToOfferInternal
         }
     }

--- a/contracts/protocol/facets/SequentialCommitHandlerFacet.sol
+++ b/contracts/protocol/facets/SequentialCommitHandlerFacet.sol
@@ -163,29 +163,13 @@ contract SequentialCommitHandlerFacet is IBosonSequentialCommitHandler, PriceDis
                 immediatePayout = thisExchangeCost.price - additionalEscrowAmount;
             }
 
-            if (_priceDiscovery.side == Side.Ask) {
-                if (additionalEscrowAmount > 0) {
-                    // Price discovery should send funds to the seller
-                    // Nothing in escrow, need to pull everything from seller
-                    if (exchangeToken == address(0)) {
-                        // If exchange is native currency, seller cannot directly approve protocol to transfer funds
-                        // They need to approve wrapper contract, so protocol can pull funds from wrapper
-                        FundsLib.transferFundsToProtocol(address(wNative), seller, additionalEscrowAmount);
-                        // But since protocol otherwise normally operates with native currency, needs to unwrap it (i.e. withdraw)
-                        wNative.withdraw(additionalEscrowAmount);
-                    } else {
-                        FundsLib.transferFundsToProtocol(exchangeToken, seller, additionalEscrowAmount);
-                    }
-                }
-            } else {
-                // when bid side, we have full proceeds in escrow. Keep minimal in, return the difference
-                if (thisExchangeCost.price > 0 && exchangeToken == address(0)) {
-                    wNative.withdraw(thisExchangeCost.price);
-                }
+            // we have full proceeds in escrow. Keep minimal in, return the difference
+            if (thisExchangeCost.price > 0 && exchangeToken == address(0)) {
+                wNative.withdraw(thisExchangeCost.price);
+            }
 
-                if (immediatePayout > 0) {
-                    FundsLib.transferFundsFromProtocol(exchangeToken, payable(seller), immediatePayout);
-                }
+            if (immediatePayout > 0) {
+                FundsLib.transferFundsFromProtocol(exchangeToken, payable(seller), immediatePayout);
             }
         }
 


### PR DESCRIPTION
Fix #912 

Three significant changes:
- whenever offer is in native tokens, price discovery is executed with wrapped tokens
- in initial price discovery, the seller does not have to deposit the price before the ask order is fulfilled
- in the sequential commit, if the ask order has a native token, the reseller does not have to wrap the ethers before the order is fulfilled