### PR TITLE
Change promise all into two separate calls.

### DIFF
--- a/test/protocol/MetaTransactionsHandlerTest.js
+++ b/test/protocol/MetaTransactionsHandlerTest.js
@@ -3689,14 +3689,12 @@ describe("IBosonMetaTransactionsHandler", function () {
           expect(offerDurations.isValid()).is.true;
 
           // Create both offers
-          await Promise.all([
-            offerHandler
-              .connect(assistant)
-              .createOffer(offerNative, offerDates, offerDurations, disputeResolver.id, agentId, offerFeeLimit),
-            offerHandler
-              .connect(assistant)
-              .createOffer(offerToken, offerDates, offerDurations, disputeResolver.id, agentId, offerFeeLimit),
-          ]);
+          await offerHandler
+            .connect(assistant)
+            .createOffer(offerNative, offerDates, offerDurations, disputeResolver.id, agentId, offerFeeLimit);
+          await offerHandler
+            .connect(assistant)
+            .createOffer(offerToken, offerDates, offerDurations, disputeResolver.id, agentId, offerFeeLimit);
 
           // top up seller's and buyer's account
           await mockToken.mint(await assistant.getAddress(), sellerDeposit);


### PR DESCRIPTION
`Promise.all` should be only used with static calls or when the order of transactions doesn't matter. 

In the changed code, the order matters, since it influences the offer id. If the order is switched, the commit to offer in 
https://github.com/bosonprotocol/boson-protocol-contracts/blob/1bc3375376b6b8d5ffb8f1fdc312d93a29315e10/test/protocol/MetaTransactionsHandlerTest.js#L3714
failed about half of the time.