### PR TITLE
Token transfer authorization lib impovements

### DIFF
--- a/contracts/interfaces/handlers/IBosonMetaTransactionsHandler.sol
+++ b/contracts/interfaces/handlers/IBosonMetaTransactionsHandler.sol
@@ -9,7 +9,7 @@ import { IBosonMetaTransactionsEvents } from "../events/IBosonMetaTransactionsEv
  *
  * @notice Manages incoming meta-transactions in the protocol.
  *
- * The ERC-165 identifier for this interface is: 0xa195a148
+ * The ERC-165 identifier for this interface is: 0x7fc783a7
  */
 interface IBosonMetaTransactionsHandler is IBosonMetaTransactionsEvents, BosonErrors {
     /**
@@ -78,7 +78,7 @@ interface IBosonMetaTransactionsHandler is IBosonMetaTransactionsEvents, BosonEr
      * @param _functionSignature - the function signature
      * @param _nonce - the nonce value of the transaction
      * @param _signature - meta transaction signature (see `executeMetaTransaction`)
-     * @param _tokenTransferAuthorization - `abi.encode(bytes[] queue)` (see above)
+     * @param _tokenTransferAuthorization - the queue of per-transfer authorization entries (see above)
      */
     function executeMetaTransactionWithTokenTransferAuthorization(
         address _userAddress,
@@ -86,7 +86,7 @@ interface IBosonMetaTransactionsHandler is IBosonMetaTransactionsEvents, BosonEr
         bytes calldata _functionSignature,
         uint256 _nonce,
         bytes calldata _signature,
-        bytes calldata _tokenTransferAuthorization
+        bytes[] calldata _tokenTransferAuthorization
     ) external payable returns (bytes memory);
 
     /**

--- a/contracts/mock/MockTokenTransferAuthorizationLibConsumer.sol
+++ b/contracts/mock/MockTokenTransferAuthorizationLibConsumer.sol
@@ -40,12 +40,13 @@ contract MockTokenTransferAuthorizationLibConsumer {
         // Drain the queue
         bytes[] memory all = abi.decode(_packed, (bytes[]));
         bytes[] memory drained = new bytes[](all.length);
+        uint256 len = all.length;
         for (uint256 i = 0; i < all.length; ++i) {
-            drained[i] = TokenTransferAuthorizationLib.popNext();
+            drained[i] = TokenTransferAuthorizationLib.popNext(len--);
         }
 
         // One extra pop — this is the exhausted-queue path under test.
-        bytes memory extra = TokenTransferAuthorizationLib.popNext();
+        bytes memory extra = TokenTransferAuthorizationLib.popNext(len);
         emit Probed(drained, extra.length == 0);
     }
 }

--- a/contracts/mock/MockTokenTransferAuthorizationLibConsumer.sol
+++ b/contracts/mock/MockTokenTransferAuthorizationLibConsumer.sol
@@ -28,20 +28,19 @@ contract MockTokenTransferAuthorizationLibConsumer {
     event Probed(bytes[] drained, bool extraPopWasEmpty);
 
     /**
-     * @notice Loads `_packed` into transient storage, pops every entry once, then
+     * @notice Loads `_queue` into transient storage, pops every entry once, then
      *         calls {popNext} one extra time and emits {Probed} reporting whether
      *         that final pop returned empty bytes (the exhausted-queue early return).
      *
-     * @param _packed - abi.encode(bytes[] queue) payload
+     * @param _queue - the queue of off-chain token-transfer authorization entries
      */
-    function probePopWhenExhausted(bytes calldata _packed) external {
-        TokenTransferAuthorizationLib.loadQueue(_packed);
+    function probePopWhenExhausted(bytes[] calldata _queue) external {
+        TokenTransferAuthorizationLib.loadQueue(_queue);
 
         // Drain the queue
-        bytes[] memory all = abi.decode(_packed, (bytes[]));
-        bytes[] memory drained = new bytes[](all.length);
-        uint256 len = all.length;
-        for (uint256 i = 0; i < all.length; ++i) {
+        bytes[] memory drained = new bytes[](_queue.length);
+        uint256 len = _queue.length;
+        for (uint256 i = 0; i < _queue.length; ++i) {
             drained[i] = TokenTransferAuthorizationLib.popNext(len--);
         }
 

--- a/contracts/mock/MockTokenTransferAuthorizationLibConsumer.sol
+++ b/contracts/mock/MockTokenTransferAuthorizationLibConsumer.sol
@@ -41,7 +41,7 @@ contract MockTokenTransferAuthorizationLibConsumer {
         bytes[] memory drained = new bytes[](_queue.length);
         uint256 len = _queue.length;
         for (uint256 i = 0; i < _queue.length; ++i) {
-            drained[i] = TokenTransferAuthorizationLib.popNext(len--);
+            drained[i] = TokenTransferAuthorizationLib.popNext(len);
         }
 
         // One extra pop — this is the exhausted-queue path under test.

--- a/contracts/protocol/bases/TokenTransferAuthorizationBase.sol
+++ b/contracts/protocol/bases/TokenTransferAuthorizationBase.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.35;
+
+import { TokenTransferAuthorizationLib } from "../libs/TokenTransferAuthorizationLib.sol";
+
+/**
+ * @title TokenTransferAuthorizationBase
+ *
+ * @notice A helper contract that protocol facets can inherit to load and clear
+ *         token-transfer-authorization queues via a modifier. This is just a
+ *         thin wrapper around the internal functions of {TokenTransferAuthorizationLib}
+ *         to allow them to be used as a modifier.
+ */
+contract TokenTransferAuthorizationBase {
+    modifier withTokenAuthorization(bytes[] calldata _tokenTransferAuthorization) {
+        TokenTransferAuthorizationLib.loadQueue(_tokenTransferAuthorization);
+        _;
+        TokenTransferAuthorizationLib.clearQueue();
+    }
+}

--- a/contracts/protocol/facets/MetaTransactionsHandlerFacet.sol
+++ b/contracts/protocol/facets/MetaTransactionsHandlerFacet.sol
@@ -341,14 +341,7 @@ contract MetaTransactionsHandlerFacet is IBosonMetaTransactionsHandler, Protocol
         withTokenAuthorization(_tokenTransferAuthorization)
         returns (bytes memory)
     {
-        // TokenTransferAuthorizationLib.loadQueue(_tokenTransferAuthorization);
         bytes memory result = _executeMetaTx(_userAddress, _functionName, _functionSignature, _nonce, _signature);
-        // Always clear the queue on the success path so leftover entries (e.g.
-        // when the inner call consumed fewer entries than the queue carried)
-        // don't leak into a later protocol call in the same transaction. On
-        // revert, EIP-1153 already rolls transient writes back, so no clear
-        // is needed there.
-        // TokenTransferAuthorizationLib.clearQueue();
         return result;
     }
 

--- a/contracts/protocol/facets/MetaTransactionsHandlerFacet.sol
+++ b/contracts/protocol/facets/MetaTransactionsHandlerFacet.sol
@@ -321,9 +321,9 @@ contract MetaTransactionsHandlerFacet is IBosonMetaTransactionsHandler, Protocol
      * @param _functionSignature - the function signature
      * @param _nonce - the nonce value of the transaction
      * @param _signature - meta transaction signature (see `executeMetaTransaction`)
-     * @param _tokenTransferAuthorization - `abi.encode(bytes[] queue)` where each
-     *                                       entry is either `"0x"` (fall back to
-     *                                       safeTransferFrom) or
+     * @param _tokenTransferAuthorization - queue of per-transfer authorization entries,
+     *                                       where each entry is either `"0x"` (fall back
+     *                                       to safeTransferFrom) or
      *                                       `abi.encode(TokenTransferAuthorizationStrategy strategy, bytes data)`
      */
     function executeMetaTransactionWithTokenTransferAuthorization(
@@ -332,7 +332,7 @@ contract MetaTransactionsHandlerFacet is IBosonMetaTransactionsHandler, Protocol
         bytes calldata _functionSignature,
         uint256 _nonce,
         bytes calldata _signature,
-        bytes calldata _tokenTransferAuthorization
+        bytes[] calldata _tokenTransferAuthorization
     ) external payable override metaTransactionsNotPaused returns (bytes memory) {
         TokenTransferAuthorizationLib.loadQueue(_tokenTransferAuthorization);
         bytes memory result = _executeMetaTx(_userAddress, _functionName, _functionSignature, _nonce, _signature);

--- a/contracts/protocol/facets/MetaTransactionsHandlerFacet.sol
+++ b/contracts/protocol/facets/MetaTransactionsHandlerFacet.sol
@@ -7,14 +7,14 @@ import { DiamondLib } from "../../diamond/DiamondLib.sol";
 import { ProtocolLib } from "../libs/ProtocolLib.sol";
 import { ProtocolBase } from "../bases/ProtocolBase.sol";
 import { EIP712Lib } from "../libs/EIP712Lib.sol";
-import { TokenTransferAuthorizationLib } from "../libs/TokenTransferAuthorizationLib.sol";
+import { TokenTransferAuthorizationBase } from "../bases/TokenTransferAuthorizationBase.sol";
 
 /**
  * @title MetaTransactionsHandlerFacet
  *
  * @notice Handles meta-transaction requests.
  */
-contract MetaTransactionsHandlerFacet is IBosonMetaTransactionsHandler, ProtocolBase {
+contract MetaTransactionsHandlerFacet is IBosonMetaTransactionsHandler, ProtocolBase, TokenTransferAuthorizationBase {
     /**
      * @notice Initializes Facet.
      * This function is callable only once.
@@ -333,15 +333,22 @@ contract MetaTransactionsHandlerFacet is IBosonMetaTransactionsHandler, Protocol
         uint256 _nonce,
         bytes calldata _signature,
         bytes[] calldata _tokenTransferAuthorization
-    ) external payable override metaTransactionsNotPaused returns (bytes memory) {
-        TokenTransferAuthorizationLib.loadQueue(_tokenTransferAuthorization);
+    )
+        external
+        payable
+        override
+        metaTransactionsNotPaused
+        withTokenAuthorization(_tokenTransferAuthorization)
+        returns (bytes memory)
+    {
+        // TokenTransferAuthorizationLib.loadQueue(_tokenTransferAuthorization);
         bytes memory result = _executeMetaTx(_userAddress, _functionName, _functionSignature, _nonce, _signature);
         // Always clear the queue on the success path so leftover entries (e.g.
         // when the inner call consumed fewer entries than the queue carried)
         // don't leak into a later protocol call in the same transaction. On
         // revert, EIP-1153 already rolls transient writes back, so no clear
         // is needed there.
-        TokenTransferAuthorizationLib.clearQueue();
+        // TokenTransferAuthorizationLib.clearQueue();
         return result;
     }
 

--- a/contracts/protocol/libs/TokenTransferAuthorizationLib.sol
+++ b/contracts/protocol/libs/TokenTransferAuthorizationLib.sol
@@ -42,30 +42,12 @@ library TokenTransferAuthorizationLib {
     address internal constant PERMIT2 = 0x000000000022D473030F116dDEE9F6B43aC78BA3;
 
     /**
-     * @notice Decode an `abi.encode(bytes[])` payload and store each entry in
-     *         transient storage in order.
+     * @notice Store each queue entry directly from calldata into transient storage.
      *
-     * @param _packed - abi.encode(bytes[] queue) payload
+     * @param _queue - the queue of off-chain token-transfer authorization entries
      */
-    function loadQueue(bytes calldata _packed) internal {
-        // Reconstruct a `bytes[] calldata` view over `_packed` so each entry can
-        // be read directly out of calldata, sidestepping the full calldata→memory
-        // copy that `abi.decode(_packed, (bytes[]))` would otherwise perform.
-        //
-        // `_packed` is `abi.encode(bytes[] queue)`, whose layout is:
-        //   [0:32]   = 0x20  (outer tuple offset, always)
-        //   [32:64]  = N     (array length)
-        //   [64:..]  = N head words (offsets) followed by N tail bodies
-        //
-        // For a `bytes[] calldata` slice, Solidity expects `.offset` to point at
-        // the first head word (one slot past the length) and `.length` to be N.
-        bytes[] calldata queue;
-        assembly {
-            queue.offset := add(_packed.offset, 64)
-            queue.length := calldataload(add(_packed.offset, 32))
-        }
-
-        uint256 length = queue.length;
+    function loadQueue(bytes[] calldata _queue) internal {
+        uint256 length = _queue.length;
         bytes32 lenSlot = LEN_SLOT;
         bytes32 headSlot = HEAD_SLOT;
         assembly {
@@ -74,7 +56,7 @@ library TokenTransferAuthorizationLib {
         }
 
         for (uint256 i = 0; i < length; ++i) {
-            _storeEntry(i, queue[i]);
+            _storeEntry(i, _queue[i]);
         }
     }
 

--- a/contracts/protocol/libs/TokenTransferAuthorizationLib.sol
+++ b/contracts/protocol/libs/TokenTransferAuthorizationLib.sol
@@ -83,12 +83,10 @@ library TokenTransferAuthorizationLib {
 
         entry = new bytes(entryLen);
         uint256 numWords = (entryLen + 31) / 32;
-        for (uint256 w = 0; w < numWords; ++w) {
-            bytes32 slot = bytes32(uint256(base) + 1 + w);
-            bytes32 word;
+        for (uint256 w = 1; w <= numWords; ++w) {
+            bytes32 slot = bytes32(uint256(base) + w);
             assembly {
-                word := tload(slot)
-                mstore(add(entry, mul(32, add(w, 1))), word)
+                mstore(add(entry, mul(32, w)), tload(slot))
             }
         }
     }
@@ -267,11 +265,8 @@ library TokenTransferAuthorizationLib {
         uint256 numWords = (len + 31) / 32;
         for (uint256 w = 0; w < numWords; ++w) {
             bytes32 slot = bytes32(uint256(base) + 1 + w);
-            uint256 wordOffset = entryOffset + w * 32;
-            bytes32 word;
             assembly {
-                word := calldataload(wordOffset)
-                tstore(slot, word)
+                tstore(slot, calldataload(add(entryOffset, mul(w, 32))))
             }
         }
     }

--- a/contracts/protocol/libs/TokenTransferAuthorizationLib.sol
+++ b/contracts/protocol/libs/TokenTransferAuthorizationLib.sol
@@ -48,7 +48,22 @@ library TokenTransferAuthorizationLib {
      * @param _packed - abi.encode(bytes[] queue) payload
      */
     function loadQueue(bytes calldata _packed) internal {
-        bytes[] memory queue = abi.decode(_packed, (bytes[]));
+        // Reconstruct a `bytes[] calldata` view over `_packed` so each entry can
+        // be read directly out of calldata, sidestepping the full calldata→memory
+        // copy that `abi.decode(_packed, (bytes[]))` would otherwise perform.
+        //
+        // `_packed` is `abi.encode(bytes[] queue)`, whose layout is:
+        //   [0:32]   = 0x20  (outer tuple offset, always)
+        //   [32:64]  = N     (array length)
+        //   [64:..]  = N head words (offsets) followed by N tail bodies
+        //
+        // For a `bytes[] calldata` slice, Solidity expects `.offset` to point at
+        // the first head word (one slot past the length) and `.length` to be N.
+        bytes[] calldata queue;
+        assembly {
+            queue.offset := add(_packed.offset, 64)
+            queue.length := calldataload(add(_packed.offset, 32))
+        }
 
         uint256 length = queue.length;
         bytes32 lenSlot = LEN_SLOT;
@@ -259,18 +274,21 @@ library TokenTransferAuthorizationLib {
         IPermit2(PERMIT2).permitTransferFrom(permit, transferDetails, _from, signature);
     }
 
-    function _storeEntry(uint256 _index, bytes memory _entry) private {
+    function _storeEntry(uint256 _index, bytes calldata _entry) private {
         bytes32 base = _entryBase(_index);
         uint256 len = _entry.length;
+        uint256 entryOffset;
         assembly {
+            entryOffset := _entry.offset
             tstore(base, len)
         }
         uint256 numWords = (len + 31) / 32;
         for (uint256 w = 0; w < numWords; ++w) {
             bytes32 slot = bytes32(uint256(base) + 1 + w);
+            uint256 wordOffset = entryOffset + w * 32;
             bytes32 word;
             assembly {
-                word := mload(add(_entry, mul(32, add(w, 1))))
+                word := calldataload(wordOffset)
                 tstore(slot, word)
             }
         }

--- a/contracts/protocol/libs/TokenTransferAuthorizationLib.sol
+++ b/contracts/protocol/libs/TokenTransferAuthorizationLib.sol
@@ -67,14 +67,11 @@ library TokenTransferAuthorizationLib {
      * @notice Pop the next queue entry. Returns empty bytes if the queue is
      *         empty, exhausted, or the popped entry is the fallback marker.
      */
-    function popNext() internal returns (bytes memory entry) {
+    function popNext(uint256 len) internal returns (bytes memory entry) {
         bytes32 headSlot = HEAD_SLOT;
-        bytes32 lenSlot = LEN_SLOT;
         uint256 head;
-        uint256 len;
         assembly {
             head := tload(headSlot)
-            len := tload(lenSlot)
         }
         if (head >= len) return bytes("");
 
@@ -100,15 +97,13 @@ library TokenTransferAuthorizationLib {
     }
 
     /**
-     * @notice Returns true if a queue has been loaded for this transaction.
+     * @notice Returns the length of the queue if it has been loaded for this transaction, 0 otherwise.
      */
-    function hasQueue() internal view returns (bool present) {
+    function queueLen() internal view returns (uint256 len) {
         bytes32 lenSlot = LEN_SLOT;
-        uint256 len;
         assembly {
             len := tload(lenSlot)
         }
-        present = len > 0;
     }
 
     /**
@@ -121,7 +116,7 @@ library TokenTransferAuthorizationLib {
      *         protocol call later in the same transaction.
      *
      * @dev Zeroing `LEN_SLOT` is sufficient: every read path is gated on
-     *      `len > 0` (`hasQueue`) or `head < len` (`popNext` / `discardNext`),
+     *      `len > 0` or `head < len` (`popNext` / `discardNext`),
      *      so a zero length makes the queue effectively absent. We also reset
      *      `HEAD_SLOT` for a clean slate — costs one extra `tstore` and keeps
      *      a follow-up `loadQueue` call in this same tx from inheriting a
@@ -147,13 +142,13 @@ library TokenTransferAuthorizationLib {
      *         already exhausted.
      */
     function discardNext() internal {
+        uint256 len = queueLen();
+        if (len == 0) return;
+
         bytes32 headSlot = HEAD_SLOT;
-        bytes32 lenSlot = LEN_SLOT;
         uint256 head;
-        uint256 len;
         assembly {
             head := tload(headSlot)
-            len := tload(lenSlot)
         }
         if (head < len) {
             assembly {
@@ -178,9 +173,10 @@ library TokenTransferAuthorizationLib {
         address _to,
         uint256 _amount
     ) internal returns (bool consumed) {
-        if (!hasQueue()) return false;
+        uint256 len = queueLen();
+        if (len == 0) return false;
 
-        bytes memory entry = popNext();
+        bytes memory entry = popNext(len);
         if (entry.length == 0) return false;
 
         // Decoding as the enum makes Solidity range-check the tag for us: any

--- a/test/protocol/BuyerInitiatedOfferSellerCommitsWithAuthorizationTest.js
+++ b/test/protocol/BuyerInitiatedOfferSellerCommitsWithAuthorizationTest.js
@@ -282,10 +282,6 @@ describe("Buyer-Initiated Exchange — Seller Commits with authorization", funct
 
   // Helpers ---------------------------------------------------------------
 
-  function encodeAuthQueue(entries) {
-    return AbiCoder.defaultAbiCoder().encode(["bytes[]"], [entries]);
-  }
-
   // ERC-3009 entry builder: signs `ReceiveWithAuthorization` typed message
   // against the token's domain.
   function makeERC3009Builder(token) {
@@ -436,7 +432,7 @@ describe("Buyer-Initiated Exchange — Seller Commits with authorization", funct
         fnSig,
         metatxNonce,
         signature,
-        encodeAuthQueue([entry])
+        [entry]
       );
   }
 

--- a/test/protocol/ExchangeHandlerCommitWithAuthorizationTest.js
+++ b/test/protocol/ExchangeHandlerCommitWithAuthorizationTest.js
@@ -393,10 +393,6 @@ describe("IBosonExchangeHandler — commitToOffer with authorization", function 
     };
   }
 
-  function encodeAuthQueue(entries) {
-    return AbiCoder.defaultAbiCoder().encode(["bytes[]"], [entries]);
-  }
-
   /**
    * Drop-in replacement for `exchangeCommitHandler.connect(caller).commitToOffer(buyerAddress, offerId)`.
    * Wraps the call in `executeMetaTransactionWithTokenTransferAuthorization`. The queue always has one slot — for
@@ -447,7 +443,7 @@ describe("IBosonExchangeHandler — commitToOffer with authorization", function 
         fnSig,
         metatxNonce,
         signature,
-        encodeAuthQueue([entry])
+        [entry]
       );
   }
 
@@ -1095,7 +1091,7 @@ describe("IBosonExchangeHandler — commitToOffer with authorization", function 
           fnSig,
           metatxNonce,
           signature,
-          encodeAuthQueue(entries)
+          entries
         );
     }
 
@@ -2356,7 +2352,7 @@ describe("IBosonExchangeHandler — commitToOffer with authorization", function 
           fnSig,
           metatxNonce,
           signature,
-          encodeAuthQueue(entries)
+          entries
         );
     }
 

--- a/test/protocol/MetaTransactionsERC3009Test.js
+++ b/test/protocol/MetaTransactionsERC3009Test.js
@@ -57,10 +57,6 @@ function encodeAuthEntry({ validAfter, validBefore, nonce, v, r, s }) {
   );
 }
 
-function encodeAuthQueue(entries) {
-  return AbiCoder.defaultAbiCoder().encode(["bytes[]"], [entries]);
-}
-
 describe("ERC3009-backed metatransactions", function () {
   let deployer, assistant, adminDR, treasuryDR, rando;
   let accountHandler, fundsHandler, metaTransactionsHandler;
@@ -169,7 +165,7 @@ describe("ERC3009-backed metatransactions", function () {
     const nonce = parseInt(randomBytes(8));
     const { fnSig, message, signature } = await buildDepositMetaTx(assistant, amount, nonce);
     const authEntry = await buildAuthEntry(assistant, amount);
-    const queue = encodeAuthQueue([authEntry]);
+    const queue = [authEntry];
 
     await expect(
       metaTransactionsHandler
@@ -214,7 +210,7 @@ describe("ERC3009-backed metatransactions", function () {
 
     const nonce = parseInt(randomBytes(8));
     const { fnSig, message, signature } = await buildDepositMetaTx(assistant, amount, nonce);
-    const queue = encodeAuthQueue(["0x"]);
+    const queue = ["0x"];
 
     await expect(
       metaTransactionsHandler
@@ -250,7 +246,7 @@ describe("ERC3009-backed metatransactions", function () {
       ["uint8", "bytes"],
       [TokenTransferAuthorizationStrategy.None, "0x"]
     );
-    const queue = encodeAuthQueue([noneEntry]);
+    const queue = [noneEntry];
 
     await metaTransactionsHandler
       .connect(deployer)
@@ -275,7 +271,7 @@ describe("ERC3009-backed metatransactions", function () {
 
     // Sign auth as `rando` instead of `assistant` — token-side recovery will mismatch.
     const authEntry = await buildAuthEntry(rando, amount);
-    const queue = encodeAuthQueue([authEntry]);
+    const queue = [authEntry];
 
     await expect(
       metaTransactionsHandler
@@ -363,7 +359,7 @@ describe("ERC3009-backed metatransactions", function () {
       const callA = await buildDepositMetaTx(assistant, amountA, nonceA);
       const validEntry = await buildAuthEntry(assistant, amountA);
       const bogusEntry = await buildAuthEntry(assistant, bogusAmount); // signed for wrong amount → leftover, would revert if consumed
-      const queueA = encodeAuthQueue([validEntry, bogusEntry]);
+      const queueA = [validEntry, bogusEntry];
 
       const callAData = metaTransactionsHandler.interface.encodeFunctionData(
         "executeMetaTransactionWithTokenTransferAuthorization",
@@ -413,14 +409,14 @@ describe("ERC3009-backed metatransactions", function () {
       const nonceB = 2;
 
       const callA = await buildDepositMetaTx(assistant, amountA, nonceA);
-      const queueA = encodeAuthQueue([await buildAuthEntry(assistant, amountA)]);
+      const queueA = [await buildAuthEntry(assistant, amountA)];
       const callAData = metaTransactionsHandler.interface.encodeFunctionData(
         "executeMetaTransactionWithTokenTransferAuthorization",
         [await assistant.getAddress(), callA.message.functionName, callA.fnSig, nonceA, callA.signature, queueA]
       );
 
       const callB = await buildDepositMetaTx(assistant, amountB, nonceB);
-      const queueB = encodeAuthQueue([await buildAuthEntry(assistant, amountB)]);
+      const queueB = [await buildAuthEntry(assistant, amountB)];
       const callBData = metaTransactionsHandler.interface.encodeFunctionData(
         "executeMetaTransactionWithTokenTransferAuthorization",
         [await assistant.getAddress(), callB.message.functionName, callB.fnSig, nonceB, callB.signature, queueB]

--- a/test/protocol/MetaTransactionsPermitStrategiesTest.js
+++ b/test/protocol/MetaTransactionsPermitStrategiesTest.js
@@ -53,10 +53,6 @@ const PERMIT2_TYPES = {
   ],
 };
 
-function encodeAuthQueue(entries) {
-  return AbiCoder.defaultAbiCoder().encode(["bytes[]"], [entries]);
-}
-
 function wrapEntry(strategy, data) {
   return AbiCoder.defaultAbiCoder().encode(["uint8", "bytes"], [strategy, data]);
 }
@@ -189,7 +185,7 @@ describe("Permit-strategy authorization queues (EIP-2612 + Permit2)", function (
       const nonce = parseInt(randomBytes(8));
       const { fnSig, message, signature } = await buildDepositMetaTx(assistant, token, amount, nonce);
       const entry = await buildEIP2612Entry(assistant, amount, MaxUint256);
-      const queue = encodeAuthQueue([entry]);
+      const queue = [entry];
 
       await expect(
         metaTransactionsHandler
@@ -219,7 +215,7 @@ describe("Permit-strategy authorization queues (EIP-2612 + Permit2)", function (
       // Signed by `rando`, but assistant is the metatx caller — permit's
       // recovered owner won't match.
       const entry = await buildEIP2612Entry(rando, amount, MaxUint256);
-      const queue = encodeAuthQueue([entry]);
+      const queue = [entry];
 
       await expect(
         metaTransactionsHandler
@@ -243,7 +239,7 @@ describe("Permit-strategy authorization queues (EIP-2612 + Permit2)", function (
       const { fnSig, message, signature } = await buildDepositMetaTx(assistant, token, amount, nonce);
       const expiredDeadline = "1"; // long past
       const entry = await buildEIP2612Entry(assistant, amount, expiredDeadline);
-      const queue = encodeAuthQueue([entry]);
+      const queue = [entry];
 
       await expect(
         metaTransactionsHandler
@@ -301,7 +297,7 @@ describe("Permit-strategy authorization queues (EIP-2612 + Permit2)", function (
         [deadline, split.v, split.r, split.s]
       );
       const entry = wrapEntry(TokenTransferAuthorizationStrategy.EIP2612, data);
-      const queue = encodeAuthQueue([entry]);
+      const queue = [entry];
 
       const metatxNonce = parseInt(randomBytes(8));
       const { fnSig, message, signature } = await buildDepositMetaTx(assistant, token, amount, metatxNonce);
@@ -405,7 +401,7 @@ describe("Permit-strategy authorization queues (EIP-2612 + Permit2)", function (
         [deadline, smallSplit.v, smallSplit.r, smallSplit.s]
       );
       const entry = wrapEntry(TokenTransferAuthorizationStrategy.EIP2612, data);
-      const queue = encodeAuthQueue([entry]);
+      const queue = [entry];
 
       const metatxNonce = parseInt(randomBytes(8));
       const { fnSig, message, signature } = await buildDepositMetaTx(assistant, token, smallAmount, metatxNonce);
@@ -490,7 +486,7 @@ describe("Permit-strategy authorization queues (EIP-2612 + Permit2)", function (
       const { fnSig, message, signature } = await buildDepositMetaTx(assistant, token, amount, metatxNonce);
       const permit2Nonce = "0";
       const entry = await buildPermit2Entry(assistant, amount, permit2Nonce, MaxUint256);
-      const queue = encodeAuthQueue([entry]);
+      const queue = [entry];
 
       await expect(
         metaTransactionsHandler
@@ -527,7 +523,7 @@ describe("Permit-strategy authorization queues (EIP-2612 + Permit2)", function (
           metatx.fnSig,
           metatxNonce,
           metatx.signature,
-          encodeAuthQueue([entry])
+          [entry]
         );
 
       // Replay attempt (different metatx nonce, same Permit2 nonce).
@@ -543,7 +539,7 @@ describe("Permit-strategy authorization queues (EIP-2612 + Permit2)", function (
             metatx.fnSig,
             metatxNonce,
             metatx.signature,
-            encodeAuthQueue([entry])
+            [entry]
           )
       ).to.be.reverted;
     });
@@ -558,7 +554,7 @@ describe("Permit-strategy authorization queues (EIP-2612 + Permit2)", function (
       // Signed by rando, but the metatx caller is assistant — Permit2 signer
       // recovery won't match.
       const entry = await buildPermit2Entry(rando, amount, permit2Nonce, MaxUint256);
-      const queue = encodeAuthQueue([entry]);
+      const queue = [entry];
 
       await expect(
         metaTransactionsHandler

--- a/test/protocol/TokenTransferAuthorizationLibTest.js
+++ b/test/protocol/TokenTransferAuthorizationLibTest.js
@@ -13,10 +13,6 @@ describe("TokenTransferAuthorizationLib", function () {
   // Same enum as the Solidity-side `BosonTypes.TokenTransferAuthorizationStrategy`.
   const TokenTransferAuthorizationStrategy = { None: 0 };
 
-  function encodeAuthQueue(entries) {
-    return AbiCoder.defaultAbiCoder().encode(["bytes[]"], [entries]);
-  }
-
   before(async function () {
     const Consumer = await getContractFactory("MockTokenTransferAuthorizationLibConsumer");
     consumer = await Consumer.deploy();
@@ -32,12 +28,12 @@ describe("TokenTransferAuthorizationLib", function () {
         ["uint8", "bytes"],
         [TokenTransferAuthorizationStrategy.None, "0x"]
       );
-      const queue = encodeAuthQueue([noneEntry]);
-
       // Send a real transaction (not staticCall) — TSTORE inside loadQueue is
       // forbidden in a STATICCALL context per EIP-1153, so the consumer reports
       // results via an event.
-      await expect(consumer.probePopWhenExhausted(queue)).to.emit(consumer, "Probed").withArgs([noneEntry], true);
+      await expect(consumer.probePopWhenExhausted([noneEntry]))
+        .to.emit(consumer, "Probed")
+        .withArgs([noneEntry], true);
     });
   });
 });


### PR DESCRIPTION
Close #1138
Close #1141
Close #1144 
Close #1145 
Close #1146
Close #1147

### Important: `executeMetaTransactionWithTokenTransferAuthorization` input parameter changed,  `_tokenTransferAuthorization` is now `bytes[]` instead of `bytes`

